### PR TITLE
Fix feature config checks for current meter

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -660,8 +660,10 @@ void validateAndFixConfig(void)
 #if defined(STM32F10X)
         // rssi adc needs the same ports
         featureClear(FEATURE_RSSI_ADC);
-        // current meter needs the same ports
-        featureClear(FEATURE_CURRENT_METER);
+        if(masterConfig.batteryConfig.currentMeterType == CURRENT_SENSOR_ADC) {
+            // adc current meter needs the same ports
+            featureClear(FEATURE_CURRENT_METER);
+        }
 #endif
 
 #if defined(STM32F10X) || defined(CHEBUZZ) || defined(STM32F3DISCOVERY)
@@ -695,13 +697,19 @@ void validateAndFixConfig(void)
 
 #if defined(NAZE) && defined(SONAR)
     if (feature(FEATURE_RX_PARALLEL_PWM) && feature(FEATURE_SONAR) && feature(FEATURE_CURRENT_METER)) {
-        featureClear(FEATURE_CURRENT_METER);
+        if(masterConfig.batteryConfig.currentMeterType == CURRENT_SENSOR_ADC) {
+            // adc current meter needs the same ports
+            featureClear(FEATURE_CURRENT_METER);
+        }
     }
 #endif
 
 #if defined(OLIMEXINO) && defined(SONAR)
     if (feature(FEATURE_SONAR) && feature(FEATURE_CURRENT_METER)) {
-        featureClear(FEATURE_CURRENT_METER);
+        if(masterConfig.batteryConfig.currentMeterType == CURRENT_SENSOR_ADC) {
+            // adc current meter needs the same ports
+            featureClear(FEATURE_CURRENT_METER);
+        }
     }
 #endif
 


### PR DESCRIPTION
Checks to see if ADC meter type is selected, only clears the feature flag if it is. Fixes #459 