### PR TITLE
Add LSM303DLHC compass support using HMC5883L driver

### DIFF
--- a/src/main/target/STM32F3DISCOVERY/target.h
+++ b/src/main/target/STM32F3DISCOVERY/target.h
@@ -42,6 +42,9 @@
 #define ACC
 #define USE_ACC_LSM303DLHC
 
+#define MAG
+#define USE_MAG_HMC5883
+
 #define BEEPER
 #define LED0
 #define LED1
@@ -54,7 +57,7 @@
 #define USE_I2C
 #define I2C_DEVICE (I2CDEV_1)
 
-#define SENSORS_SET (SENSOR_ACC)
+#define SENSORS_SET (SENSOR_ACC | SENSOR_MAG)
 
 #define BLACKBOX
 #define GPS


### PR DESCRIPTION
LSM303DLHC compass is compatible to the HMC5883L. This was an easy one. 