### PR TITLE
Removed unused DEG2RAD macro.

### DIFF
--- a/src/main/common/maths.h
+++ b/src/main/common/maths.h
@@ -30,8 +30,6 @@
 #define RADX10 (M_PI / 1800.0f)                  // 0.001745329252f
 #define RAD    (M_PI / 180.0f)
 
-#define DEG2RAD(degrees) (degrees * RAD)
-
 #define min(a, b) ((a) < (b) ? (a) : (b))
 #define max(a, b) ((a) > (b) ? (a) : (b))
 #define abs(x) ((x) > 0 ? (x) : -(x))


### PR DESCRIPTION
This macro was used literally nowhere in the codebase.