### PR TITLE
Fix double constatns

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -459,7 +459,7 @@ CFLAGS		 = $(ARCH_FLAGS) \
 		   $(addprefix -I,$(INCLUDE_DIRS)) \
 		   $(DEBUG_FLAGS) \
 		   -std=gnu99 \
-		   -Wall -Wextra -Wunsafe-loop-optimizations \
+		   -Wall -Wextra -Wunsafe-loop-optimizations -Wdouble-promotion \
 		   -ffunction-sections \
 		   -fdata-sections \
 		   $(DEVICE_FLAGS) \

--- a/src/main/common/maths.h
+++ b/src/main/common/maths.h
@@ -21,9 +21,11 @@
 #define sq(x) ((x)*(x))
 #endif
 
-#ifndef M_PI
+#ifdef M_PI
+// M_PI should be float, but previous definition may be double
+# undef M_PI
+#endif
 #define M_PI       3.14159265358979323846f
-#endif /* M_PI */
 
 #define RADX10 (M_PI / 1800.0f)                  // 0.001745329252f
 #define RAD    (M_PI / 180.0f)

--- a/src/main/telemetry/frsky.c
+++ b/src/main/telemetry/frsky.c
@@ -211,7 +211,7 @@ static void sendSatalliteSignalQualityAsTemperature2(void)
     } else {
         float tmp = (satellite - 32) / 1.8;
         //Round the value
-        tmp += (tmp < 0) ? -0.5 : 0.5;
+        tmp += (tmp < 0) ? -0.5f : 0.5f;
         serialize16(tmp);
     }
 }

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -324,7 +324,7 @@ void handleSmartPortTelemetry(void)
             case FSSP_DATAID_SPEED      :
                 if (sensors(SENSOR_GPS) && STATE(GPS_FIX)) {
                     tmpf = GPS_speed;
-                    tmpf *= 0.36;
+                    tmpf *= 0.36f;
                     smartPortSendPackage(id, (uint32_t)lroundf(tmpf)); // given in 0.1 m/s, provide in KM/H
                     smartPortHasRequest = 0;
                 }


### PR DESCRIPTION
some constants were double, M_PI was sometimes inherided as double

added -Wdouble-promotion to makefile warnings

Saves some flash space
