### PR TITLE
Fixed external barometer & magnetometer detection

### DIFF
--- a/src/main/sensors/initialisation.c
+++ b/src/main/sensors/initialisation.c
@@ -381,12 +381,14 @@ static void detectBaro()
 
 #ifdef USE_BARO_MS5611
     if (ms5611Detect(&baro)) {
+        sensorsSet(SENSOR_BARO);
         return;
     }
 #endif
 
 #ifdef USE_BARO_BMP085
     if (bmp085Detect(bmp085Config, &baro)) {
+        sensorsSet(SENSOR_BARO);
         return;
     }
 #endif
@@ -440,6 +442,7 @@ retry:
 #ifdef USE_MAG_HMC5883
         case MAG_HMC5883:
             if (hmc5883lDetect(&mag, hmc5883Config)) {
+                sensorsSet(SENSOR_MAG);
 #ifdef MAG_HMC5883_ALIGN
                 magAlign = MAG_HMC5883_ALIGN;
 #endif
@@ -454,7 +457,7 @@ retry:
 #ifdef USE_MAG_AK8975
         case MAG_AK8975:
             if (ak8975detect(&mag)) {
-
+                sensorsSet(SENSOR_MAG);
 #ifdef MAG_AK8975_ALIGN
                 magAlign = MAG_AK8975_ALIGN;
 #endif

--- a/src/main/sensors/initialisation.c
+++ b/src/main/sensors/initialisation.c
@@ -457,6 +457,7 @@ retry:
 #ifdef USE_MAG_AK8975
         case MAG_AK8975:
             if (ak8975detect(&mag)) {
+
                 sensorsSet(SENSOR_MAG);
 #ifdef MAG_AK8975_ALIGN
                 magAlign = MAG_AK8975_ALIGN;


### PR DESCRIPTION
Fixed an issue when external magnetometer & barometer are not detected and used by code. Reason - sensor initialisation code never sets SENSOR_BARO & SENSOR_MAG bits, even if hardware is correctly detected.