### PR TITLE
Blackbox: Log PID intermediates for pidLuxFloat

### DIFF
--- a/src/main/flight/flight.c
+++ b/src/main/flight/flight.c
@@ -201,8 +201,13 @@ static void pidLuxFloat(pidProfile_t *pidProfile, controlRateConfig_t *controlRa
 
         // -----calculate total PID output
         axisPID[axis] = constrain(lrintf(PTerm + ITerm - DTerm), -1000, 1000);
-    }
 
+#ifdef BLACKBOX
+        axisPID_P[axis] = PTerm;
+        axisPID_I[axis] = ITerm;
+        axisPID_D[axis] = -DTerm;
+#endif
+    }
 }
 
 static void pidMultiWii(pidProfile_t *pidProfile, controlRateConfig_t *controlRateConfig,


### PR DESCRIPTION
Previously nothing was logged since the intermediate calculations were floats. Logging them converted to integers is better than nothing.