### PR TITLE
Baseflight pid (pid_controller=2) horizon mode tuneup

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -159,7 +159,7 @@ static void resetPidProfile(pidProfile_t *pidProfile)
     pidProfile->D_f[YAW] = 0.05f;
     pidProfile->A_level = 5.0f;
     pidProfile->H_level = 3.0f;
-    pidProfile->H_sensitivity = 10.0f;
+    pidProfile->H_sensitivity = 75;
 }
 
 #ifdef GPS

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -159,6 +159,7 @@ static void resetPidProfile(pidProfile_t *pidProfile)
     pidProfile->D_f[YAW] = 0.05f;
     pidProfile->A_level = 5.0f;
     pidProfile->H_level = 3.0f;
+    pidProfile->H_sensitivity = 10.0f;
 }
 
 #ifdef GPS

--- a/src/main/flight/flight.h
+++ b/src/main/flight/flight.h
@@ -42,7 +42,7 @@ typedef struct pidProfile_s {
     float D_f[3];
     float A_level;
     float H_level;
-    float H_sensitivity;
+    uint8_t H_sensitivity;
 } pidProfile_t;
 
 typedef enum {

--- a/src/main/flight/flight.h
+++ b/src/main/flight/flight.h
@@ -42,6 +42,7 @@ typedef struct pidProfile_s {
     float D_f[3];
     float A_level;
     float H_level;
+    float H_sensitivity;
 } pidProfile_t;
 
 typedef enum {

--- a/src/main/io/rc_controls.h
+++ b/src/main/io/rc_controls.h
@@ -140,7 +140,7 @@ throttleStatus_e calculateThrottleStatus(rxConfig_t *rxConfig, uint16_t deadband
 void processRcStickPositions(rxConfig_t *rxConfig, throttleStatus_e throttleStatus, bool retarded_arm, bool disarm_kill_switch);
 
 void updateActivatedModes(modeActivationCondition_t *modeActivationConditions);
-
+int32_t getRcStickPosition(int32_t axis);
 
 typedef enum {
     ADJUSTMENT_NONE = 0,

--- a/src/main/io/rc_controls.h
+++ b/src/main/io/rc_controls.h
@@ -140,7 +140,7 @@ throttleStatus_e calculateThrottleStatus(rxConfig_t *rxConfig, uint16_t deadband
 void processRcStickPositions(rxConfig_t *rxConfig, throttleStatus_e throttleStatus, bool retarded_arm, bool disarm_kill_switch);
 
 void updateActivatedModes(modeActivationCondition_t *modeActivationConditions);
-int32_t getRcStickPosition(int32_t axis);
+
 
 typedef enum {
     ADJUSTMENT_NONE = 0,

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -392,6 +392,7 @@ const clivalue_t valueTable[] = {
 
     { "level_horizon",              VAR_FLOAT  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.H_level, 0, 10 },
     { "level_angle",                VAR_FLOAT  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.A_level, 0, 10 },
+    { "sensitivity_horizon",        VAR_FLOAT  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.H_sensitivity, 0, 250 },
 
     { "p_alt",                      VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.P8[PIDALT], 0, 200 },
     { "i_alt",                      VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.I8[PIDALT], 0, 200 },

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -392,7 +392,7 @@ const clivalue_t valueTable[] = {
 
     { "level_horizon",              VAR_FLOAT  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.H_level, 0, 10 },
     { "level_angle",                VAR_FLOAT  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.A_level, 0, 10 },
-    { "sensitivity_horizon",        VAR_FLOAT  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.H_sensitivity, 0, 250 },
+    { "sensitivity_horizon",        VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.H_sensitivity, 0, 250 },
 
     { "p_alt",                      VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.P8[PIDALT], 0, 200 },
     { "i_alt",                      VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.I8[PIDALT], 0, 200 },

--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -846,7 +846,7 @@ static bool processOutCommand(uint8_t cmdMSP)
                 if (i == PIDLEVEL) {
                     serialize8(constrain(lrintf(currentProfile->pidProfile.A_level * 10.0f), 0, 250));
                     serialize8(constrain(lrintf(currentProfile->pidProfile.H_level * 10.0f), 0, 250));
-                    serialize8(0);
+                    serialize8(constrain(lrintf(currentProfile->pidProfile.H_sensitivity * 10.0f), 0, 250));
                 } else {
                     serialize8(currentProfile->pidProfile.P8[i]);
                     serialize8(currentProfile->pidProfile.I8[i]);
@@ -1165,7 +1165,7 @@ static bool processInCommand(void)
                 if (i == PIDLEVEL) {
                     currentProfile->pidProfile.A_level = (float)read8() / 10.0f;
                     currentProfile->pidProfile.H_level = (float)read8() / 10.0f;
-                    read8();
+                    currentProfile->pidProfile.H_sensitivity = (float)read8() / 10.0f;
                 } else {
                     currentProfile->pidProfile.P8[i] = read8();
                     currentProfile->pidProfile.I8[i] = read8();

--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -846,7 +846,7 @@ static bool processOutCommand(uint8_t cmdMSP)
                 if (i == PIDLEVEL) {
                     serialize8(constrain(lrintf(currentProfile->pidProfile.A_level * 10.0f), 0, 250));
                     serialize8(constrain(lrintf(currentProfile->pidProfile.H_level * 10.0f), 0, 250));
-                    serialize8(constrain(lrintf(currentProfile->pidProfile.H_sensitivity * 10.0f), 0, 250));
+                    serialize8(constrain(lrintf(currentProfile->pidProfile.H_sensitivity), 0, 250));
                 } else {
                     serialize8(currentProfile->pidProfile.P8[i]);
                     serialize8(currentProfile->pidProfile.I8[i]);
@@ -1165,7 +1165,7 @@ static bool processInCommand(void)
                 if (i == PIDLEVEL) {
                     currentProfile->pidProfile.A_level = (float)read8() / 10.0f;
                     currentProfile->pidProfile.H_level = (float)read8() / 10.0f;
-                    currentProfile->pidProfile.H_sensitivity = (float)read8() / 10.0f;
+                    currentProfile->pidProfile.H_sensitivity = read8();
                 } else {
                     currentProfile->pidProfile.P8[i] = read8();
                     currentProfile->pidProfile.I8[i] = read8();

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -338,6 +338,11 @@ void mwArm(void)
     }
 }
 
+int32_t getRcStickPosition(int32_t axis) {
+
+    return min(abs(rcData[axis] - masterConfig.rxConfig.midrc), 500);
+}
+
 // Automatic ACC Offset Calibration
 bool AccInflightCalibrationArmed = false;
 bool AccInflightCalibrationMeasurementDone = false;

--- a/src/main/mw.h
+++ b/src/main/mw.h
@@ -22,3 +22,5 @@ void handleInflightCalibrationStickPosition();
 
 void mwDisarm(void);
 void mwArm(void);
+
+int32_t getRcStickPosition(int32_t axis);


### PR DESCRIPTION
This code uses a stick position algorithm for calculating the leveling force when inverted.  This is based on RC911's "Stick Mixing" algorithm on the KK2 controller, and is similar to the horizon mode in PID controller 0.  

Flight test is here:
https://www.youtube.com/watch?v=C_vZDNst6pM

When tuning, the Level P term is the leveling force when in angle mode.  The Level I term is the leveling force when in horizon mode, and the Level D term is the percentage of stick travel where leveling is active.  The default values seem to work fine.