### PR TITLE
atomic.h - Bump version check number

### DIFF
--- a/src/main/common/atomic.h
+++ b/src/main/common/atomic.h
@@ -83,7 +83,7 @@ static inline uint8_t __basepriSetRetVal(uint8_t prio)
 // ideally this would only protect memory passed as parameter (any type should work), but gcc is curently creating almost full barrier
 // this macro can be used only ONCE PER LINE, but multiple uses per block are fine
 
-#if (__GNUC__ > 4 || (__GNUC__ == 4 && (__GNUC_MINOR__ > 8)))
+#if (__GNUC__ > 4)
 #warning "Please verify that ATOMIC_BARRIER works as intended"
 // increment version number is BARRIER works
 // TODO - use flag to disable ATOMIC_BARRIER and use full barrier instead


### PR DESCRIPTION
Version for warning is increased to gcc > 4.x, used approach should be safe in gcc 4.x (and most probably also in future versions)
