### PR TITLE
auto-disarm implementation, slight rewrite of HFMan commit 931478054e70c...

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -352,6 +352,7 @@ static void resetConf(void)
 
     masterConfig.retarded_arm = 0;
     masterConfig.disarm_kill_switch = 1;
+    masterConfig.auto_disarm_delay = 5;
     masterConfig.small_angle = 25;
 
     masterConfig.airplaneConfig.flaps_speed = 0;

--- a/src/main/config/config_master.h
+++ b/src/main/config/config_master.h
@@ -63,6 +63,7 @@ typedef struct master_t {
 
     uint8_t retarded_arm;                   // allow disarm/arm on throttle down + roll left/right
     uint8_t disarm_kill_switch;             // allow disarm via AUX switch regardless of throttle value
+    uint8_t auto_disarm_delay;              // allow automatically disarming multicopters after auto_disarm_delay seconds of zero throttle. Disabled when 0
     uint8_t small_angle;
 
     airplaneConfig_t airplaneConfig;

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -232,6 +232,7 @@ const clivalue_t valueTable[] = {
 
     { "retarded_arm",               VAR_UINT8  | MASTER_VALUE,  &masterConfig.retarded_arm, 0, 1 },
     { "disarm_kill_switch",         VAR_UINT8  | MASTER_VALUE,  &masterConfig.disarm_kill_switch, 0, 1 },
+    { "auto_disarm_delay",          VAR_UINT8  | MASTER_VALUE,  &masterConfig.auto_disarm_delay, 0, 60 },
     { "small_angle",                VAR_UINT8  | MASTER_VALUE,  &masterConfig.small_angle, 0, 180 },
 
     { "flaps_speed",                VAR_UINT8  | MASTER_VALUE,  &masterConfig.airplaneConfig.flaps_speed, 0, 100 },


### PR DESCRIPTION
...d6a51916ea9430f041f61b7f7ba

Added automatic disarm after 5 seconds when feature MOTOR_STOP is enabled (has no effect on
FIXED_WING configurations.)  Users that don't have a buzzer to warn when
board is armed and use feature MOTOR_STOP can forget to disarm the
board. For example after landing they pick up copter and then
accidentally move throttle up when trying to remove flight battery.

Configurable via CLI using 'set auto_disarm_board=x' where x is 0-60
seconds.  If zero, does not auto_disarm.
