### PR TITLE
Bugfix for parallel PWM mode not entering failsafe when PWM is lost

### DIFF
--- a/src/main/drivers/pwm_rx.c
+++ b/src/main/drivers/pwm_rx.c
@@ -231,6 +231,11 @@ static void pwmEdgeCallback(uint8_t port, captureCompare_t capture)
         // switch state
         pwmInputPort->state = 0;
         pwmICConfig(timerHardwarePtr->tim, timerHardwarePtr->channel, TIM_ICPolarity_Rising);
+		
+		// Increment failsafe counter
+		if(pwmInputPort->channel == 1){
+			ppmFrameCount++;
+		}
     }
 }
 


### PR DESCRIPTION
This is perhaps not the cleanest solution, as it's not entirely clear from the rest of the code whether or not the PPM failsafe system is supposed to be triggered when PWM is lost.  However it is a lot better than no failsafe trigger at all.
