### PR TITLE
Current monitoring on CC3D

### DIFF
--- a/src/main/drivers/adc_stm32f10x.c
+++ b/src/main/drivers/adc_stm32f10x.c
@@ -69,6 +69,14 @@ void adcInit(drv_adc_config_t *init)
     adcConfig[ADC_BATTERY].dmaIndex = configuredAdcChannels++;
     adcConfig[ADC_BATTERY].enabled = true;
     adcConfig[ADC_BATTERY].sampleTime = ADC_SampleTime_239Cycles5;
+
+    if (init->enableCurrentMeter) {
+        GPIO_InitStructure.GPIO_Pin   = GPIO_Pin_1;
+        adcConfig[ADC_CURRENT].adcChannel = ADC_Channel_1;
+        adcConfig[ADC_CURRENT].dmaIndex = configuredAdcChannels++;
+        adcConfig[ADC_CURRENT].enabled = true;
+        adcConfig[ADC_CURRENT].sampleTime = ADC_SampleTime_239Cycles5;
+    }
     GPIO_Init(GPIOA, &GPIO_InitStructure);
 #else
     // configure always-present battery index (ADC4)

--- a/src/main/drivers/pwm_mapping.c
+++ b/src/main/drivers/pwm_mapping.c
@@ -309,6 +309,12 @@ pwmOutputConfiguration_t *pwmInit(drv_pwm_config_t *init)
             continue;
         }
 #endif
+
+#ifdef CC3D
+        if (init->useCurrentMeterADC && timerIndex == PWM6) {
+            continue;
+        }
+#endif
         // hacks to allow current functionality
         if (type == MAP_TO_PWM_INPUT && !init->useParallelPWM)
             type = 0;

--- a/src/main/drivers/pwm_mapping.h
+++ b/src/main/drivers/pwm_mapping.h
@@ -39,6 +39,7 @@ typedef struct drv_pwm_config_t {
     bool useParallelPWM;
     bool usePPM;
     bool useRSSIADC;
+    bool useCurrentMeterADC;
 #ifdef STM32F10X
     bool useUART2;
 #endif

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -293,6 +293,7 @@ void init(void)
     pwm_params.useSoftSerial = feature(FEATURE_SOFTSERIAL);
     pwm_params.useParallelPWM = feature(FEATURE_RX_PARALLEL_PWM);
     pwm_params.useRSSIADC = feature(FEATURE_RSSI_ADC);
+    pwm_params.useCurrentMeterADC = feature(FEATURE_CURRENT_METER);
     pwm_params.useLEDStrip = feature(FEATURE_LED_STRIP);
     pwm_params.usePPM = feature(FEATURE_RX_PPM);
     pwm_params.useServos = isMixerUsingServos();


### PR DESCRIPTION
The input for current monitoring is on pin 8 of the RC-input connector. As it is directly connected to the processor, the tension delivered by the current sensor must not be over 3.3V.
The drawn battery capacity is also evaluated (mAh) and transmitted.
