### PR TITLE
travis: Add inital support for travis-ci.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ env:
   - TARGET=SPARKY
   - TARGET=STM32F3DISCOVERY
 language: c
-compiler: gcc
+compiler: arm-none-eabi-gcc
 before_install: sudo add-apt-repository -y ppa:terry.guo/gcc-arm-embedded && sudo apt-get update
 install: sudo apt-get install build-essential gcc-arm-none-eabi git
-script: make
+before_script: $CC --version
+script: make -j2


### PR DESCRIPTION
- Initial support for travis-ci.org
- Example build: https://travis-ci.org/kylemanna/cleanflight
- Hope is to later add unit tests and builds for more then just NAZE
- Recommend setting up travis-ci.org for cleanflight and then merging this.  Should trigger a fresh build on the merge then.
