### PR TITLE
FrSky telemetry update

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -201,6 +201,11 @@ void resetTelemetryConfig(telemetryConfig_t *telemetryConfig)
     telemetryConfig->telemetry_provider = TELEMETRY_PROVIDER_FRSKY;
     telemetryConfig->frsky_inversion = SERIAL_NOT_INVERTED;
     telemetryConfig->telemetry_switch = 0;
+	telemetryConfig->gpsNoFixLat = 0;
+    telemetryConfig->gpsNoFixLon = 0;
+    telemetryConfig->frsky_coordinate_format = FRSKY_FORMAT_DMS;
+    telemetryConfig->frsky_unit = FRSKY_UNIT_METRICS;
+    telemetryConfig->batterySize = 0;
 }
 
 void resetSerialConfig(serialConfig_t *serialConfig)
@@ -305,6 +310,7 @@ static void resetConf(void)
     // gps/nav stuff
     masterConfig.gpsConfig.provider = GPS_NMEA;
     masterConfig.gpsConfig.sbasMode = SBAS_AUTO;
+    masterConfig.gpsConfig.gpsAutoConfig = GPS_AUTOCONFIG_ON;
 #endif
 
     resetSerialConfig(&masterConfig.serialConfig);

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -255,7 +255,10 @@ void gpsInitUblox(void)
             if (gpsData.messageState == GPS_MESSAGE_STATE_INIT) {
 
                 if (gpsData.state_position < sizeof(ubloxInit)) {
-                    serialWrite(gpsPort, ubloxInit[gpsData.state_position]);
+					//Either use specific config file for GPS or let dynamically upload config
+					if( gpsConfig->gpsAutoConfig == GPS_AUTOCONFIG_ON ) {
+                        serialWrite(gpsPort, ubloxInit[gpsData.state_position]);
+                    }
                     gpsData.state_position++;
                 } else {
                     gpsData.state_position = 0;
@@ -265,7 +268,10 @@ void gpsInitUblox(void)
 
             if (gpsData.messageState == GPS_MESSAGE_STATE_SBAS) {
                 if (gpsData.state_position < UBLOX_SBAS_MESSAGE_LENGTH) {
-                    serialWrite(gpsPort, ubloxSbas[gpsConfig->sbasMode].message[gpsData.state_position]);
+					//Either use specific config file for GPS or let dynamically upload config
+					if( gpsConfig->gpsAutoConfig == GPS_AUTOCONFIG_ON ) {
+                       serialWrite(gpsPort, ubloxSbas[gpsConfig->sbasMode].message[gpsData.state_position]);
+                    }
                     gpsData.state_position++;
                 } else {
                     gpsData.messageState++;

--- a/src/main/io/gps.h
+++ b/src/main/io/gps.h
@@ -45,11 +45,16 @@ typedef enum {
     GPS_BAUDRATE_9600
 } gpsBaudRate_e;
 
+typedef enum {
+    GPS_AUTOCONFIG_ON = 0,
+    GPS_AUTOCONFIG_OFF
+} gpsAutoConfig_e;
 #define GPS_BAUDRATE_MAX GPS_BAUDRATE_9600
 
 typedef struct gpsConfig_s {
     gpsProvider_e provider;
     sbasMode_e sbasMode;
+	gpsAutoConfig_e gpsAutoConfig;
 } gpsConfig_t;
 
 typedef enum {

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -240,6 +240,7 @@ const clivalue_t valueTable[] = {
 
     { "gps_provider",               VAR_UINT8  | MASTER_VALUE,  &masterConfig.gpsConfig.provider, 0, GPS_PROVIDER_MAX },
     { "gps_sbas_mode",              VAR_UINT8  | MASTER_VALUE,  &masterConfig.gpsConfig.sbasMode, 0, SBAS_MODE_MAX },
+	{ "gps_auto_config",            VAR_UINT8  | MASTER_VALUE,  &masterConfig.gpsConfig.gpsAutoConfig, 0, GPS_AUTOCONFIG_OFF },
 
 
     { "gps_pos_p",                  VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.P8[PIDPOS], 0, 200 },
@@ -263,6 +264,11 @@ const clivalue_t valueTable[] = {
     { "telemetry_provider",         VAR_UINT8  | MASTER_VALUE,  &masterConfig.telemetryConfig.telemetry_provider, 0, TELEMETRY_PROVIDER_MAX },
     { "telemetry_switch",           VAR_UINT8  | MASTER_VALUE,  &masterConfig.telemetryConfig.telemetry_switch, 0, 1 },
     { "frsky_inversion",            VAR_UINT8  | MASTER_VALUE,  &masterConfig.telemetryConfig.frsky_inversion, 0, 1 },
+    { "frsky_default_lat",          VAR_FLOAT  | MASTER_VALUE,  &masterConfig.telemetryConfig.gpsNoFixLat, -90.0, 90.0 },
+    { "frsky_default_lon",          VAR_FLOAT  | MASTER_VALUE,  &masterConfig.telemetryConfig.gpsNoFixLon, -180.0, 180.0 },
+    { "frsky_coordinates_format",   VAR_UINT8  | MASTER_VALUE,  &masterConfig.telemetryConfig.frsky_coordinate_format, 0, FRSKY_FORMAT_NMEA },
+    { "frsky_unit",                 VAR_UINT8  | MASTER_VALUE,  &masterConfig.telemetryConfig.frsky_unit, 0, FRSKY_UNIT_IMPERIALS },
+    { "frsky_battery_size",         VAR_UINT16 | MASTER_VALUE,  &masterConfig.telemetryConfig.batterySize, 0, 20000 },
 
     { "vbat_scale",                 VAR_UINT8  | MASTER_VALUE,  &masterConfig.batteryConfig.vbatscale, VBAT_SCALE_MIN, VBAT_SCALE_MAX },
     { "vbat_max_cell_voltage",      VAR_UINT8  | MASTER_VALUE,  &masterConfig.batteryConfig.vbatmaxcellvoltage, 10, 50 },

--- a/src/main/telemetry/telemetry.h
+++ b/src/main/telemetry/telemetry.h
@@ -32,10 +32,24 @@ typedef enum {
     TELEMETRY_PROVIDER_MAX = TELEMETRY_PROVIDER_MSP
 } telemetryProvider_e;
 
+typedef enum {
+    FRSKY_FORMAT_DMS = 0,
+    FRSKY_FORMAT_NMEA
+} frskyGpsCoordFormat_e;
+
+typedef enum {
+    FRSKY_UNIT_METRICS = 0,
+    FRSKY_UNIT_IMPERIALS
+} frskyUnit_e;
 typedef struct telemetryConfig_s {
     telemetryProvider_e telemetry_provider;
     uint8_t telemetry_switch;               // Use aux channel to change serial output & baudrate( MSP / Telemetry ). It disables automatic switching to Telemetry when armed.
     serialInversion_e frsky_inversion;
+	float gpsNoFixLat;   
+    float gpsNoFixLon;  
+    frskyGpsCoordFormat_e frsky_coordinate_format;   
+    frskyUnit_e frsky_unit; 
+    uint16_t batterySize;
 } telemetryConfig_t;
 
 void checkTelemetryState(void);


### PR DESCRIPTION
Several change for FrSky telemetry :
- frsky_default_lat / frsky_default_lon : leave it to 0 if you don't want to display compass information in telemetry if you don't have GPS fix, otherwise set the value you want
- frsky_coordinates_format : 0 for DMS (default) or 1 for NMEA
- frsky_unit : 0 for METRICS (default) or 1 for IMPERIALS, this one is used for temperature2 (Num satellite / hdop)
- frsky_battery_size : leave it to 0 will display consumption, set it to a different value (e.g. 1300 for 1300 mah), it will compute the remaining percent.

RPM will display battery size (not armed), or throttle pulse (armed). For this to work, you need to set blade number to 12 in Taranis.

One change not for telemetry :
- gps_auto_config : it's not related to telemetry, it's just a parameter to allow dynamic configuration (0, default value) or static configuration for ublox gps (1). I prefere to have my own ublox configuration, based on this one (https://raw.githubusercontent.com/diydrones/ardupilot/master/libraries/AP_GPS/config/3DR-Ublox.txt)
