### PR TITLE
Fix bug that allowed arming craft before gyro calibration completed

### DIFF
--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -151,8 +151,8 @@ void updateAutotuneState(void)
 bool isCalibrating()
 {
 #ifdef BARO
-    if (sensors(SENSOR_ACC) && !isBaroCalibrationComplete()) {
-        return false;
+    if (sensors(SENSOR_BARO) && !isBaroCalibrationComplete()) {
+        return true;
     }
 #endif
 


### PR DESCRIPTION
Fixes #426 (tested on my quad that has a barometer present)