### PR TITLE
HoTT battery alarm

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -220,6 +220,7 @@ void resetTelemetryConfig(telemetryConfig_t *telemetryConfig)
     telemetryConfig->gpsNoFixLongitude = 0;
     telemetryConfig->frsky_coordinate_format = FRSKY_FORMAT_DMS;
     telemetryConfig->frsky_unit = FRSKY_UNIT_METRICS;
+    telemetryConfig->HottAlarmSoundPeriod = 5;
 }
 
 void resetBatteryConfig(batteryConfig_t *batteryConfig)

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -220,7 +220,7 @@ void resetTelemetryConfig(telemetryConfig_t *telemetryConfig)
     telemetryConfig->gpsNoFixLongitude = 0;
     telemetryConfig->frsky_coordinate_format = FRSKY_FORMAT_DMS;
     telemetryConfig->frsky_unit = FRSKY_UNIT_METRICS;
-    telemetryConfig->HottAlarmSoundPeriod = 5;
+    telemetryConfig->hottAlarmSoundInterval = 5;
 }
 
 void resetBatteryConfig(batteryConfig_t *batteryConfig)

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -317,6 +317,7 @@ const clivalue_t valueTable[] = {
     { "frsky_default_longitude",    VAR_FLOAT  | MASTER_VALUE,  &masterConfig.telemetryConfig.gpsNoFixLongitude, -180.0, 180.0 },
     { "frsky_coordinates_format",   VAR_UINT8  | MASTER_VALUE,  &masterConfig.telemetryConfig.frsky_coordinate_format, 0, FRSKY_FORMAT_NMEA },
     { "frsky_unit",                 VAR_UINT8  | MASTER_VALUE,  &masterConfig.telemetryConfig.frsky_unit, 0, FRSKY_UNIT_IMPERIALS },
+    { "Hott_alarm_sound_period",    VAR_UINT8  | MASTER_VALUE,  &masterConfig.telemetryConfig.HottAlarmSoundPeriod, 0, 120 },
 
     { "battery_capacity",           VAR_UINT16 | MASTER_VALUE,  &masterConfig.batteryConfig.batteryCapacity, 0, 20000 },
     { "vbat_scale",                 VAR_UINT8  | MASTER_VALUE,  &masterConfig.batteryConfig.vbatscale, VBAT_SCALE_MIN, VBAT_SCALE_MAX },

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -317,7 +317,7 @@ const clivalue_t valueTable[] = {
     { "frsky_default_longitude",    VAR_FLOAT  | MASTER_VALUE,  &masterConfig.telemetryConfig.gpsNoFixLongitude, -180.0, 180.0 },
     { "frsky_coordinates_format",   VAR_UINT8  | MASTER_VALUE,  &masterConfig.telemetryConfig.frsky_coordinate_format, 0, FRSKY_FORMAT_NMEA },
     { "frsky_unit",                 VAR_UINT8  | MASTER_VALUE,  &masterConfig.telemetryConfig.frsky_unit, 0, FRSKY_UNIT_IMPERIALS },
-    { "Hott_alarm_sound_period",    VAR_UINT8  | MASTER_VALUE,  &masterConfig.telemetryConfig.HottAlarmSoundPeriod, 0, 120 },
+    { "hott_alarm_sound_interval",    VAR_UINT8  | MASTER_VALUE,  &masterConfig.telemetryConfig.hottAlarmSoundInterval, 0, 120 },
 
     { "battery_capacity",           VAR_UINT16 | MASTER_VALUE,  &masterConfig.batteryConfig.batteryCapacity, 0, 20000 },
     { "vbat_scale",                 VAR_UINT8  | MASTER_VALUE,  &masterConfig.batteryConfig.vbatscale, VBAT_SCALE_MIN, VBAT_SCALE_MAX },

--- a/src/main/telemetry/hott.c
+++ b/src/main/telemetry/hott.c
@@ -213,7 +213,7 @@ void hottPrepareGPSResponse(HOTT_GPS_MSG_t *hottGPSMessage)
 
 static bool shouldTriggerVoiceAlarmNow(void)
 {
-	return ((millis() - lastHottAlarmSoundTime) >= (useHottAlarmSoundInterval() * MILLISECONDS_IN_A_SECOND));
+	return ((millis() - lastHottAlarmSoundTime) >= (telemetryConfig->hottAlarmSoundInterval * MILLISECONDS_IN_A_SECOND));
 }
 
 static inline void updateAlarmBatteryStatus(HOTT_EAM_MSG_t *hottEAMMessage)

--- a/src/main/telemetry/telemetry.c
+++ b/src/main/telemetry/telemetry.c
@@ -48,6 +48,11 @@ static bool telemetryPortIsShared;
 
 static telemetryConfig_t *telemetryConfig;
 
+
+uint8_t useHottAlarmSoundPeriod (void)
+{
+    return telemetryConfig->HottAlarmSoundPeriod;
+}
 void useTelemetryConfig(telemetryConfig_t *telemetryConfigToUse)
 {
     telemetryConfig = telemetryConfigToUse;

--- a/src/main/telemetry/telemetry.c
+++ b/src/main/telemetry/telemetry.c
@@ -49,9 +49,9 @@ static bool telemetryPortIsShared;
 static telemetryConfig_t *telemetryConfig;
 
 
-uint8_t useHottAlarmSoundPeriod (void)
+uint8_t useHottAlarmSoundInterval(void)
 {
-    return telemetryConfig->HottAlarmSoundPeriod;
+    return telemetryConfig->hottAlarmSoundInterval;
 }
 void useTelemetryConfig(telemetryConfig_t *telemetryConfigToUse)
 {

--- a/src/main/telemetry/telemetry.c
+++ b/src/main/telemetry/telemetry.c
@@ -48,11 +48,6 @@ static bool telemetryPortIsShared;
 
 static telemetryConfig_t *telemetryConfig;
 
-
-uint8_t useHottAlarmSoundInterval(void)
-{
-    return telemetryConfig->hottAlarmSoundInterval;
-}
 void useTelemetryConfig(telemetryConfig_t *telemetryConfigToUse)
 {
     telemetryConfig = telemetryConfigToUse;

--- a/src/main/telemetry/telemetry.h
+++ b/src/main/telemetry/telemetry.h
@@ -60,6 +60,5 @@ uint32_t getTelemetryProviderBaudRate(void);
 void useTelemetryConfig(telemetryConfig_t *telemetryConfig);
 bool telemetryAllowsOtherSerial(int serialPortFunction);
 bool isTelemetryPortShared(void);
-uint8_t useHottAlarmSoundInterval (void);
 
 #endif /* TELEMETRY_COMMON_H_ */

--- a/src/main/telemetry/telemetry.h
+++ b/src/main/telemetry/telemetry.h
@@ -50,7 +50,7 @@ typedef struct telemetryConfig_s {
     float gpsNoFixLongitude;  
     frskyGpsCoordFormat_e frsky_coordinate_format;   
     frskyUnit_e frsky_unit; 
-    uint8_t HottAlarmSoundPeriod;
+    uint8_t hottAlarmSoundInterval;
 } telemetryConfig_t;
 
 void checkTelemetryState(void);
@@ -60,6 +60,6 @@ uint32_t getTelemetryProviderBaudRate(void);
 void useTelemetryConfig(telemetryConfig_t *telemetryConfig);
 bool telemetryAllowsOtherSerial(int serialPortFunction);
 bool isTelemetryPortShared(void);
-uint8_t useHottAlarmSoundPeriod (void);
+uint8_t useHottAlarmSoundInterval (void);
 
 #endif /* TELEMETRY_COMMON_H_ */

--- a/src/main/telemetry/telemetry.h
+++ b/src/main/telemetry/telemetry.h
@@ -50,6 +50,7 @@ typedef struct telemetryConfig_s {
     float gpsNoFixLongitude;  
     frskyGpsCoordFormat_e frsky_coordinate_format;   
     frskyUnit_e frsky_unit; 
+    uint8_t HottAlarmSoundPeriod;
 } telemetryConfig_t;
 
 void checkTelemetryState(void);
@@ -59,5 +60,6 @@ uint32_t getTelemetryProviderBaudRate(void);
 void useTelemetryConfig(telemetryConfig_t *telemetryConfig);
 bool telemetryAllowsOtherSerial(int serialPortFunction);
 bool isTelemetryPortShared(void);
+uint8_t useHottAlarmSoundPeriod (void);
 
 #endif /* TELEMETRY_COMMON_H_ */

--- a/src/test/unit/telemetry_hott_unittest.cc
+++ b/src/test/unit/telemetry_hott_unittest.cc
@@ -152,6 +152,9 @@ int16_t debug[4];
 
 uint8_t stateFlags;
 
+uint16_t batteryWarningVoltage;
+uint8_t useHottAlarmSoundPeriod (void) { return 0; }
+
 
 uint8_t GPS_numSat;
 int32_t GPS_coord[2];


### PR DESCRIPTION
This alarm is for battery voltage in **EAM** Hott telemetry **binary** mode. 
It is triggered when the battery voltage becomes lower than the warning battery level.
The period of the alarm sound is set under CLI : parameter *Hott_alarm_sound_period* (default value is 5s) up to 120s.
On the Hott TX, the sound is either a beep, or a voice alarm ("under voltage") when using earphones. The *Batt1* value blinks accordingly on the TX display.