### PR TITLE
README: Add build status icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Cleanflight
 
+[![Build Status](https://travis-ci.org/cleanflight/cleanflight.svg?branch=master)](https://travis-ci.org/cleanflight/cleanflight)
+
 Clean-code version of baseflight flight-controller - flight controllers are used to fly multi-rotor craft and fixed wing craft.
 
 This fork differs from baseflight in that it attempts to use modern software development practices which result in:


### PR DESCRIPTION
- Add build status icon via Travis CI to the to portion of the README
  so that build errors are quickly discovered and investigated.
- Also draws attention to the build.
