### PR TITLE
ALIENWII F3/F1 target cleanup and documentation update

### DIFF
--- a/docs/Board - AlienWii32.md
+++ b/docs/Board - AlienWii32.md
@@ -24,3 +24,9 @@ Here are the hardware specifications:
 Deltang receivers in serial mode will work like any other Spektrum satellite receiver (10bit, 22ms) only the bind process will be different. 
 
 The pin layout for the ALIENWIIF1 is very similar to NAZE32 or the related clones (MW32, Flip32, etc.). The hardware bind pin is connected to pin 41 (PB5). The pin layout for the ALIENWIIF3 is similar to Sparky. The hardware bind pin is connected to pin 25 (PB12). The AlienWii32 firmware will be built as target ALIENWIIF1 or ALIENWIIF3. The firmware image will come with alternative default settings which will give the user a plug and play experience. There is no computer needed to get this into the air with an small Quadcopter. An preconfigured custom mixer for an Octocopter is part of the default settings to allow clean straight wiring with the AlienWii32. The mixer can be activated with "mixer custom" in the CLI. To use the AlienWii32 in an Hexa- or Octocopter or to do some more tuning additional configuration changes can be done as usual in the CLI or the Cleanflight configurator. 
+
+## Flashing the firmware
+
+The AlienWii32 F1 board can be flashed like the Naze board or the related clones. All the different methods will work in the same way.
+
+The AlienWii32 F3 board needs to be flashed via the USB port in DFU mode. Flashing via the Cleanflight GUI is not possible yet. The DFU mode can be activated via setting the BOOT0 jumper during power on of the board. The second method is to connect with an terminal program (i.e. Putty) to the board and enter the character "R" immediately after connecting. Details about the flashing process can be found in the related section of the Sparky documentation. The BOOT0 jumper should be removed and the board needs to be repowerd after firmware flashing. Please be aware, during reboot of the AlienWii F3 board, the GUI will disconnect and an manual reconnect is required.

--- a/src/main/target/ALIENWIIF3/target.h
+++ b/src/main/target/ALIENWIIF3/target.h
@@ -28,7 +28,7 @@
 
 #define USABLE_TIMER_CHANNEL_COUNT 11
 
-// MPU 9150 INT connected to PA15, pulled up to VCC by 10K Resistor, contains MPU6050 and AK8975 in single component.
+// Using MPU6050 for the moment.
 #define GYRO
 #define USE_GYRO_MPU6050
 
@@ -39,11 +39,13 @@
 
 #define ACC_MPU6050_ALIGN CW270_DEG
 
+// No baro support.
 //#define BARO
 //#define USE_BARO_MS5611
 
-#define MAG
-#define USE_MAG_AK8975
+// No mag support for now (option to use MPU9150 in the future).
+//#define MAG
+//#define USE_MAG_AK8975
 
 #define MAG_AK8975_ALIGN CW0_DEG_FLIP
 
@@ -51,9 +53,9 @@
 #define LED1
 
 #define USE_VCP
-#define USE_USART1 // Conn 1 - TX (PB6) RX PB7 (AF7)
-#define USE_USART2 // Input - RX (PA3)
-#define USE_USART3 // Servo out - 10/RX (PB11) 11/TX (PB10)
+#define USE_USART1 // Not connected - TX (PB6) RX PB7 (AF7)
+#define USE_USART2 // Receiver - RX (PA3)
+#define USE_USART3 // Not connected - 10/RX (PB11) 11/TX (PB10)
 #define SERIAL_PORT_COUNT 4
 
 #define UART1_TX_PIN        GPIO_Pin_6 // PB6
@@ -63,14 +65,13 @@
 #define UART1_TX_PINSOURCE  GPIO_PinSource6
 #define UART1_RX_PINSOURCE  GPIO_PinSource7
 
-#define UART2_TX_PIN        GPIO_Pin_2 // PA2 - Clashes with PWM6 input.
+#define UART2_TX_PIN        GPIO_Pin_2 // PA2
 #define UART2_RX_PIN        GPIO_Pin_3 // PA3
 #define UART2_GPIO          GPIOA
 #define UART2_GPIO_AF       GPIO_AF_7
 #define UART2_TX_PINSOURCE  GPIO_PinSource2
 #define UART2_RX_PINSOURCE  GPIO_PinSource3
 
-// Note: PA5 and PA0 are N/C on the sparky - potentially use for ADC or LED STRIP?
 
 #define USE_I2C
 #define I2C_DEVICE (I2CDEV_2) // SDA (PA10/AF4), SCL (PA9/AF4)
@@ -89,53 +90,20 @@
 #define BLACKBOX
 #define SERIAL_RX
 #define GPS
-#define DISPLAY
-
-#define LED_STRIP
-#if 1
-// LED strip configuration using PWM motor output pin 5.
-#define LED_STRIP_TIMER TIM16
-
-#define USE_LED_STRIP_ON_DMA1_CHANNEL3
-#define WS2811_GPIO                     GPIOA
-#define WS2811_GPIO_AHB_PERIPHERAL      RCC_AHBPeriph_GPIOA
-#define WS2811_GPIO_AF                  GPIO_AF_1
-#define WS2811_PIN                      GPIO_Pin_6 // TIM16_CH1
-#define WS2811_PIN_SOURCE               GPIO_PinSource6
-#define WS2811_TIMER                    TIM16
-#define WS2811_TIMER_APB2_PERIPHERAL    RCC_APB2Periph_TIM16
-#define WS2811_DMA_CHANNEL              DMA1_Channel3
-#define WS2811_IRQ                      DMA1_Channel3_IRQn
-#endif
-
-#if 0
-// Alternate LED strip pin
-// FIXME DMA IRQ Transfer Complete is never called because the  TIM17_DMA_RMP needs to be set in SYSCFG_CFGR1
-#define LED_STRIP_TIMER TIM17
-
-#define USE_LED_STRIP_ON_DMA1_CHANNEL7
-#define WS2811_GPIO                     GPIOA
-#define WS2811_GPIO_AHB_PERIPHERAL      RCC_AHBPeriph_GPIOA
-#define WS2811_GPIO_AF                  GPIO_AF_1
-#define WS2811_PIN                      GPIO_Pin_7 // TIM17_CH1
-#define WS2811_PIN_SOURCE               GPIO_PinSource7
-#define WS2811_TIMER                    TIM17
-#define WS2811_TIMER_APB2_PERIPHERAL    RCC_APB2Periph_TIM17
-#define WS2811_DMA_CHANNEL              DMA1_Channel7
-#define WS2811_IRQ                      DMA1_Channel7_IRQn
-#endif
+//#define DISPLAY
+#define AUTOTUNE
 
 
 #define SPEKTRUM_BIND
 // USART2, PA3
-#define BIND_PORT GPIOA
-#define BIND_PIN Pin_3
+#define BIND_PORT  GPIOA
+#define BIND_PIN   Pin_3
+
+// alternative defaults for AlienWii32 F3 target
+#define ALIENWII32
+#define HARDWARE_BIND_PLUG
 
 // Hardware bind plug at PB12 (Pin 25)
 #define BINDPLUG_PORT  GPIOB
 #define BINDPLUG_PIN   Pin_12
 
-// alternative defaults for AlienWii32 F3 target
-#define ALIENWII32
-#define BRUSHED_MOTORS
-#define HARDWARE_BIND_PLUG

--- a/src/main/target/NAZE/target.h
+++ b/src/main/target/NAZE/target.h
@@ -154,8 +154,8 @@
 #ifdef ALIENWII32
 #undef TARGET_BOARD_IDENTIFIER
 #define TARGET_BOARD_IDENTIFIER "AWF1" // AlienWii32 F1.
-#define BRUSHED_MOTORS
 #define HARDWARE_BIND_PLUG
+
 // Hardware bind plug at PB5 (Pin 41)
 #define BINDPLUG_PORT  GPIOB
 #define BINDPLUG_PIN   Pin_5


### PR DESCRIPTION
Please can we also add the HEX for the ALIENWIIF3 target to the next release. Thanks.

BTW: here is an picture of an AlienWii32 F3 prototype:

http://www.multiwii.com/forum/viewtopic.php?f=12&t=4893&p=61295#p61295
