### PR TITLE
Use same PWM mapping for PPM and Serial RX

### DIFF
--- a/src/main/drivers/pwm_mapping.c
+++ b/src/main/drivers/pwm_mapping.c
@@ -28,6 +28,7 @@
 #include "pwm_output.h"
 #include "pwm_rx.h"
 #include "pwm_mapping.h"
+#include "config/config.h"
 /*
     Configuration maps
 
@@ -257,7 +258,7 @@ pwmOutputConfiguration_t *pwmInit(drv_pwm_config_t *init)
     // this is pretty hacky shit, but it will do for now. array of 4 config maps, [ multiPWM multiPPM airPWM airPPM ]
     if (init->airplane)
         i = 2; // switch to air hardware config
-    if (init->usePPM)
+    if (init->usePPM || feature(FEATURE_RX_SERIAL))
         i++; // next index is for PPM
 
     setup = hardwareMaps[i];


### PR DESCRIPTION
Without this fix an Octocopter with serialh RX will not work. Standard
receiver mapping with only 6 motors outputs will apply.
