### PR TITLE
RSSI_ADC configurable scale in CLI

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -317,6 +317,7 @@ static void resetConf(void)
     masterConfig.rxConfig.mincheck = 1100;
     masterConfig.rxConfig.maxcheck = 1900;
     masterConfig.rxConfig.rssi_channel = 0;
+    masterConfig.rxConfig.rssi_scale = RSSI_SCALE_DEFAULT;
 
     masterConfig.inputFilteringMode = INPUT_FILTERING_DISABLED;
 

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -204,6 +204,7 @@ const clivalue_t valueTable[] = {
     { "min_check",                  VAR_UINT16 | MASTER_VALUE,  &masterConfig.rxConfig.mincheck, PWM_RANGE_ZERO, PWM_RANGE_MAX },
     { "max_check",                  VAR_UINT16 | MASTER_VALUE,  &masterConfig.rxConfig.maxcheck, PWM_RANGE_ZERO, PWM_RANGE_MAX },
     { "rssi_channel",               VAR_INT8   | MASTER_VALUE,  &masterConfig.rxConfig.rssi_channel, 0, MAX_SUPPORTED_RC_CHANNEL_COUNT },
+    { "rssi_scale",                 VAR_INT8   | MASTER_VALUE,  &masterConfig.rxConfig.rssi_scale, RSSI_SCALE_MIN, RSSI_SCALE_MAX },
     { "input_filtering_mode",       VAR_INT8   | MASTER_VALUE,  &masterConfig.inputFilteringMode, 0, 1 },
 
     { "min_throttle",               VAR_UINT16 | MASTER_VALUE,  &masterConfig.escAndServoConfig.minthrottle, PWM_RANGE_ZERO, PWM_RANGE_MAX },

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -347,7 +347,7 @@ void updateRSSIPWM(void)
 }
 
 #define RSSI_ADC_SAMPLE_COUNT 16
-#define RSSI_SCALE (0xFFF / 100.0f)
+//#define RSSI_SCALE (0xFFF / 100.0f)
 
 void updateRSSIADC(uint32_t currentTime)
 {
@@ -362,7 +362,7 @@ void updateRSSIADC(uint32_t currentTime)
 
     int16_t adcRssiMean = 0;
     uint16_t adcRssiSample = adcGetChannel(ADC_RSSI);
-    uint8_t rssiPercentage = adcRssiSample / RSSI_SCALE;
+    uint8_t rssiPercentage = adcRssiSample / rxConfig->rssi_scale;
 
     adcRssiSampleIndex = (adcRssiSampleIndex + 1) % RSSI_ADC_SAMPLE_COUNT;
 

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -58,6 +58,10 @@ extern int16_t rcData[MAX_SUPPORTED_RC_CHANNEL_COUNT];       // interval [1000;2
 
 #define MAX_MAPPABLE_RX_INPUTS 8
 
+#define RSSI_SCALE_MIN 1
+#define RSSI_SCALE_MAX 255
+#define RSSI_SCALE_DEFAULT 30
+
 typedef struct rxConfig_s {
     uint8_t rcmap[MAX_MAPPABLE_RX_INPUTS];  // mapping of radio channels to internal RPYTA+ order
     uint8_t serialrx_provider;              // type of UART-based receiver (0 = spek 10, 1 = spek 11, 2 = sbus). Must be enabled by FEATURE_RX_SERIAL first.
@@ -65,6 +69,7 @@ typedef struct rxConfig_s {
     uint16_t mincheck;                      // minimum rc end
     uint16_t maxcheck;                      // maximum rc end
     uint8_t rssi_channel;
+    uint8_t rssi_scale;
 } rxConfig_t;
 
 #define REMAPPABLE_CHANNEL_COUNT (sizeof(((rxConfig_t *)0)->rcmap) / sizeof(((rxConfig_t *)0)->rcmap[0]))


### PR DESCRIPTION
A configurable scale for RSSI (rssi_scale in CLI) is applied to the rssi voltage for tuning. Set in CLI its value is between 1 (to avoid a 0 division) and 255.
The rssi voltage (applied on RC2 of NAZE32) is obtained with a low pass RC filter (R=220K and C=1microF) on the PPM signal. For my configuration, the resulting voltage is 2V which then can be set to a 96% RSSI level (with rssi_scale=29).
