### PR TITLE
G-Tune implementation and Harakiri pid updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,6 +261,7 @@ COMMON_SRC	 = build_config.c \
 		   $(DEVICE_STDPERIPH_SRC)
 
 HIGHEND_SRC  = flight/autotune.c \
+		   flight/gtune.c \
 		   flight/navigation.c \
 		   flight/gps_conversion.c \
 		   common/colorconversion.c \

--- a/docs/Gtune.md
+++ b/docs/Gtune.md
@@ -19,7 +19,7 @@ The easiest way to tune all axes at once is to do some air-jumps with the copter
 You can set a too high P for the axes as default in the GUI, when the copter starts shaking the wobbles will be detected and P tuned down (be careful with the strength setting though - see below).
 Yaw tune is disabled in any copter with less than 4 motors (like tricopters).
 G-Tune in Horizon or Level mode will just affect Yaw axis (if more than 3 motors...)
-You will see the results in the GUI - the the tuning results will only be saved if you disable G-Tune mode while the copter is disarmed or you save the configuration in an alternative way (like hitting save button in the GUI, casting an eepromwrite with trimming, acc calibration etc.)
+You will see the results in the GUI - the tuning results will only be saved if you disable G-Tune mode while the copter is disarmed or you save the configuration in an alternative way (like hitting save button in the GUI, casting an eepromwrite with trimming, acc calibration etc.)
 TPA and G-Tune: It is not tested and will most likely not result into something good. However G-Tune might be able to replace TPA for you.
 
 ## Parameters and their function:

--- a/docs/Gtune.md
+++ b/docs/Gtune.md
@@ -1,0 +1,46 @@
+# G-Tune instructions.
+
+The algorithm has been originally developed by Mohammad Hefny (mohammad.hefny@gmail.com)
+http://technicaladventure.blogspot.com/2014/06/zero-pids-tuner-for-multirotors.html
+http://diydrones.com/profiles/blogs/zero-pid-tunes-for-multirotors-part-2
+http://www.multiwii.com/forum/viewtopic.php?f=8&t=5190
+
+The G-Tune functionality for Cleanflight is ported from the Harakiri firmware.
+
+- Safety preamble: Use at your own risk -
+
+The implementation you have here is quiet different and just for adjusting the P values of ROLL/PITCH/YAW in Acro mode.
+When flying in Acro mode (yaw tune in other modes possible as well - see below) you can activate G-Tune with an AUX box (switch).
+It will start tuning the wanted / possible axes (see below) in a predefined range (see below).
+After activation you will probably notice nothing! That means G-Tune will not start shaking your copter, you will have to do it (or simply fly and let it work).
+The G-Tune is based on the gyro error so it is only active when you give no RC input (that would be an additional error). So if you just roll only pitch
+and yaw are tuned. If you stop rolling G-Tune will wait ca. 400ms to let the axis settle and then start tuning that axis again. All axes are treated independently.
+The easiest way to tune all axes at once is to do some air-jumps with the copter in Acro (RC centered and G-Tune activated... of course..).
+You can set a too high P for the axes as default in the GUI, when the copter starts shaking the wobbles will be detected and P tuned down (be careful with the strength setting though - see below).
+Yaw tune is disabled in any copter with less than 4 motors (like tricopters).
+G-Tune in Horizon or Level mode will just affect Yaw axis (if more than 3 motors...)
+You will see the results in the GUI - the the tuning results will only be saved if you disable G-Tune mode while the copter is disarmed or you save the configuration in an alternative way (like hitting save button in the GUI, casting an eepromwrite with trimming, acc calibration etc.)
+TPA and G-Tune: It is not tested and will most likely not result into something good. However G-Tune might be able to replace TPA for you.
+
+## Parameters and their function:
+
+gtune_loP_rll  = 20 [10..200] Lower limit of ROLL P during G-Tune.  Note "20" means "2.0" in the GUI.
+gtune_loP_ptch = 20 [10..200] Lower limit of PITCH P during G-Tune. Note "20" means "2.0" in the GUI.
+gtune_loP_yw   = 20 [10..200] Lower limit of YAW P during G-Tune.   Note "20" means "2.0" in the GUI.
+gtune_hiP_rll  = 70 [0..200]  Higher limit of ROLL P during G-Tune. 0 Disables tuning for that axis.  Note "70" means "7.0" in the GUI.
+gtune_hiP_ptch = 70 [0..200]  Higher limit of PITCH P during G-Tune. 0 Disables tuning for that axis. Note "70" means "7.0" in the GUI.
+gtune_hiP_yw   = 70 [0..200]  Higher limit of YAW P during G-Tune. 0 Disables tuning for that axis.   Note "70" means "7.0" in the GUI.
+gtune_pwr      = 0  [0..10]   Strength of adjustment
+
+So you have lower and higher limits for each P for every axis. The preset range (GUI: 2.0 - 7.0) is quiet broad to represent most setups.
+If you want tighter ranges change them here. The gtune_loP_XXX can not be lower than "10" that means a P of "1.0" in the GUI. So you can not have "Zero P",
+you are in maybe sluggish initial control.
+If you want to exclude one axis from the tuning you must set gtune_hiP_XXX to zero. Let's say you want to disable yaw tuning write in CLI
+"set gtune_hiP_yw = 0". Note: The MultiWii Wiki advises you to trim the yaw axis on your transmitter. If you have done so (yaw not neutral on your RC)
+yaw tuning will be disabled.
+
+Setting the strength of tuning:
+gtune_pwr [0..10] Strength of adjustment.
+My small copter works fine with 0 and doesn't like a value of "3". My big copter likes "gtune_pwr = 5". It shifts the tuning to higher values and if too high can
+diminish the wobble blocking! So start with 0 (default). If you feel your resulting P is always too low for you increase gtune_pwr. You will see it getting a little shaky
+if value too high.

--- a/docs/Gtune.md
+++ b/docs/Gtune.md
@@ -24,13 +24,13 @@ TPA and G-Tune: It is not tested and will most likely not result into something 
 
 ## Parameters and their function:
 
-gtune_loP_rll  = 20 [10..200] Lower limit of ROLL P during G-Tune.  Note "20" means "2.0" in the GUI.
-gtune_loP_ptch = 20 [10..200] Lower limit of PITCH P during G-Tune. Note "20" means "2.0" in the GUI.
-gtune_loP_yw   = 20 [10..200] Lower limit of YAW P during G-Tune.   Note "20" means "2.0" in the GUI.
-gtune_hiP_rll  = 70 [0..200]  Higher limit of ROLL P during G-Tune. 0 Disables tuning for that axis.  Note "70" means "7.0" in the GUI.
-gtune_hiP_ptch = 70 [0..200]  Higher limit of PITCH P during G-Tune. 0 Disables tuning for that axis. Note "70" means "7.0" in the GUI.
-gtune_hiP_yw   = 70 [0..200]  Higher limit of YAW P during G-Tune. 0 Disables tuning for that axis.   Note "70" means "7.0" in the GUI.
-gtune_pwr      = 0  [0..10]   Strength of adjustment
+    gtune_loP_rll  = 20 [10..200] Lower limit of ROLL P during G-Tune.  Note "20" means "2.0" in the GUI.
+    gtune_loP_ptch = 20 [10..200] Lower limit of PITCH P during G-Tune. Note "20" means "2.0" in the GUI.
+    gtune_loP_yw   = 20 [10..200] Lower limit of YAW P during G-Tune.   Note "20" means "2.0" in the GUI.
+    gtune_hiP_rll  = 70 [0..200]  Higher limit of ROLL P during G-Tune. 0 Disables tuning for that axis.  Note "70" means "7.0" in the GUI.
+    gtune_hiP_ptch = 70 [0..200]  Higher limit of PITCH P during G-Tune. 0 Disables tuning for that axis. Note "70" means "7.0" in the GUI.
+    gtune_hiP_yw   = 70 [0..200]  Higher limit of YAW P during G-Tune. 0 Disables tuning for that axis.   Note "70" means "7.0" in the GUI.
+    gtune_pwr      = 0  [0..10]   Strength of adjustment
 
 So you have lower and higher limits for each P for every axis. The preset range (GUI: 2.0 - 7.0) is quiet broad to represent most setups.
 If you want tighter ranges change them here. The gtune_loP_XXX can not be lower than "10" that means a P of "1.0" in the GUI. So you can not have "Zero P",

--- a/docs/Gtune.md
+++ b/docs/Gtune.md
@@ -14,7 +14,7 @@ When flying in Acro mode (yaw tune in other modes possible as well - see below) 
 It will start tuning the wanted / possible axes (see below) in a predefined range (see below).
 After activation you will probably notice nothing! That means G-Tune will not start shaking your copter, you will have to do it (or simply fly and let it work).
 The G-Tune is based on the gyro error so it is only active when you give no RC input (that would be an additional error). So if you just roll only pitch
-and yaw are tuned. If you stop rolling G-Tune will wait ca. 400ms to let the axis settle and then start tuning that axis again. All axes are treated independently.
+and yaw are tuned. If you stop rolling G-Tune will wait ca. 450ms to let the axis settle and then start tuning that axis again. All axes are treated independently.
 The easiest way to tune all axes at once is to do some air-jumps with the copter in Acro (RC centered and G-Tune activated... of course..).
 You can set a too high P for the axes as default in the GUI, when the copter starts shaking the wobbles will be detected and P tuned down (be careful with the strength setting though - see below).
 Yaw tune is disabled in any copter with less than 4 motors (like tricopters).
@@ -24,17 +24,18 @@ TPA and G-Tune: It is not tested and will most likely not result into something 
 
 ## Parameters and their function:
 
-    gtune_loP_rll  = 20 [10..200] Lower limit of ROLL P during G-Tune.  Note "20" means "2.0" in the GUI.
-    gtune_loP_ptch = 20 [10..200] Lower limit of PITCH P during G-Tune. Note "20" means "2.0" in the GUI.
-    gtune_loP_yw   = 20 [10..200] Lower limit of YAW P during G-Tune.   Note "20" means "2.0" in the GUI.
-    gtune_hiP_rll  = 70 [0..200]  Higher limit of ROLL P during G-Tune. 0 Disables tuning for that axis.  Note "70" means "7.0" in the GUI.
-    gtune_hiP_ptch = 70 [0..200]  Higher limit of PITCH P during G-Tune. 0 Disables tuning for that axis. Note "70" means "7.0" in the GUI.
-    gtune_hiP_yw   = 70 [0..200]  Higher limit of YAW P during G-Tune. 0 Disables tuning for that axis.   Note "70" means "7.0" in the GUI.
-    gtune_pwr      = 0  [0..10]   Strength of adjustment
+    gtune_loP_rll        = 10  [0..200] Lower limit of ROLL P during G-Tune.  Note "10" means "1.0" in the GUI.
+    gtune_loP_ptch       = 10  [0..200] Lower limit of PITCH P during G-Tune. Note "10" means "1.0" in the GUI.
+    gtune_loP_yw         = 10  [0..200] Lower limit of YAW P during G-Tune.   Note "10" means "1.0" in the GUI.
+    gtune_hiP_rll        = 100 [0..200] Higher limit of ROLL P during G-Tune. 0 Disables tuning for that axis.  Note "100" means "10.0" in the GUI.
+    gtune_hiP_ptch       = 100 [0..200] Higher limit of PITCH P during G-Tune. 0 Disables tuning for that axis. Note "100" means "10.0" in the GUI.
+    gtune_hiP_yw         = 100 [0..200] Higher limit of YAW P during G-Tune. 0 Disables tuning for that axis.   Note "100" means "10.0" in the GUI.
+    gtune_pwr            = 0   [0..10] Strength of adjustment
+    gtune_settle_time    = 450 [200..1000] Settle time in ms
+    gtune_average_cycles = 16  [8..128] Number of looptime cycles used for gyro average calcullation
 
-So you have lower and higher limits for each P for every axis. The preset range (GUI: 2.0 - 7.0) is quiet broad to represent most setups.
-If you want tighter ranges change them here. The gtune_loP_XXX can not be lower than "10" that means a P of "1.0" in the GUI. So you can not have "Zero P",
-you are in maybe sluggish initial control.
+So you have lower and higher limits for each P for every axis. The preset range (GUI: 1.0 - 10.0) is quiet broad to represent most setups.
+If you want tighter or more loose ranges change them here. gtune_loP_XXX can be configured lower than "10" that means a P of "1.0" in the GUI. So you can have "Zero P" but you may get sluggish initial control.
 If you want to exclude one axis from the tuning you must set gtune_hiP_XXX to zero. Let's say you want to disable yaw tuning write in CLI
 "set gtune_hiP_yw = 0". Note: The MultiWii Wiki advises you to trim the yaw axis on your transmitter. If you have done so (yaw not neutral on your RC)
 yaw tuning will be disabled.

--- a/docs/Gtune.md
+++ b/docs/Gtune.md
@@ -10,7 +10,7 @@ The G-Tune functionality for Cleanflight is ported from the Harakiri firmware.
 - Safety preamble: Use at your own risk -
 
 The implementation you have here is quiet different and just for adjusting the P values of ROLL/PITCH/YAW in Acro mode.
-When flying in Acro mode (yaw tune in other modes possible as well - see below) you can activate G-Tune with an AUX box (switch).
+When flying in Acro mode (yaw tune in other modes possible as well - see below) you can activate G-Tune with an AUX box (switch) while the copter is armed.
 It will start tuning the wanted / possible axes (see below) in a predefined range (see below).
 After activation you will probably notice nothing! That means G-Tune will not start shaking your copter, you will have to do it (or simply fly and let it work).
 The G-Tune is based on the gyro error so it is only active when you give no RC input (that would be an additional error). So if you just roll only pitch
@@ -19,7 +19,7 @@ The easiest way to tune all axes at once is to do some air-jumps with the copter
 You can set a too high P for the axes as default in the GUI, when the copter starts shaking the wobbles will be detected and P tuned down (be careful with the strength setting though - see below).
 Yaw tune is disabled in any copter with less than 4 motors (like tricopters).
 G-Tune in Horizon or Level mode will just affect Yaw axis (if more than 3 motors...)
-You will see the results in the GUI - the tuning results will only be saved if you disable G-Tune mode while the copter is disarmed or you save the configuration in an alternative way (like hitting save button in the GUI, casting an eepromwrite with trimming, acc calibration etc.)
+You will see the results in the GUI - the tuning results will only be saved if you enable G-Tune mode while the copter is disarmed and G-Tune was used before when armed. You also can save the configuration in an alternative way (like hitting save button in the GUI, casting an eepromwrite with trimming, acc calibration etc.)
 TPA and G-Tune: It is not tested and will most likely not result into something good. However G-Tune might be able to replace TPA for you.
 
 ## Parameters and their function:

--- a/docs/Modes.md
+++ b/docs/Modes.md
@@ -28,6 +28,7 @@ auxillary receiver channels and other events such as failsafe detection.
 | 21      | 20     | AUTOTUNE   | Autotune Pitch/Roll PIDs                                             |
 | 22      | 21     | SONAR      | Altitude hold mode (sonar sensor only)                               |
 | 26      | 25     | BLACKBOX   | Enable BlackBox logging                                              |
+| 27      | 26     | GTUNE      | G-Tune - auto tuning of Pitch/Roll/Yaw P values                      |
 
 ## Mode details
 

--- a/docs/PID tuning.md
+++ b/docs/PID tuning.md
@@ -150,10 +150,10 @@ For the ALIENWII32 targets the gyroscale is removed for more yaw authority. This
 
 PID Controller 5 is an port of the PID controller from the Harakiri firmware.
 
-The algorithm is leveraging more floating point math. This PID controller also compensates for different looptimes on roll and pitch. It likely don't need retuning of the PID values when looptime is changing. Actually there are two settings hardcoded which are configurable via the GUI in Harakiri:
+The algorithm is leveraging more floating point math. This PID controller also compensates for different looptimes on roll and pitch. It likely don't need retuning of the PID values when looptime is changing. There are two additional settings which are configurable via the CLI in Harakiri:
 
-        OLD_YAW 0 // [0/1] 0 = multiwii 2.3 yaw, 1 = older yaw.
-        MAIN_CUT_HZ 12.0f // (default 12Hz, Range 1-50Hz)
+        set pid5_maincuthz = 12     [1-50Hz] Cut Off Frequency for D term of main Pid controller
+        set pid5_oldyw = 0          [0/1] 0 = multiwii 2.3 yaw (default), 1 = older yaw
 
 The PID controller is flight tested and running well with the default PID settings. If you want do acrobatics start slowly.
 

--- a/docs/PID tuning.md
+++ b/docs/PID tuning.md
@@ -152,7 +152,8 @@ PID Controller 5 is an port of the PID controller from the Harakiri firmware.
 
 The algorithm is leveraging more floating point math. This PID controller also compensates for different looptimes on roll and pitch. It likely don't need retuning of the PID values when looptime is changing. There are two additional settings which are configurable via the CLI in Harakiri:
 
-        set pid5_maincuthz = 12     [1-50Hz] Cut Off Frequency for D term of main Pid controller
+        set dterm_cut_hz = 0        [1-50Hz] Cut Off Frequency for D term of main PID controller
+                                    (default of 0 equals to 12Hz which was the hardcoded setting in previous Cleanflight versions)
         set pid5_oldyw = 0          [0/1] 0 = multiwii 2.3 yaw (default), 1 = older yaw
 
 The PID controller is flight tested and running well with the default PID settings. If you want do acrobatics start slowly.

--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1162,6 +1162,10 @@ void blackboxLogEvent(FlightLogEvent event, flightLogEventData_t *data)
                 blackboxWrite(data->inflightAdjustment.adjustmentFunction);
                 blackboxWriteSignedVB(data->inflightAdjustment.newValue);
             }
+        case FLIGHT_LOG_EVENT_GTUNE_RESULT:
+            blackboxWrite(data->gtuneCycleResult.gtuneAxis);
+            blackboxWrite(data->gtuneCycleResult.gtuneGyroAVG);
+            blackboxWrite(data->gtuneCycleResult.gtuneNewP);
         break;
         case FLIGHT_LOG_EVENT_LOGGING_RESUME:
             blackboxWriteUnsignedVB(data->loggingResume.logIteration);

--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1164,8 +1164,8 @@ void blackboxLogEvent(FlightLogEvent event, flightLogEventData_t *data)
             }
         case FLIGHT_LOG_EVENT_GTUNE_RESULT:
             blackboxWrite(data->gtuneCycleResult.gtuneAxis);
-            blackboxWrite(data->gtuneCycleResult.gtuneGyroAVG);
-            blackboxWrite(data->gtuneCycleResult.gtuneNewP);
+            blackboxWriteSignedVB(data->gtuneCycleResult.gtuneGyroAVG);
+            blackboxWriteS16(data->gtuneCycleResult.gtuneNewP);
         break;
         case FLIGHT_LOG_EVENT_LOGGING_RESUME:
             blackboxWriteUnsignedVB(data->loggingResume.logIteration);

--- a/src/main/blackbox/blackbox_fielddefs.h
+++ b/src/main/blackbox/blackbox_fielddefs.h
@@ -149,18 +149,16 @@ typedef struct flightLogEvent_inflightAdjustment_t {
     float newFloatValue;
 } flightLogEvent_inflightAdjustment_t;
 
-<<<<<<< Upstream, based on origin/master
 typedef struct flightLogEvent_loggingResume_t {
     uint32_t logIteration;
     uint32_t currentTime;
 } flightLogEvent_loggingResume_t;
-=======
+
 typedef struct flightLogEvent_gtuneCycleResult_t {
     uint8_t gtuneAxis;
     int32_t gtuneGyroAVG;
     int16_t gtuneNewP;
 } flightLogEvent_gtuneCycleResult_t;
->>>>>>> 6f60c52 Add BlackBox recording for G-Tune
 
 typedef union flightLogEventData_t
 {
@@ -169,11 +167,8 @@ typedef union flightLogEventData_t
     flightLogEvent_autotuneCycleResult_t autotuneCycleResult;
     flightLogEvent_autotuneTargets_t autotuneTargets;
     flightLogEvent_inflightAdjustment_t inflightAdjustment;
-<<<<<<< Upstream, based on origin/master
     flightLogEvent_loggingResume_t loggingResume;
-=======
     flightLogEvent_gtuneCycleResult_t gtuneCycleResult;
->>>>>>> 6f60c52 Add BlackBox recording for G-Tune
 } flightLogEventData_t;
 
 typedef struct flightLogEvent_t

--- a/src/main/blackbox/blackbox_fielddefs.h
+++ b/src/main/blackbox/blackbox_fielddefs.h
@@ -157,8 +157,8 @@ typedef struct flightLogEvent_loggingResume_t {
 =======
 typedef struct flightLogEvent_gtuneCycleResult_t {
     uint8_t gtuneAxis;
-    uint32_t gtuneGyroAVG;
-    uint8_t gtuneNewP;
+    int32_t gtuneGyroAVG;
+    int16_t gtuneNewP;
 } flightLogEvent_gtuneCycleResult_t;
 >>>>>>> 6f60c52 Add BlackBox recording for G-Tune
 

--- a/src/main/blackbox/blackbox_fielddefs.h
+++ b/src/main/blackbox/blackbox_fielddefs.h
@@ -108,6 +108,7 @@ typedef enum FlightLogEvent {
     FLIGHT_LOG_EVENT_AUTOTUNE_TARGETS = 12,
     FLIGHT_LOG_EVENT_INFLIGHT_ADJUSTMENT = 13,
     FLIGHT_LOG_EVENT_LOGGING_RESUME = 14,
+    FLIGHT_LOG_EVENT_GTUNE_RESULT = 20,
     FLIGHT_LOG_EVENT_LOG_END = 255
 } FlightLogEvent;
 
@@ -148,10 +149,18 @@ typedef struct flightLogEvent_inflightAdjustment_t {
     float newFloatValue;
 } flightLogEvent_inflightAdjustment_t;
 
+<<<<<<< Upstream, based on origin/master
 typedef struct flightLogEvent_loggingResume_t {
     uint32_t logIteration;
     uint32_t currentTime;
 } flightLogEvent_loggingResume_t;
+=======
+typedef struct flightLogEvent_gtuneCycleResult_t {
+    uint8_t gtuneAxis;
+    uint32_t gtuneGyroAVG;
+    uint8_t gtuneNewP;
+} flightLogEvent_gtuneCycleResult_t;
+>>>>>>> 6f60c52 Add BlackBox recording for G-Tune
 
 typedef union flightLogEventData_t
 {
@@ -160,7 +169,11 @@ typedef union flightLogEventData_t
     flightLogEvent_autotuneCycleResult_t autotuneCycleResult;
     flightLogEvent_autotuneTargets_t autotuneTargets;
     flightLogEvent_inflightAdjustment_t inflightAdjustment;
+<<<<<<< Upstream, based on origin/master
     flightLogEvent_loggingResume_t loggingResume;
+=======
+    flightLogEvent_gtuneCycleResult_t gtuneCycleResult;
+>>>>>>> 6f60c52 Add BlackBox recording for G-Tune
 } flightLogEventData_t;
 
 typedef struct flightLogEvent_t

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -192,13 +192,15 @@ static void resetPidProfile(pidProfile_t *pidProfile)
     pidProfile->pid5_maincuthz = 12;
 
 #ifdef GTUNE
-    pidProfile->gtune_lolimP[ROLL] = 20;          // [10..200] Lower limit of ROLL P during G tune.
-    pidProfile->gtune_lolimP[PITCH] = 20;         // [10..200] Lower limit of PITCH P during G tune.
-    pidProfile->gtune_lolimP[YAW] = 20;           // [10..200] Lower limit of YAW P during G tune.
-    pidProfile->gtune_hilimP[ROLL] = 70;          // [0..200] Higher limit of ROLL P during G tune. 0 Disables tuning for that axis.
-    pidProfile->gtune_hilimP[PITCH] = 70;         // [0..200] Higher limit of PITCH P during G tune. 0 Disables tuning for that axis.
-    pidProfile->gtune_hilimP[YAW] = 70;           // [0..200] Higher limit of YAW P during G tune. 0 Disables tuning for that axis.
+    pidProfile->gtune_lolimP[ROLL] = 10;          // [0..200] Lower limit of ROLL P during G tune.
+    pidProfile->gtune_lolimP[PITCH] = 10;         // [0..200] Lower limit of PITCH P during G tune.
+    pidProfile->gtune_lolimP[YAW] = 10;           // [0..200] Lower limit of YAW P during G tune.
+    pidProfile->gtune_hilimP[ROLL] = 100;         // [0..200] Higher limit of ROLL P during G tune. 0 Disables tuning for that axis.
+    pidProfile->gtune_hilimP[PITCH] = 100;        // [0..200] Higher limit of PITCH P during G tune. 0 Disables tuning for that axis.
+    pidProfile->gtune_hilimP[YAW] = 100;          // [0..200] Higher limit of YAW P during G tune. 0 Disables tuning for that axis.
     pidProfile->gtune_pwr = 0;                    // [0..10] Strength of adjustment
+    pidProfile->gtune_settle_time = 450;          // [200..1000] Settle time in ms
+    pidProfile->gtune_average_cycles = 16;        // [8..128] Number of looptime cycles used for gyro average calculation
 #endif
 }
 

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -187,6 +187,9 @@ static void resetPidProfile(pidProfile_t *pidProfile)
     pidProfile->A_level = 5.0f;
     pidProfile->H_level = 3.0f;
     pidProfile->H_sensitivity = 75;
+
+    pidProfile->pid5_oldyw = 0;
+    pidProfile->pid5_maincuthz = 12;
 }
 
 #ifdef GPS

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -189,7 +189,6 @@ static void resetPidProfile(pidProfile_t *pidProfile)
     pidProfile->H_sensitivity = 75;
 
     pidProfile->pid5_oldyw = 0;
-    pidProfile->pid5_maincuthz = 12;
 
 #ifdef GTUNE
     pidProfile->gtune_lolimP[ROLL] = 10;          // [0..200] Lower limit of ROLL P during G tune.

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -190,6 +190,16 @@ static void resetPidProfile(pidProfile_t *pidProfile)
 
     pidProfile->pid5_oldyw = 0;
     pidProfile->pid5_maincuthz = 12;
+
+#ifdef GTUNE
+    pidProfile->gtune_lolimP[ROLL] = 20;          // [10..200] Lower limit of ROLL P during G tune.
+    pidProfile->gtune_lolimP[PITCH] = 20;         // [10..200] Lower limit of PITCH P during G tune.
+    pidProfile->gtune_lolimP[YAW] = 20;           // [10..200] Lower limit of YAW P during G tune.
+    pidProfile->gtune_hilimP[ROLL] = 70;          // [0..200] Higher limit of ROLL P during G tune. 0 Disables tuning for that axis.
+    pidProfile->gtune_hilimP[PITCH] = 70;         // [0..200] Higher limit of PITCH P during G tune. 0 Disables tuning for that axis.
+    pidProfile->gtune_hilimP[YAW] = 70;           // [0..200] Higher limit of YAW P during G tune. 0 Disables tuning for that axis.
+    pidProfile->gtune_pwr = 0;                    // [0..10] Strength of adjustment
+#endif
 }
 
 #ifdef GPS

--- a/src/main/config/runtime_config.h
+++ b/src/main/config/runtime_config.h
@@ -42,6 +42,7 @@ typedef enum {
     PASSTHRU_MODE   = (1 << 8),
     SONAR_MODE      = (1 << 9),
     FAILSAFE_MODE   = (1 << 10),
+    GTUNE_MODE      = (1 << 11),
 } flightModeFlags_e;
 
 extern uint16_t flightModeFlags;

--- a/src/main/flight/gtune.c
+++ b/src/main/flight/gtune.c
@@ -155,7 +155,7 @@ void calculate_Gtune(uint8_t axis)
 
 #ifdef BLACKBOX
                 if (feature(FEATURE_BLACKBOX)) {
-                	flightLogEvent_gtuneCycleResult_t eventData;
+                    flightLogEvent_gtuneCycleResult_t eventData;
 
                     eventData.gtuneAxis = axis;
                     eventData.gtuneGyroAVG = AvgGyro[axis];

--- a/src/main/flight/gtune.c
+++ b/src/main/flight/gtune.c
@@ -159,7 +159,8 @@ void calculate_Gtune(uint8_t axis)
 
                     eventData.gtuneAxis = axis;
                     eventData.gtuneGyroAVG = AvgGyro[axis];
-                    eventData.gtuneNewP = newP;
+                    if (floatPID) eventData.gtuneNewP = newP / 10;
+                    else eventData.gtuneNewP = newP;
 
                     blackboxLogEvent(FLIGHT_LOG_EVENT_GTUNE_RESULT, (flightLogEventData_t*)&eventData);
                 }

--- a/src/main/flight/gtune.c
+++ b/src/main/flight/gtune.c
@@ -103,7 +103,7 @@ void init_Gtune(pidProfile_t *pidProfileToTune)
         if ((pidProfile->gtune_hilimP[i] && pidProfile->gtune_lolimP[i] > pidProfile->gtune_hilimP[i]) || // User config error disable axisis for tuning
             (motorCount < 4 && i == FD_YAW)) pidProfile->gtune_hilimP[i] = 0;   // Disable Yawtuning for everything below a quadcopter
         if (floatPID) {
-            if(pidProfile->P_f[i] < pidProfile->gtune_lolimP[i]) pidProfile->P_f[i] = pidProfile->gtune_lolimP[i];
+            if((pidProfile->P_f[i] * 10) < pidProfile->gtune_lolimP[i]) pidProfile->P_f[i] = (float)(pidProfile->gtune_lolimP[i] / 10);
             result_P64[i] = (int16_t)pidProfile->P_f[i] << 6;                   // 6 bit extra resolution for P.
         } else {
             if(pidProfile->P8[i] < pidProfile->gtune_lolimP[i]) pidProfile->P8[i] = pidProfile->gtune_lolimP[i];
@@ -152,7 +152,7 @@ void calculate_Gtune(uint8_t axis)
                     if (ABS(diff_G) > threshP && axis != FD_YAW) result_P64[axis] -= 32; // Don't use antiwobble for YAW
                 }
                 result_P64[axis] = constrain(result_P64[axis], (int16_t)pidProfile->gtune_lolimP[axis] << 6, (int16_t)pidProfile->gtune_hilimP[axis] << 6);
-                if (floatPID) pidProfile->P_f[axis] = (float)(result_P64[axis] >> 6); // new P value for float PID
+                if (floatPID) pidProfile->P_f[axis] = (float)((result_P64[axis] >> 6) / 10); // new P value for float PID
                 else pidProfile->P8[axis] = result_P64[axis] >> 6;              // new P value
             }
             OldError[axis] = error;

--- a/src/main/flight/gtune.c
+++ b/src/main/flight/gtune.c
@@ -32,6 +32,7 @@
 #include "drivers/accgyro.h"
 
 #include "sensors/sensors.h"
+#include "sensors/gyro.h"
 #include "sensors/acceleration.h"
 
 #include "flight/pid.h"
@@ -144,9 +145,9 @@ void calculate_Gtune(uint8_t axis)
         time_skip[axis]++;
         if (time_skip[axis] > 0) {
             if (axis == FD_YAW) {
-                AvgGyro[axis] += 32 * ((int16_t)gyroData[axis] / 32);           // Chop some jitter and average
+                AvgGyro[axis] += 32 * ((int16_t)gyroADC[axis] / 32);           // Chop some jitter and average
             } else {
-                AvgGyro[axis] += 128 * ((int16_t)gyroData[axis] / 128);         // Chop some jitter and average
+                AvgGyro[axis] += 128 * ((int16_t)gyroADC[axis] / 128);         // Chop some jitter and average
             }
         }
         if (time_skip[axis] == pidProfile->gtune_average_cycles) {              // Looptime cycles for gyro average calculation. default 16.

--- a/src/main/flight/gtune.c
+++ b/src/main/flight/gtune.c
@@ -1,0 +1,164 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+
+#include "platform.h"
+
+#ifdef GTUNE
+
+#include "common/axis.h"
+#include "common/maths.h"
+
+#include "drivers/system.h"
+#include "drivers/sensor.h"
+#include "drivers/accgyro.h"
+
+#include "sensors/sensors.h"
+#include "sensors/acceleration.h"
+
+#include "flight/pid.h"
+#include "flight/imu.h"
+
+#include "config/config.h"
+#include "blackbox/blackbox.h"
+
+#include "io/rc_controls.h"
+
+#include "config/runtime_config.h"
+
+extern uint8_t motorCount;
+
+/*
+ ****************************************************************************
+ ***                    G_Tune                                            ***
+ ****************************************************************************
+	G_Tune Mode
+	This is the multiwii implementation of ZERO-PID Algorithm
+	http://technicaladventure.blogspot.com/2014/06/zero-pids-tuner-for-multirotors.html
+	The algorithm has been originally developed by Mohammad Hefny (mohammad.hefny@gmail.com)
+
+	You may use/modify this algorithm on your own risk, kindly refer to above link in any future distribution.
+ */
+
+/*
+   version 1.0.0: MIN & Maxis & Tuned Band
+   version 1.0.1:
+                a. error is gyro reading not rc - gyro.
+                b. OldError = Error no averaging.
+                c. No Min Maxis BOUNDRY
+    version 1.0.2:
+                a. no boundaries
+                b. I - Factor tune.
+                c. time_skip
+
+   Crashpilot: Reduced to just P tuning in a predefined range - so it is not "zero pid" anymore.
+   Tuning is limited to just work when stick is centered besides that YAW is tuned in non Acro as well.
+   See also:
+   http://diydrones.com/profiles/blogs/zero-pid-tunes-for-multirotors-part-2
+   http://www.multiwii.com/forum/viewtopic.php?f=8&t=5190
+   Gyrosetting 2000DPS
+   GyroScale = (1 / 16,4 ) * RADX(see board.h) = 0,001064225154 digit per rad/s
+
+    pidProfile->gtune_lolimP[ROLL]   = 20; [10..200] Lower limit of ROLL P during G tune.
+    pidProfile->gtune_lolimP[PITCH]  = 20; [10..200] Lower limit of PITCH P during G tune.
+    pidProfile->gtune_lolimP[YAW]    = 20; [10..200] Lower limit of YAW P during G tune.
+    pidProfile->gtune_hilimP[ROLL]   = 70; [0..200]  Higher limit of ROLL P during G tune. 0 Disables tuning for that axisis.
+    pidProfile->gtune_hilimP[PITCH]  = 70; [0..200]  Higher limit of PITCH P during G tune. 0 Disables tuning for that axisis.
+    pidProfile->gtune_hilimP[YAW]    = 70; [0..200]  Higher limit of YAW P during G tune. 0 Disables tuning for that axisis.
+    pidProfile->gtune_pwr            = 0;  [0..10] Strength of adjustment
+*/
+
+static pidProfile_t *pidProfile;
+static int8_t time_skip[3];
+static int16_t OldError[3], result_P64[3];
+static int32_t AvgGyro[3];
+static bool floatPID;
+
+void init_Gtune(pidProfile_t *pidProfileToTune)
+{
+    uint8_t i;
+
+    pidProfile = pidProfileToTune;
+	if (pidProfile->pidController == 2) floatPID = true;                        // LuxFloat is using float values for PID settings
+	else floatPID = false;
+	for (i = 0; i < 3; i++) {
+        if ((pidProfile->gtune_hilimP[i] && pidProfile->gtune_lolimP[i] > pidProfile->gtune_hilimP[i]) || // User config error disable axisis for tuning
+            (motorCount < 4 && i == FD_YAW)) pidProfile->gtune_hilimP[i] = 0;   // Disable Yawtuning for everything below a quadcopter
+        if (floatPID) {
+            if(pidProfile->P_f[i] < pidProfile->gtune_lolimP[i]) pidProfile->P_f[i] = pidProfile->gtune_lolimP[i];
+            result_P64[i] = (int16_t)pidProfile->P_f[i] << 6;                   // 6 bit extra resolution for P.
+        } else {
+            if(pidProfile->P8[i] < pidProfile->gtune_lolimP[i]) pidProfile->P8[i] = pidProfile->gtune_lolimP[i];
+            result_P64[i] = (int16_t)pidProfile->P8[i] << 6;                    // 6 bit extra resolution for P.
+        }
+        OldError[i] = 0;
+        time_skip[i] = -125;
+    }
+}
+
+void calculate_Gtune(uint8_t axis)
+{
+    int16_t error, diff_G, threshP;
+
+    if(rcCommand[axis] || (axis != FD_YAW && (FLIGHT_MODE(ANGLE_MODE) || FLIGHT_MODE(HORIZON_MODE)))) {  // Block Tuning on stickinput. Always allow Gtune on YAW, Roll & Pitch only in acromode
+        OldError[axis] = 0;
+        time_skip[axis] = -125;                                                 // Some settletime after stick center. (125 + 16)* 3ms clycle = 423ms (ca.)
+    } else {
+        if (!time_skip[axis]) AvgGyro[axis] = 0;
+        time_skip[axis]++;
+        if (time_skip[axis] > 0) {
+            if (axis == FD_YAW) AvgGyro[axis] += 32 * ((int16_t)gyroData[axis] / 32); // Chop some jitter and average
+            else AvgGyro[axis] += 128 * ((int16_t)gyroData[axis] / 128);        // Chop some jitter and average
+        }
+        if (time_skip[axis] == 16) {                                            // ca 48 ms
+            AvgGyro[axis] /= time_skip[axis];                                   // AvgGyro[axis] has now very clean gyrodata
+            time_skip[axis] = 0;
+            if (axis == FD_YAW) {
+                threshP = 20;
+                error = -AvgGyro[axis];
+            } else {
+                threshP = 10;
+                error = AvgGyro[axis];
+            }
+            if (pidProfile->gtune_hilimP[axis] && error && OldError[axis] && error != OldError[axis]) {  // Don't run when not needed or pointless to do so
+                diff_G = ABS(error) - ABS(OldError[axis]);
+                if ((error > 0 && OldError[axis] > 0) || (error < 0 && OldError[axis] < 0)) {
+                    if (diff_G > threshP) result_P64[axis] += 64 + pidProfile->gtune_pwr; // Shift balance a little on the plus side.
+                    else {
+                        if (diff_G < -threshP) {
+                            if (axis == FD_YAW) result_P64[axis] -= 64 + pidProfile->gtune_pwr;
+                            else result_P64[axis] -= 32;
+                        }
+                    }
+                } else {
+                    if (ABS(diff_G) > threshP && axis != FD_YAW) result_P64[axis] -= 32; // Don't use antiwobble for YAW
+                }
+                result_P64[axis] = constrain(result_P64[axis], (int16_t)pidProfile->gtune_lolimP[axis] << 6, (int16_t)pidProfile->gtune_hilimP[axis] << 6);
+                if (floatPID) pidProfile->P_f[axis] = (float)(result_P64[axis] >> 6); // new P value for float PID
+                else pidProfile->P8[axis] = result_P64[axis] >> 6;              // new P value
+            }
+            OldError[axis] = error;
+        }
+    }
+}
+
+#endif
+

--- a/src/main/flight/gtune.c
+++ b/src/main/flight/gtune.c
@@ -107,18 +107,18 @@ void init_Gtune(pidProfile_t *pidProfileToTune)
 
     pidProfile = pidProfileToTune;
 	if (pidProfile->pidController == 2) {
-	    floatPID = true;                        // LuxFloat is using float values for PID settings
+	    floatPID = true;                                                        // LuxFloat is using float values for PID settings
 	} else {
 	    floatPID = false;
 	}
 	updateDelayCycles();
 	for (i = 0; i < 3; i++) {
         if ((pidProfile->gtune_hilimP[i] && pidProfile->gtune_lolimP[i] > pidProfile->gtune_hilimP[i]) || (motorCount < 4 && i == FD_YAW)) { // User config error disable axisis for tuning
-            pidProfile->gtune_hilimP[i] = 0;                                    // Disable yawtuning for everything below a quadcopter
+            pidProfile->gtune_hilimP[i] = 0;                                    // Disable YAW tuning for everything below a quadcopter
         }
         if (floatPID) {
-            if((pidProfile->P_f[i] * 10) < pidProfile->gtune_lolimP[i]) {
-                pidProfile->P_f[i] = (float)(pidProfile->gtune_lolimP[i] / 10);
+            if((pidProfile->P_f[i] * 10.0f) < pidProfile->gtune_lolimP[i]) {
+                pidProfile->P_f[i] = (float)(pidProfile->gtune_lolimP[i] / 10.0f);
             }
             result_P64[i] = (int16_t)pidProfile->P_f[i] << 6;                   // 6 bit extra resolution for P.
         } else {
@@ -164,7 +164,7 @@ void calculate_Gtune(uint8_t axis)
                 if ((error > 0 && OldError[axis] > 0) || (error < 0 && OldError[axis] < 0)) {
                     if (diff_G > threshP) {
                         if (axis == FD_YAW) {
-                            result_P64[axis] += 256 + pidProfile->gtune_pwr;    // YAW ends up at low limit on PID2, give it some more to work with.
+                            result_P64[axis] += 256 + pidProfile->gtune_pwr;    // YAW ends up at low limit on float PID, give it some more to work with.
                         } else {
                             result_P64[axis] += 64 + pidProfile->gtune_pwr;     // Shift balance a little on the plus side.
                         }
@@ -190,17 +190,13 @@ void calculate_Gtune(uint8_t axis)
 
                     eventData.gtuneAxis = axis;
                     eventData.gtuneGyroAVG = AvgGyro[axis];
-                    if (floatPID) {
-                        eventData.gtuneNewP = newP / 10;
-                    } else {
-                        eventData.gtuneNewP = newP;
-                    }
+                    eventData.gtuneNewP = newP;                                 // for float PID the logged P value is still mutiplyed by 10
                     blackboxLogEvent(FLIGHT_LOG_EVENT_GTUNE_RESULT, (flightLogEventData_t*)&eventData);
                 }
 #endif
 
                 if (floatPID) {
-                    pidProfile->P_f[axis] = (float)(newP / 10);                 // new P value for float PID
+                    pidProfile->P_f[axis] = (float)newP / 10.0f;                // new P value for float PID
                 } else {
                     pidProfile->P8[axis] = newP;                                // new P value
                 }

--- a/src/main/flight/gtune.h
+++ b/src/main/flight/gtune.h
@@ -1,0 +1,21 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+void init_Gtune(pidProfile_t *pidProfileToTune);
+void calculate_Gtune(uint8_t axis);

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -712,7 +712,7 @@ rollAndPitchTrims_t *angleTrim, rxConfig_t *rxConfig)
     Mwii3msTimescale = (int32_t)FLOATcycleTime & (int32_t)~3;                  // Filter last 2 bit jitter
     Mwii3msTimescale /= 3000.0f;
 
-    if (OLD_YAW) { // [0/1] 0 = multiwii 2.3 yaw, 1 = older yaw. hardcoded for now
+    if (pidProfile->pid5_oldyw) { // [0/1] 0 = multiwii 2.3 yaw, 1 = older yaw
         PTerm = ((int32_t)pidProfile->P8[FD_YAW] * (100 - (int32_t)controlRateConfig->rates[FD_YAW] * (int32_t)ABS(rcCommand[FD_YAW]) / 500)) / 100;
         int32_t tmp = lrintf(gyroADC[FD_YAW] * 0.25f);
         PTerm = rcCommand[FD_YAW] - tmp * PTerm / 80;

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -42,6 +42,7 @@
 #include "flight/imu.h"
 #include "flight/navigation.h"
 #include "flight/autotune.h"
+#include "flight/gtune.h"
 #include "flight/filter.h"
 
 #include "config/runtime_config.h"
@@ -222,6 +223,12 @@ static void pidLuxFloat(pidProfile_t *pidProfile, controlRateConfig_t *controlRa
         // -----calculate total PID output
         axisPID[axis] = constrain(lrintf(PTerm + ITerm + DTerm), -1000, 1000);
 
+#ifdef GTUNE
+        if (FLIGHT_MODE(GTUNE_MODE) && ARMING_FLAG(ARMED)) {
+            calculate_Gtune(axis);
+        }
+#endif
+
 #ifdef BLACKBOX
         axisPID_P[axis] = PTerm;
         axisPID_I[axis] = ITerm;
@@ -317,6 +324,12 @@ static void pidMultiWii(pidProfile_t *pidProfile, controlRateConfig_t *controlRa
         DTerm = (deltaSum * dynD8[axis]) / 32;
         axisPID[axis] = PTerm + ITerm - DTerm;
 
+#ifdef GTUNE
+        if (FLIGHT_MODE(GTUNE_MODE) && ARMING_FLAG(ARMED)) {
+            calculate_Gtune(axis);
+        }
+#endif
+
 #ifdef BLACKBOX
         axisPID_P[axis] = PTerm;
         axisPID_I[axis] = ITerm;
@@ -408,6 +421,12 @@ static void pidMultiWii23(pidProfile_t *pidProfile, controlRateConfig_t *control
 
         axisPID[axis] = PTerm + ITerm - DTerm;
 
+#ifdef GTUNE
+        if (FLIGHT_MODE(GTUNE_MODE) && ARMING_FLAG(ARMED)) {
+            calculate_Gtune(axis);
+        }
+#endif
+
 #ifdef BLACKBOX
         axisPID_P[axis] = PTerm;
         axisPID_I[axis] = ITerm;
@@ -436,6 +455,17 @@ static void pidMultiWii23(pidProfile_t *pidProfile, controlRateConfig_t *control
     ITerm = constrain((int16_t)(errorGyroI[FD_YAW] >> 13), -GYRO_I_MAX, +GYRO_I_MAX);
 
     axisPID[FD_YAW] =  PTerm + ITerm;
+
+    if (motorCount >= 4) {                                                     // prevent "yaw jump" during yaw correction
+        int16_t limit = ABS(rcCommand[FD_YAW]) + 100;
+        axisPID[FD_YAW] = (float)constrain((int32_t)axisPID[FD_YAW], -limit, +limit);
+    }
+
+#ifdef GTUNE
+    if (FLIGHT_MODE(GTUNE_MODE) && ARMING_FLAG(ARMED)) {
+        calculate_Gtune(FD_YAW);
+    }
+#endif
 
 #ifdef BLACKBOX
     axisPID_P[FD_YAW] = PTerm;
@@ -530,6 +560,12 @@ static void pidMultiWiiHybrid(pidProfile_t *pidProfile, controlRateConfig_t *con
         DTerm = (deltaSum * dynD8[axis]) / 32;
         axisPID[axis] = PTerm + ITerm - DTerm;
 
+#ifdef GTUNE
+        if (FLIGHT_MODE(GTUNE_MODE) && ARMING_FLAG(ARMED)) {
+            calculate_Gtune(axis);
+        }
+#endif
+
 #ifdef BLACKBOX
         axisPID_P[axis] = PTerm;
         axisPID_I[axis] = ITerm;
@@ -558,6 +594,16 @@ static void pidMultiWiiHybrid(pidProfile_t *pidProfile, controlRateConfig_t *con
 
     axisPID[FD_YAW] =  PTerm + ITerm;
 
+    if (motorCount >= 4) {                                                     // prevent "yaw jump" during yaw correction
+        int16_t limit = ABS(rcCommand[FD_YAW]) + 100;
+        axisPID[FD_YAW] = (float)constrain((int32_t)axisPID[FD_YAW], -limit, +limit);
+    }
+
+#ifdef GTUNE
+    if (FLIGHT_MODE(GTUNE_MODE) && ARMING_FLAG(ARMED)) {
+        calculate_Gtune(FD_YAW);
+    }
+#endif
 
 #ifdef BLACKBOX
     axisPID_P[FD_YAW] = PTerm;
@@ -650,6 +696,12 @@ rollAndPitchTrims_t *angleTrim, rxConfig_t *rxConfig)
 
         axisPID[axis] = lrintf(PTerm + ITerm - DTerm);                         // Round up result.
 
+#ifdef GTUNE
+        if (FLIGHT_MODE(GTUNE_MODE) && ARMING_FLAG(ARMED)) {
+            calculate_Gtune(axis);
+        }
+#endif
+
 #ifdef BLACKBOX
         axisPID_P[axis] = PTerm;
         axisPID_I[axis] = ITerm;
@@ -696,6 +748,17 @@ rollAndPitchTrims_t *angleTrim, rxConfig_t *rxConfig)
 
     axisPID[FD_YAW] = PTerm + ITerm;
     axisPID[FD_YAW] = lrintf(axisPID[FD_YAW]);                                 // Round up result.
+
+    if (motorCount >= 4) {                                                     // prevent "yaw jump" during yaw correction
+        int16_t limit = ABS(rcCommand[FD_YAW]) + 100;
+        axisPID[FD_YAW] = (float)constrain((int32_t)axisPID[FD_YAW], -limit, +limit);
+    }
+
+#ifdef GTUNE
+    if (FLIGHT_MODE(GTUNE_MODE) && ARMING_FLAG(ARMED)) {
+        calculate_Gtune(FD_YAW);
+    }
+#endif
 
 #ifdef BLACKBOX
     axisPID_P[FD_YAW] = PTerm;
@@ -822,6 +885,12 @@ static void pidRewrite(pidProfile_t *pidProfile, controlRateConfig_t *controlRat
 
         // -----calculate total PID output
         axisPID[axis] = PTerm + ITerm + DTerm;
+
+#ifdef GTUNE
+        if (FLIGHT_MODE(GTUNE_MODE) && ARMING_FLAG(ARMED)) {
+             calculate_Gtune(axis);
+        }
+#endif
 
 #ifdef BLACKBOX
         axisPID_P[axis] = PTerm;

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -456,11 +456,6 @@ static void pidMultiWii23(pidProfile_t *pidProfile, controlRateConfig_t *control
 
     axisPID[FD_YAW] =  PTerm + ITerm;
 
-    if (motorCount >= 4) {                                                     // prevent "yaw jump" during yaw correction
-        int16_t limit = ABS(rcCommand[FD_YAW]) + 100;
-        axisPID[FD_YAW] = (float)constrain((int32_t)axisPID[FD_YAW], -limit, +limit);
-    }
-
 #ifdef GTUNE
     if (FLIGHT_MODE(GTUNE_MODE) && ARMING_FLAG(ARMED)) {
         calculate_Gtune(FD_YAW);
@@ -593,11 +588,6 @@ static void pidMultiWiiHybrid(pidProfile_t *pidProfile, controlRateConfig_t *con
     ITerm = constrain((int16_t)(errorGyroI[FD_YAW] >> 13), -GYRO_I_MAX, +GYRO_I_MAX);
 
     axisPID[FD_YAW] =  PTerm + ITerm;
-
-    if (motorCount >= 4) {                                                     // prevent "yaw jump" during yaw correction
-        int16_t limit = ABS(rcCommand[FD_YAW]) + 100;
-        axisPID[FD_YAW] = (float)constrain((int32_t)axisPID[FD_YAW], -limit, +limit);
-    }
 
 #ifdef GTUNE
     if (FLIGHT_MODE(GTUNE_MODE) && ARMING_FLAG(ARMED)) {
@@ -748,11 +738,6 @@ rollAndPitchTrims_t *angleTrim, rxConfig_t *rxConfig)
 
     axisPID[FD_YAW] = PTerm + ITerm;
     axisPID[FD_YAW] = lrintf(axisPID[FD_YAW]);                                 // Round up result.
-
-    if (motorCount >= 4) {                                                     // prevent "yaw jump" during yaw correction
-        int16_t limit = ABS(rcCommand[FD_YAW]) + 100;
-        axisPID[FD_YAW] = (float)constrain((int32_t)axisPID[FD_YAW], -limit, +limit);
-    }
 
 #ifdef GTUNE
     if (FLIGHT_MODE(GTUNE_MODE) && ARMING_FLAG(ARMED)) {

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -63,10 +63,17 @@ typedef struct pidProfile_s {
     uint8_t H_sensitivity;
 
     uint16_t yaw_p_limit;                   // set P term limit (fixed value was 300)
-    uint8_t pid5_oldyw;                     // Old yaw behavior for PID5
     uint8_t dterm_cut_hz;                   // (default 17Hz, Range 1-50Hz) Used for PT1 element in PID1, PID2 and PID5
     uint8_t pterm_cut_hz;                   // Used for fitlering Pterm noise on noisy frames
     uint8_t gyro_cut_hz;                    // Used for soft gyro filtering
+
+    uint8_t pid5_oldyw;                     // [0/1] 0 = multiwii 2.3 yaw, 1 = older yaw
+
+#ifdef GTUNE
+    uint8_t  gtune_lolimP[3];               // [10..200] Lower limit of P during G tune
+    uint8_t  gtune_hilimP[3];               // [0..200] Higher limit of P during G tune. 0 Disables tuning for that axis.
+    int8_t   gtune_pwr;                     // [0..10] Strength of adjustment
+#endif
 } pidProfile_t;
 
 #define DEGREES_TO_DECIDEGREES(angle) (angle * 10)

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -61,7 +61,9 @@ typedef struct pidProfile_s {
     float A_level;
     float H_level;
     uint8_t H_sensitivity;
+
     uint16_t yaw_p_limit;                   // set P term limit (fixed value was 300)
+    uint8_t pid5_oldyw;                     // Old yaw behavior for PID5
     uint8_t dterm_cut_hz;                   // (default 17Hz, Range 1-50Hz) Used for PT1 element in PID1, PID2 and PID5
     uint8_t pterm_cut_hz;                   // Used for fitlering Pterm noise on noisy frames
     uint8_t gyro_cut_hz;                    // Used for soft gyro filtering

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -70,9 +70,11 @@ typedef struct pidProfile_s {
     uint8_t pid5_oldyw;                     // [0/1] 0 = multiwii 2.3 yaw, 1 = older yaw
 
 #ifdef GTUNE
-    uint8_t  gtune_lolimP[3];               // [10..200] Lower limit of P during G tune
+    uint8_t  gtune_lolimP[3];               // [0..200] Lower limit of P during G tune
     uint8_t  gtune_hilimP[3];               // [0..200] Higher limit of P during G tune. 0 Disables tuning for that axis.
-    int8_t   gtune_pwr;                     // [0..10] Strength of adjustment
+    uint8_t  gtune_pwr;                     // [0..10] Strength of adjustment
+    uint16_t gtune_settle_time;             // [200..1000] Settle time in ms
+    uint8_t  gtune_average_cycles;          // [8..128] Number of looptime cycles used for gyro average calculation
 #endif
 } pidProfile_t;
 

--- a/src/main/io/rc_controls.h
+++ b/src/main/io/rc_controls.h
@@ -48,6 +48,7 @@ typedef enum {
     BOXSERVO3,
     BOXBLACKBOX,
     BOXFAILSAFE,
+    BOXGTUNE,
     CHECKBOX_ITEM_COUNT
 } boxId_e;
 

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -524,7 +524,9 @@ const clivalue_t valueTable[] = {
     { "gtune_hiP_rll",              VAR_UINT8  | PROFILE_VALUE,  &masterConfig.profile[0].pidProfile.gtune_hilimP[FD_ROLL], 0, 200 },
     { "gtune_hiP_ptch",             VAR_UINT8  | PROFILE_VALUE,  &masterConfig.profile[0].pidProfile.gtune_hilimP[FD_PITCH], 0, 200 },
     { "gtune_hiP_yw",               VAR_UINT8  | PROFILE_VALUE,  &masterConfig.profile[0].pidProfile.gtune_hilimP[FD_YAW], 0, 200 },
-    { "gtune_pwr",                  VAR_INT8   | PROFILE_VALUE,  &masterConfig.profile[0].pidProfile.gtune_pwr, 0, 10 },
+    { "gtune_pwr",                  VAR_UINT8  | PROFILE_VALUE,  &masterConfig.profile[0].pidProfile.gtune_pwr, 0, 10 },
+    { "gtune_settle_time",          VAR_UINT16 | PROFILE_VALUE,  &masterConfig.profile[0].pidProfile.gtune_settle_time, 200, 1000 },
+    { "gtune_average_cycles",       VAR_UINT8  | PROFILE_VALUE,  &masterConfig.profile[0].pidProfile.gtune_average_cycles, 8, 128 },
 #endif
 
 #ifdef BLACKBOX

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -514,6 +514,9 @@ const clivalue_t valueTable[] = {
 	{ "pterm_cut_hz",               VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.pterm_cut_hz, 0, 200 },
 	{ "gyro_cut_hz",                VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.gyro_cut_hz, 0, 200 },
 
+    { "pid5_oldyw",                 VAR_UINT8  | PROFILE_VALUE,  &masterConfig.profile[0].pidProfile.pid5_oldyw, 0, 1 },
+    { "pid5_maincuthz",             VAR_UINT8  | PROFILE_VALUE,  &masterConfig.profile[0].pidProfile.pid5_maincuthz, 1, 50 },
+
 #ifdef BLACKBOX
     { "blackbox_rate_num",          VAR_UINT8  | MASTER_VALUE,  &masterConfig.blackbox_rate_num, 1, 32 },
     { "blackbox_rate_denom",        VAR_UINT8  | MASTER_VALUE,  &masterConfig.blackbox_rate_denom, 1, 32 },

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -517,6 +517,16 @@ const clivalue_t valueTable[] = {
     { "pid5_oldyw",                 VAR_UINT8  | PROFILE_VALUE,  &masterConfig.profile[0].pidProfile.pid5_oldyw, 0, 1 },
     { "pid5_maincuthz",             VAR_UINT8  | PROFILE_VALUE,  &masterConfig.profile[0].pidProfile.pid5_maincuthz, 1, 50 },
 
+#ifdef GTUNE
+    { "gtune_loP_rll",              VAR_UINT8  | PROFILE_VALUE,  &masterConfig.profile[0].pidProfile.gtune_lolimP[FD_ROLL], 10, 200 },
+    { "gtune_loP_ptch",             VAR_UINT8  | PROFILE_VALUE,  &masterConfig.profile[0].pidProfile.gtune_lolimP[FD_PITCH], 10, 200 },
+    { "gtune_loP_yw",               VAR_UINT8  | PROFILE_VALUE,  &masterConfig.profile[0].pidProfile.gtune_lolimP[FD_YAW], 10, 200 },
+    { "gtune_hiP_rll",              VAR_UINT8  | PROFILE_VALUE,  &masterConfig.profile[0].pidProfile.gtune_hilimP[FD_ROLL], 0, 200 },
+    { "gtune_hiP_ptch",             VAR_UINT8  | PROFILE_VALUE,  &masterConfig.profile[0].pidProfile.gtune_hilimP[FD_PITCH], 0, 200 },
+    { "gtune_hiP_yw",               VAR_UINT8  | PROFILE_VALUE,  &masterConfig.profile[0].pidProfile.gtune_hilimP[FD_YAW], 0, 200 },
+    { "gtune_pwr",                  VAR_INT8   | PROFILE_VALUE,  &masterConfig.profile[0].pidProfile.gtune_pwr, 0, 10 },
+#endif
+
 #ifdef BLACKBOX
     { "blackbox_rate_num",          VAR_UINT8  | MASTER_VALUE,  &masterConfig.blackbox_rate_num, 1, 32 },
     { "blackbox_rate_denom",        VAR_UINT8  | MASTER_VALUE,  &masterConfig.blackbox_rate_denom, 1, 32 },

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -515,7 +515,6 @@ const clivalue_t valueTable[] = {
 	{ "gyro_cut_hz",                VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.gyro_cut_hz, 0, 200 },
 
     { "pid5_oldyw",                 VAR_UINT8  | PROFILE_VALUE,  &masterConfig.profile[0].pidProfile.pid5_oldyw, 0, 1 },
-    { "pid5_maincuthz",             VAR_UINT8  | PROFILE_VALUE,  &masterConfig.profile[0].pidProfile.pid5_maincuthz, 1, 50 },
 
 #ifdef GTUNE
     { "gtune_loP_rll",              VAR_UINT8  | PROFILE_VALUE,  &masterConfig.profile[0].pidProfile.gtune_lolimP[FD_ROLL], 10, 200 },

--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -347,6 +347,7 @@ static const box_t boxes[CHECKBOX_ITEM_COUNT + 1] = {
     { BOXSERVO3, "SERVO3;", 25 },
     { BOXBLACKBOX, "BLACKBOX;", 26 },
     { BOXFAILSAFE, "FAILSAFE;", 27 },
+    { BOXGTUNE, "GTUNE;", 28 },
     { CHECKBOX_ITEM_COUNT, NULL, 0xFF }
 };
 
@@ -703,6 +704,10 @@ void mspInit(serialConfig_t *serialConfig)
         activeBoxIds[activeBoxIdCount++] = BOXFAILSAFE;
     }
 
+#ifdef GTUNE
+    activeBoxIds[activeBoxIdCount++] = BOXGTUNE;
+#endif
+
     memset(mspPorts, 0x00, sizeof(mspPorts));
     mspAllocateSerialPorts(serialConfig);
 }
@@ -822,6 +827,7 @@ static bool processOutCommand(uint8_t cmdMSP)
             IS_ENABLED(IS_RC_MODE_ACTIVE(BOXOSD)) << BOXOSD |
             IS_ENABLED(IS_RC_MODE_ACTIVE(BOXTELEMETRY)) << BOXTELEMETRY |
             IS_ENABLED(IS_RC_MODE_ACTIVE(BOXAUTOTUNE)) << BOXAUTOTUNE |
+            IS_ENABLED(IS_RC_MODE_ACTIVE(BOXGTUNE)) << BOXGTUNE |
             IS_ENABLED(FLIGHT_MODE(SONAR_MODE)) << BOXSONAR |
             IS_ENABLED(ARMING_FLAG(ARMED)) << BOXARM |
             IS_ENABLED(IS_RC_MODE_ACTIVE(BOXBLACKBOX)) << BOXBLACKBOX |

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -71,6 +71,7 @@
 #include "flight/altitudehold.h"
 #include "flight/failsafe.h"
 #include "flight/autotune.h"
+#include "flight/gtune.h"
 #include "flight/navigation.h"
 #include "flight/filter.h"
 
@@ -156,6 +157,30 @@ void updateAutotuneState(void)
 
     if (!ARMING_FLAG(ARMED) && autoTuneWasUsed) {
         landedAfterAutoTuning = true;
+    }
+}
+#endif
+
+#ifdef GTUNE
+
+void updateGtuneState(void)
+{
+    static bool GTuneWasUsed = false;
+
+    if (IS_RC_MODE_ACTIVE(BOXGTUNE)) {
+        if (!FLIGHT_MODE(GTUNE_MODE)) {
+        	ENABLE_FLIGHT_MODE(GTUNE_MODE);
+            init_Gtune(&currentProfile->pidProfile);
+            GTuneWasUsed = true;
+        }
+    } else {
+        if (FLIGHT_MODE(GTUNE_MODE)) {
+    	    DISABLE_FLIGHT_MODE(GTUNE_MODE);
+            if (!ARMING_FLAG(ARMED) && GTuneWasUsed) {
+                saveConfigAndNotify();
+                GTuneWasUsed = false;
+            }
+        }
     }
 }
 #endif
@@ -804,6 +829,10 @@ void loop(void)
         if (sensors(SENSOR_MAG)) {
         	updateMagHold();
         }
+#endif
+
+#ifdef GTUNE
+        updateGtuneState();
 #endif
 
 #if defined(BARO) || defined(SONAR)

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -168,18 +168,18 @@ void updateGtuneState(void)
     static bool GTuneWasUsed = false;
 
     if (IS_RC_MODE_ACTIVE(BOXGTUNE)) {
-        if (!FLIGHT_MODE(GTUNE_MODE)) {
-        	ENABLE_FLIGHT_MODE(GTUNE_MODE);
+        if (!FLIGHT_MODE(GTUNE_MODE) && ARMING_FLAG(ARMED)) {
+            ENABLE_FLIGHT_MODE(GTUNE_MODE);
             init_Gtune(&currentProfile->pidProfile);
             GTuneWasUsed = true;
         }
+        if (!FLIGHT_MODE(GTUNE_MODE) && !ARMING_FLAG(ARMED) && GTuneWasUsed) {
+            saveConfigAndNotify();
+            GTuneWasUsed = false;
+        }
     } else {
-        if (FLIGHT_MODE(GTUNE_MODE)) {
+        if (FLIGHT_MODE(GTUNE_MODE) && ARMING_FLAG(ARMED)) {
     	    DISABLE_FLIGHT_MODE(GTUNE_MODE);
-            if (!ARMING_FLAG(ARMED) && GTuneWasUsed) {
-                saveConfigAndNotify();
-                GTuneWasUsed = false;
-            }
         }
     }
 }

--- a/src/main/target/ALIENWIIF3/target.h
+++ b/src/main/target/ALIENWIIF3/target.h
@@ -115,6 +115,7 @@
 //#define GPS
 //#define DISPLAY
 #define AUTOTUNE
+#define GTUNE
 #define USE_SERVOS
 #define USE_CLI
 

--- a/src/main/target/CC3D/target.h
+++ b/src/main/target/CC3D/target.h
@@ -113,6 +113,7 @@
 #define SERIAL_RX
 #define SONAR
 #define AUTOTUNE
+#define GTUNE
 #define USE_SERVOS
 #define USE_CLI
 
@@ -120,6 +121,7 @@
 // disabled some features for OPBL build due to code size.
 #undef AUTOTUNE
 #undef DISPLAY
+#undef GTUNE
 #undef SONAR
 #define SKIP_CLI_COMMAND_HELP
 #endif

--- a/src/main/target/NAZE/target.h
+++ b/src/main/target/NAZE/target.h
@@ -175,6 +175,7 @@
 #define TELEMETRY
 #define SERIAL_RX
 #define AUTOTUNE
+#define GTUNE
 #define USE_SERVOS
 #define USE_CLI
 

--- a/src/main/target/NAZE32PRO/target.h
+++ b/src/main/target/NAZE32PRO/target.h
@@ -45,6 +45,7 @@
 #define TELEMETRY
 #define SERIAL_RX
 #define AUTOTUNE
+#define GTUNE
 #define USE_SERVOS
 #define USE_CLI
 

--- a/src/main/target/SPARKY/target.h
+++ b/src/main/target/SPARKY/target.h
@@ -108,6 +108,7 @@
 #define CURRENT_METER_ADC_CHANNEL   ADC_Channel_4
 
 #define AUTOTUNE
+#define GTUNE
 #define BLACKBOX
 #define TELEMETRY
 #define SERIAL_RX


### PR DESCRIPTION
Implement G-Tune (ported from Harakiri). Documentation can be found here:

https://github.com/MJ666/cleanflight/blob/Harakiri_PID_update/docs/Gtune.md

G-Tune is tested in a quite some test flights and is working much more saver and less intrusive than the CF Autotune. It should work on all PID controllers (PID 0, PID 3 and PID 5 are tested). Please see also here #560.

Make two formerly hardcoded parameter for the Harakiri PID configurable. The first one has helped some users with there tuning problem to eliminate some wobble.

        set pid5_maincuthz = 12     [1-50Hz] Cut Off Frequency for D term of main Pid controller
        set pid5_oldyw = 0          [0/1] 0 = multiwii 2.3 yaw (default), 1 = older yaw

Added an yaw constrain if yaw stick commands are given to PID 3, PID 4 and PID 5 controllers. Recommendation by Crashpilot1000.

