### PR TITLE
AlienWii32 alternative defaults for NAZE target

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -435,6 +435,19 @@ static void resetConf(void)
     applyDefaultLedStripConfig(masterConfig.ledConfigs);
 #endif
 
+    // alternative defaults AlienWii32 (activate via OPTIONS="ALIENWII32" during make for NAZE target)
+#ifdef ALIENWII32
+    featureSet(FEATURE_RX_MSP);
+    featureSet(FEATURE_MOTOR_STOP);
+    masterConfig.rxConfig.serialrx_provider = 1;
+    masterConfig.escAndServoConfig.minthrottle = 1000;
+    masterConfig.escAndServoConfig.maxthrottle = 2000;
+    currentControlRateProfile->rcRate8 = 130;
+    currentControlRateProfile->rollPitchRate = 20;
+    currentControlRateProfile->yawRate = 60;
+    parseRcChannels("TAER1234", &masterConfig.rxConfig);
+#endif
+
     // copy first profile into remaining profile
     for (i = 1; i < MAX_PROFILE_COUNT; i++) {
         memcpy(&masterConfig.profile[i], currentProfile, sizeof(profile_t));

--- a/src/main/target/NAZE/target.h
+++ b/src/main/target/NAZE/target.h
@@ -111,3 +111,8 @@
 #define TELEMETRY
 #define SERIAL_RX
 #define AUTOTUNE
+
+    // alternative defaults AlienWii32 (activate via OPTIONS="ALIENWII32" during make for NAZE target)
+#ifdef ALIENWII32
+#define BRUSHED_MOTORS
+#endif


### PR DESCRIPTION
Activate via OPTIONS="ALIENWII32" during make
