### PR TITLE
CC3D - Add sonar.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -427,6 +427,7 @@ CC3D_SRC	 = \
 		   drivers/serial_softserial.c \
 		   drivers/serial_uart.c \
 		   drivers/serial_uart_stm32f10x.c \
+		   drivers/sonar_hcsr04.c \
 		   drivers/sound_beeper_stm32f10x.c \
 		   drivers/system_stm32f10x.c \
 		   drivers/timer.c \

--- a/docs/Board - CC3D.md
+++ b/docs/Board - CC3D.md
@@ -23,8 +23,8 @@ The 8 pin RC_Input connector has the following pinouts when used in RX_PPM/RX_SE
 | 1   | Ground    |                                  |
 | 2   | +5V       |                                  |
 | 3   | PPM Input | Enable `feature RX_PPM`          | 
-| 4   | SoftSerial1 TX | Enable `feature SOFTSERIAL` |
-| 5   | SoftSerial1 RX | Enable `feature SOFTSERIAL` |
+| 4   | SoftSerial1 TX / Sonar trigger | |
+| 5   | SoftSerial1 RX / Sonar Echo    | |
 | 6   | Current   | Enable `feature CURRENT_METER`.  Connect to the output of a current sensor, 0v-3.3v input |
 | 7   | Battery Voltage sensor | Enable `feature VBAT`. Connect to main battery using a voltage divider, 0v-3.3v input |
 | 8   | RSSI      | Enable `feature RSSI_ADC`.  Connect to the output of a PWM-RSSI conditioner, 0v-3.3v input |

--- a/docs/Sonar.md
+++ b/docs/Sonar.md
@@ -19,6 +19,8 @@ Currently the only supported sensor is the HCSR04 sensor.
 | Parallel PWM  | PB8 / Motor 5 | PB9 / Motor 6 | NO (5v tolerant)    |
 | PPM/Serial RX | PB0 / RC7     | PB1 / RC8     | YES (3.3v input)    |
 
+#### Constraints
+
 Current meter cannot be used in conjunction with Parallel PWM and Sonar.
 
 ### Olimexino
@@ -27,4 +29,16 @@ Current meter cannot be used in conjunction with Parallel PWM and Sonar.
 | ------------- | ------------- | ------------------- |
 | PB0 / RC7     | PB1 / RC8     | YES (3.3v input)    |
 
-Current meter cannot be used in conjunction with sonar.
+#### Constraints
+
+Current meter cannot be used in conjunction with Sonar.
+
+### CC3D
+
+| Trigger       | Echo          | Inline 1k resistors |
+| ------------- | ------------- | ------------------- |
+| PB5           | PB0           | YES (3.3v input)    |
+
+#### Constraints
+
+Sonar cannot be used in conjuction with SoftSerial or Parallel PWM.

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -758,6 +758,13 @@ void validateAndFixConfig(void)
     }
 #endif
 
+#if defined(CC3D) && defined(SONAR) && defined(USE_SOFTSERIAL1)
+    if (feature(FEATURE_SONAR) && feature(FEATURE_SOFTSERIAL)) {
+        featureClear(FEATURE_SONAR);
+    }
+#endif
+
+
     useRxConfig(&masterConfig.rxConfig);
 
     serialConfig_t *serialConfig = &masterConfig.serialConfig;

--- a/src/main/drivers/pwm_mapping.c
+++ b/src/main/drivers/pwm_mapping.c
@@ -409,6 +409,17 @@ pwmOutputConfiguration_t *pwmInit(drv_pwm_config_t *init)
         }
 #endif
 
+#ifdef SONAR
+        if (init->sonarGPIOConfig && timerHardwarePtr->gpio == init->sonarGPIOConfig->gpio &&
+            (
+                timerHardwarePtr->pin == init->sonarGPIOConfig->triggerPin ||
+                timerHardwarePtr->pin == init->sonarGPIOConfig->echoPin
+            )
+        ) {
+            continue;
+        }
+#endif
+
         // hacks to allow current functionality
         if (type == MAP_TO_PWM_INPUT && !init->useParallelPWM)
             continue;

--- a/src/main/drivers/pwm_mapping.h
+++ b/src/main/drivers/pwm_mapping.h
@@ -36,6 +36,12 @@
 #define PWM_TIMER_MHZ 1
 #define ONESHOT125_TIMER_MHZ 8
 
+typedef struct sonarGPIOConfig_s {
+    GPIO_TypeDef *gpio;
+    uint16_t triggerPin;
+    uint16_t echoPin;
+} sonarGPIOConfig_t;
+
 typedef struct drv_pwm_config_t {
     bool useParallelPWM;
     bool usePPM;
@@ -59,6 +65,7 @@ typedef struct drv_pwm_config_t {
     uint16_t motorPwmRate;
     uint16_t idlePulse;  // PWM value to use when initializing the driver. set this to either PULSE_1MS (regular pwm),
                          // some higher value (used by 3d mode), or 0, for brushed pwm drivers.
+    sonarGPIOConfig_t *sonarGPIOConfig;
 } drv_pwm_config_t;
 
 

--- a/src/main/drivers/sonar_hcsr04.h
+++ b/src/main/drivers/sonar_hcsr04.h
@@ -25,6 +25,8 @@ typedef struct sonarHardware_s {
     IRQn_Type exti_irqn;
 } sonarHardware_t;
 
+#define SONAR_GPIO GPIOB
+
 void hcsr04_init(const sonarHardware_t *sonarHardware);
 
 void hcsr04_start_reading(void);

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -47,6 +47,7 @@
 #include "drivers/bus_spi.h"
 #include "drivers/inverter.h"
 #include "drivers/flash_m25p16.h"
+#include "drivers/sonar_hcsr04.h"
 
 #include "rx/rx.h"
 
@@ -117,6 +118,7 @@ void displayInit(rxConfig_t *intialRxConfig);
 void ledStripInit(ledConfig_t *ledConfigsToUse, hsvColor_t *colorsToUse);
 void loop(void);
 void spektrumBind(rxConfig_t *rxConfig);
+const sonarHardware_t *sonarGetHardwareConfiguration(void);
 
 #ifdef STM32F303xC
 // from system_stm32f30x.c
@@ -345,6 +347,18 @@ void init(void)
 
     mspInit(&masterConfig.serialConfig);
     cliInit(&masterConfig.serialConfig);
+
+#ifdef SONAR
+    if (feature(FEATURE_SONAR)) {
+        const sonarHardware_t *sonarHardware = sonarGetHardwareConfiguration();
+        sonarGPIOConfig_t sonarGPIOConfig = {
+                .echoPin = sonarHardware->trigger_pin,
+                .triggerPin = sonarHardware->echo_pin,
+                .gpio = SONAR_GPIO
+        };
+        pwm_params.sonarGPIOConfig = &sonarGPIOConfig;
+    }
+#endif
 
     failsafeInit(&masterConfig.rxConfig);
 

--- a/src/main/sensors/sonar.c
+++ b/src/main/sensors/sonar.c
@@ -37,8 +37,7 @@
 
 static int32_t calculatedAltitude;
 
-void sonarInit(void)
-{
+const sonarHardware_t *sonarGetHardwareConfiguration(void) {
 #if defined(NAZE) || defined(EUSTM32F103RC) || defined(PORT103R)
     static const sonarHardware_t const sonarPWM56 = {
         .trigger_pin = Pin_8,   // PWM5 (PB8) - 5v tolerant
@@ -56,9 +55,9 @@ void sonarInit(void)
     };
     // If we are using parallel PWM for our receiver, then use motor pins 5 and 6 for sonar, otherwise use rc pins 7 and 8
     if (feature(FEATURE_RX_PARALLEL_PWM)) {
-        hcsr04_init(&sonarPWM56);
+        return &sonarPWM56;
     } else {
-        hcsr04_init(&sonarRC78);
+        return &sonarRC78;
     }
 #elif defined(OLIMEXINO)
     static const sonarHardware_t const sonarHardware = {
@@ -68,11 +67,25 @@ void sonarInit(void)
         .exti_pin_source = GPIO_PinSource1,
         .exti_irqn = EXTI1_IRQn
     };
-    hcsr04_init(&sonarHardware);
+    return &sonarHardware;
+#elif defined(CC3D)
+    static const sonarHardware_t const sonarHardware = {
+        .trigger_pin = Pin_5,   // (PB5)
+        .echo_pin = Pin_0,      // (PB1) - only 3.3v ( add a 1K Ohms resistor )
+        .exti_line = EXTI_Line0,
+        .exti_pin_source = GPIO_PinSource0,
+        .exti_irqn = EXTI1_IRQn
+    };
+    return &sonarHardware;
 #else
 #error Sonar not defined for target
 #endif
+}
 
+void sonarInit(void)
+{
+    const sonarHardware_t *sonarHardware = sonarGetHardwareConfiguration();
+    hcsr04_init(sonarHardware);
     sensorsSet(SENSOR_SONAR);
     calculatedAltitude = -1;
 }

--- a/src/main/sensors/sonar.h
+++ b/src/main/sensors/sonar.h
@@ -23,3 +23,4 @@ void sonarUpdate(void);
 int32_t sonarRead(void);
 int32_t sonarCalculateAltitude(int32_t sonarAlt, int16_t tiltAngle);
 int32_t sonarGetLatestAltitude(void);
+

--- a/src/main/target/CC3D/target.h
+++ b/src/main/target/CC3D/target.h
@@ -111,12 +111,14 @@
 #define BLACKBOX
 #define TELEMETRY
 #define SERIAL_RX
+#define SONAR
 #define AUTOTUNE
 #define USE_SERVOS
 
 #if defined(OPBL)
 #undef AUTOTUNE // disabled for OPBL build due to code size.
 #endif
+
 
 #define SPEKTRUM_BIND
 // USART3, PB11 (Flexport)


### PR DESCRIPTION
This also ensures that the PWM mapping does not use the sonar pins when
sonar is enabled in a board agnostic way.