### PR TITLE
Disable debug vars by default

### DIFF
--- a/src/main/flight/autotune.c
+++ b/src/main/flight/autotune.c
@@ -270,7 +270,9 @@ float autotune(angle_index_t angleIndex, const rollAndPitchInclination_t *inclin
             firstPeakAngle = currentAngle;
             targetAngleAtPeak = targetAngle;
 
+#ifdef DEBUG_AUTOTUNE
             debug[3] = DEGREES_TO_DECIDEGREES(firstPeakAngle);
+#endif
 
         } else if (firstPeakAngle > 0) {
             switch (cycle) {
@@ -320,7 +322,9 @@ float autotune(angle_index_t angleIndex, const rollAndPitchInclination_t *inclin
 
         if (currentAngle < secondPeakAngle) {
             secondPeakAngle = currentAngle;
+#ifdef DEBUG_AUTOTUNE
             debug[3] = DEGREES_TO_DECIDEGREES(secondPeakAngle);
+#endif
         }
 
         float oscillationAmplitude = firstPeakAngle - secondPeakAngle;
@@ -395,9 +399,11 @@ float autotune(angle_index_t angleIndex, const rollAndPitchInclination_t *inclin
         }
     }
 
+#ifdef DEBUG_AUTOTUNE
     if (angleIndex == AI_ROLL) {
         debug[0] += 100;
     }
+#endif
 
     updateTargetAngle();
 

--- a/src/main/rx/sbus.c
+++ b/src/main/rx/sbus.c
@@ -50,7 +50,7 @@
 #define SBUS_TIME_NEEDED_PER_FRAME 3000
 
 #ifndef CJMCU
-#define DEBUG_SBUS_PACKETS
+//#define DEBUG_SBUS_PACKETS
 #endif
 
 #ifdef DEBUG_SBUS_PACKETS


### PR DESCRIPTION
I was having some issues using the debug[] vars and it turned out that some were being written to by default.  I thought that fixing that might save someone else the time tracking them down.