### PR TITLE
Bugfix for failsafe ignoring RX signal mapping

### DIFF
--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -289,7 +289,7 @@ void processRxChannels(void)
         uint16_t sample = rcReadRawFunc(&rxRuntimeConfig, rawChannel);
 
         if (feature(FEATURE_FAILSAFE) && shouldCheckPulse) {
-            failsafe->vTable->checkPulse(rawChannel, sample);
+            failsafe->vTable->checkPulse(chan, sample);
         }
 
         // validate the range


### PR DESCRIPTION
An example is when a GPS is being used on UART2 (Rx pin 4), with the mapping of AET4R123.  This code prevents failsafe being triggered by GPS data on Rx pin 4.