### PR TITLE
Fix broken link in Buzzer.md.

### DIFF
--- a/docs/Buzzer.md
+++ b/docs/Buzzer.md
@@ -35,4 +35,4 @@ Buzzer support on the CC3D requires that a buzzer circuit be created to which th
 PA15 is unused and not connected according to the CC3D Revision A schematic.
 Connecting to PA15 requires careful soldering.
 
-See the [CC3D - buzzer circuir.pdf](Wiring/CC3D - buzzer circuir.pdf) for details.
+See the [CC3D - buzzer circuit.pdf](Wiring/CC3D - buzzer circuit.pdf) for details.


### PR DESCRIPTION
There was a broken link caused by a typo in 'docs/Buzzer.md'.