### PR TITLE
Update rc_controls.c

### DIFF
--- a/src/main/io/rc_controls.c
+++ b/src/main/io/rc_controls.c
@@ -423,7 +423,6 @@ void changeControlRateProfile(uint8_t profileIndex);
 
 void applySelectAdjustment(uint8_t adjustmentFunction, uint8_t position) {
 
-    queueConfirmationBeep(position + 1);
     switch(adjustmentFunction) {
         case ADJUSTMENT_RATE_PROFILE:
             if (getCurrentControlRateProfile() != position) {


### PR DESCRIPTION
Remove line which causes repeated beeping when a rate profile adjustment range is configured.
