### PR TITLE
Fix ADC clock speed to be within specification

### DIFF
--- a/src/main/drivers/adc_stm32f10x.c
+++ b/src/main/drivers/adc_stm32f10x.c
@@ -117,6 +117,9 @@ void adcInit(drv_adc_config_t *init)
         adcConfig[ADC_CURRENT].sampleTime = ADC_SampleTime_239Cycles5;
     }
 
+
+    RCC_ADCCLKConfig(RCC_PCLK2_Div8);  // 9MHz from 72MHz APB2 clock(HSE), 8MHz from 64MHz (HSI)
+
     RCC_AHBPeriphClockCmd(RCC_AHBPeriph_DMA1, ENABLE);
     RCC_APB2PeriphClockCmd(RCC_APB2Periph_ADC1, ENABLE);
 


### PR DESCRIPTION
ADC clock speed may be slightly higher, but there is no benefit in current code

stm32f303 code does set prescaler correctly (but quite low)