### PR TITLE
Adding 'get' command to the CLI, to view a single variable.

### DIFF
--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -81,6 +81,7 @@ static void cliMotor(char *cmdline);
 static void cliProfile(char *cmdline);
 static void cliSave(char *cmdline);
 static void cliSet(char *cmdline);
+static void cliGet(char *cmdline);
 static void cliStatus(char *cmdline);
 static void cliVersion(char *cmdline);
 
@@ -136,6 +137,7 @@ const clicmd_t cmdTable[] = {
     { "dump", "print configurable settings in a pastable form", cliDump },
     { "exit", "", cliExit },
     { "feature", "list or -val or val", cliFeature },
+    { "get", "get variable value", cliGet },
 #ifdef GPS
     { "gpspassthrough", "passthrough gps to serial", cliGpsPassthrough },
 #endif
@@ -972,6 +974,29 @@ static void cliSet(char *cmdline)
             }
         }
     }
+}
+
+static void cliGet(char *cmdline)
+{
+    uint32_t i;
+    uint32_t len;
+    const clivalue_t *val;
+  	
+    len = strlen(cmdline);
+	
+	// Find the matching variable
+	for (i = 0; i < VALUE_COUNT; i++) {
+		if ((strncasecmp(cmdline, valueTable[i].name, strlen(valueTable[i].name)) == 0) && (len == strlen(valueTable[i].name))) {
+			val = &valueTable[i];
+			printf("%s = ", valueTable[i].name);
+			cliPrintVar(val, 0);
+			printf("\r\n");
+			return;
+		}
+	}
+	
+	// If we get down here, then the variable was not found
+	printf("Variable '%s' not found.\r\n ", cmdline);
 }
 
 static void cliStatus(char *cmdline)


### PR DESCRIPTION
This enables the user to type "get variablename" in the CLI, which then shows the value of that variable (or a message saying "Variable 'variablename' not found").
This is easier for the user when they just want to see a single variable, instead of typing 'dump' and then having to parse a big long list of data.  It is also more intuitive than typing 'set variablename', as this feels unsafe.
