### PR TITLE
Removed unused RADX10.

### DIFF
--- a/src/main/common/maths.h
+++ b/src/main/common/maths.h
@@ -30,8 +30,6 @@
 #define RADX10 (M_PI / 1800.0f)                  // 0.001745329252f
 #define RAD    (M_PI / 180.0f)
 
-#define DEG2RAD(degrees) (degrees * RAD)
-
 #define min(a, b) ((a) < (b) ? (a) : (b))
 #define max(a, b) ((a) > (b) ? (a) : (b))
 #define abs(x) ((x) > 0 ? (x) : -(x))

--- a/src/main/common/maths.h
+++ b/src/main/common/maths.h
@@ -27,7 +27,6 @@
 #endif
 #define M_PI       3.14159265358979323846f
 
-#define RADX10 (M_PI / 1800.0f)                  // 0.001745329252f
 #define RAD    (M_PI / 180.0f)
 
 #define min(a, b) ((a) < (b) ? (a) : (b))


### PR DESCRIPTION
Review this request first: https://github.com/cleanflight/cleanflight/pull/397, then only compare new changes onto that one, or ask me to rebase :)

The RADX10 macro is literally not used anywhere.