### PR TITLE
Correction of typo and consequences

### DIFF
--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -247,6 +247,12 @@ serialPortSearchResult_t *findNextSerialPort(serialPortFunction_e function, cons
         uint8_t serialPortIndex = lookupSerialPortIndexByIdentifier(serialPortFunction->identifier);
         const serialPortConstraint_t *serialPortConstraint = &serialPortConstraints[serialPortIndex];
 
+#if defined(CC3D)
+        if (!feature(FEATURE_SOFTSERIAL) && (
+                serialPortConstraint->identifier == SERIAL_PORT_SOFTSERIAL1)) {
+            continue;
+        }
+#else
 #if defined(USE_SOFTSERIAL1) ||(defined(USE_SOFTSERIAL2))
         if (!feature(FEATURE_SOFTSERIAL) && (
                 serialPortConstraint->identifier == SERIAL_PORT_SOFTSERIAL1 ||
@@ -254,13 +260,12 @@ serialPortSearchResult_t *findNextSerialPort(serialPortFunction_e function, cons
         )) {
             continue;
         }
-
+#endif
 #if (defined(NAZE) || defined(OLIMEXINO)) && defined(SONAR)
         if (feature(FEATURE_SONAR) && !feature(FEATURE_RX_PARALLEL_PWM) && (serialPortConstraint->identifier == SERIAL_PORT_SOFTSERIAL2)) {
             continue;
         }
 #endif
-
 #endif
 
         if (functionConstraint->requiredSerialPortFeatures != SPF_NONE) {

--- a/src/main/io/serial.h
+++ b/src/main/io/serial.h
@@ -85,16 +85,15 @@ typedef enum {
 #define SERIAL_PORT_IDENTIFIER_COUNT 5
 #else
 
-#ifdef CCD3
+#ifdef CC3D
 
 typedef enum {
-    SERIAL_PORT_USART1,
+    SERIAL_PORT_USART1 = 0,
     SERIAL_PORT_USART3,
     SERIAL_PORT_SOFTSERIAL1,
-    SERIAL_PORT_SOFTSERIAL2
 } serialPortIdentifier_e;
 
-#define SERIAL_PORT_IDENTIFIER_COUNT 4
+#define SERIAL_PORT_IDENTIFIER_COUNT 3
 #else
 
 typedef enum {


### PR DESCRIPTION
Correction of typo in io/serial.h (CCD3 instead of CC3D) and consequences :
- cleaning of serialPortIdentifier_e
- specific case for CC3D in io/serial.c
