### PR TITLE
Correct Box Documentation

### DIFF
--- a/docs/Modes.md
+++ b/docs/Modes.md
@@ -9,24 +9,24 @@ auxillary receiver channels and other events such as failsafe detection.
 | 1       | ANGLE      | Legacy auto-level flight mode                                        |
 | 2       | HORIZON    | Auto-level flight mode                                               |
 | 3       | BARO       | Altitude hold mode (Requires barometer sensor)                       |
-| 5       | MAG        | Heading lock                                                         |
-| 6       | HEADFREE   | Head Free - When enabled yaw has no effect on pitch/roll inputs      |
-| 7       | HEADADJ    | Heading Adjust - Sets a new yaw origin for HEADFREE mode             |
-| 8       | CAMSTAB    | Camera Stabilisation                                                 |
-| 9       | CAMTRIG    |                                                                      |
-| 10      | GPSHOME    | Autonomous flight to HOME position                                   |
-| 11      | GPSHOLD    | Maintain the same longitude/lattitude                                |
-| 12      | PASSTHRU   |                                                                      |
-| 13      | BEEPERON   | Enable beeping - useful for locating a crashed aircraft              |
-| 14      | LEDMAX     |                                                                      |
-| 15      | LEDLOW     |                                                                      |
-| 16      | LLIGHTS    |                                                                      |
-| 17      | CALIB      |                                                                      |
-| 18      | GOV        |                                                                      |
-| 19      | OSD        | Enable/Disable On-Screen-Display (OSD)                               |
-| 20      | TELEMETRY  | Enable telemetry via switch                                          |
-| 21      | AUTOTUNE   | Autotune Pitch/Roll PIDs                                             |
-| 22      | SONAR      | Altitude hold mode (sonar sensor only)                               |
+| 4       | MAG        | Heading lock                                                         |
+| 5       | HEADFREE   | Head Free - When enabled yaw has no effect on pitch/roll inputs      |
+| 6       | HEADADJ    | Heading Adjust - Sets a new yaw origin for HEADFREE mode             |
+| 7       | CAMSTAB    | Camera Stabilisation                                                 |
+| 8       | CAMTRIG    |                                                                      |
+| 9       | GPSHOME    | Autonomous flight to HOME position                                   |
+| 10      | GPSHOLD    | Maintain the same longitude/lattitude                                |
+| 11      | PASSTHRU   |                                                                      |
+| 12      | BEEPERON   | Enable beeping - useful for locating a crashed aircraft              |
+| 13      | LEDMAX     |                                                                      |
+| 14      | LEDLOW     |                                                                      |
+| 15      | LLIGHTS    |                                                                      |
+| 16      | CALIB      |                                                                      |
+| 17      | GOV        |                                                                      |
+| 18      | OSD        | Enable/Disable On-Screen-Display (OSD)                               |
+| 19      | TELEMETRY  | Enable telemetry via switch                                          |
+| 20      | AUTOTUNE   | Autotune Pitch/Roll PIDs                                             |
+| 21      | SONAR      | Altitude hold mode (sonar sensor only)                               |
 
 ## Mode details
 


### PR DESCRIPTION
Update numbering of boxes to match https://github.com/cleanflight/cleanflight/blob/master/src/main/io/rc_controls.h#L22
Alternately rc_controls.h should be updated to make it match the current documentation. The commented out BOXVARIO messes it up (maybe the old numbering matches MultiWii? I don't know as I never used MultiWii).