### PR TITLE
Bugfix for wrong number of beeps when changing profiles

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -634,7 +634,7 @@ void changeProfile(uint8_t profileIndex)
     masterConfig.current_profile_index = profileIndex;
     writeEEPROM();
     readEEPROM();
-    blinkLedAndSoundBeeper(2, 40, profileIndex);
+    blinkLedAndSoundBeeper(2, 40, profileIndex + 1);
 }
 
 bool feature(uint32_t mask)


### PR DESCRIPTION
When changing profiles with the sticks, CleanFlight was beeping 0 times for profile
1, once for profile 2, and twice for profile 3.  This wasn't intuitive, and was
different to how Baseflight beeps when changing profiles.
This change makes baseflight give the same number of beeps as the profile number
that you change into.
