### PR TITLE
Feature adc lowfreq

### DIFF
--- a/src/main/drivers/adc.h
+++ b/src/main/drivers/adc.h
@@ -42,3 +42,4 @@ typedef struct drv_adc_config_t {
 
 void adcInit(drv_adc_config_t *init);
 uint16_t adcGetChannel(uint8_t channel);
+void adcTriggerConversion(void);

--- a/src/main/drivers/adc_stm32f10x.c
+++ b/src/main/drivers/adc_stm32f10x.c
@@ -142,7 +142,7 @@ void adcInit(drv_adc_config_t *init)
 
     adc.ADC_Mode = ADC_Mode_Independent;
     adc.ADC_ScanConvMode = configuredAdcChannels > 1 ? ENABLE : DISABLE;
-    adc.ADC_ContinuousConvMode = ENABLE;
+    adc.ADC_ContinuousConvMode = DISABLE;
     adc.ADC_ExternalTrigConv = ADC_ExternalTrigConv_None;
     adc.ADC_DataAlign = ADC_DataAlign_Right;
     adc.ADC_NbrOfChannel = configuredAdcChannels;
@@ -164,5 +164,11 @@ void adcInit(drv_adc_config_t *init)
     ADC_StartCalibration(ADC1);
     while(ADC_GetCalibrationStatus(ADC1));
 
+    ADC_SoftwareStartConvCmd(ADC1, ENABLE);
+}
+
+// start conversion scan on all channels. Called from systick handler now
+void adcTriggerConversion(void)
+{
     ADC_SoftwareStartConvCmd(ADC1, ENABLE);
 }

--- a/src/main/drivers/adc_stm32f30x.c
+++ b/src/main/drivers/adc_stm32f30x.c
@@ -157,3 +157,7 @@ void adcInit(drv_adc_config_t *init)
     ADC_StartConversion(ADC1);
 }
 
+// dummy implementation, stm32f303 ADC clock and sampling time results in 116Hz conversion rate
+void adcTriggerConversion(void)
+{
+}

--- a/src/main/drivers/system.c
+++ b/src/main/drivers/system.c
@@ -27,6 +27,7 @@
 #include "light_led.h"
 #include "sound_beeper.h"
 #include "nvic.h"
+#include "adc.h"
 
 #include "system.h"
 
@@ -46,6 +47,8 @@ static void cycleCounterInit(void)
 void SysTick_Handler(void)
 {
     sysTickUptime++;
+    // trigger ADC conversion from here
+    adcTriggerConversion();
 }
 
 // Return system uptime in microseconds (rollover in 70minutes)


### PR DESCRIPTION
ADC sampling speed is higher than necessary. Current necessary to charge sampling capacitor is causing error for high-impedance sources - typically current measurement.

This patch triggers ADC conversion from systick handler, decreasing conversion to 1kHz. At this speed sampling current is much smaller that other error sources. Only stm32f10x is changed - 30x conversion speed is lower than 1kHz
