### PR TITLE
Update frsky.c Fix for RPM with feature motor_stop

### DIFF
--- a/src/main/telemetry/frsky.c
+++ b/src/main/telemetry/frsky.c
@@ -121,6 +121,7 @@ extern int16_t telemTemperature1; // FIXME dependency on mw.c
 
 static uint32_t lastCycleTime = 0;
 static uint8_t cycleNum = 0;
+escAndServoConfig_t *escAndServoConfig;
 static void sendDataHead(uint8_t id)
 {
     serialWrite(frskyPort, PROTOCOL_HEADER);
@@ -190,7 +191,14 @@ static void sendThrottleOrBatterySizeAsRpm(void)
 {
     sendDataHead(ID_RPM);
     if (ARMING_FLAG(ARMED)) {
-        serialize16(rcCommand[THROTTLE] / BLADE_NUMBER_DIVIDER);
+        if(rcCommand[THROTTLE] <= escAndServoConfig->minthrottle){
+            if (!feature(FEATURE_MOTOR_STOP))
+                serialize16(rcCommand[THROTTLE] / BLADE_NUMBER_DIVIDER);
+            else
+                serialize16(escAndServoConfig->mincommand / BLADE_NUMBER_DIVIDER);
+        }
+	else
+		serialize16(rcCommand[THROTTLE] / BLADE_NUMBER_DIVIDER);
     } else {
         serialize16((batteryConfig->batteryCapacity / BLADE_NUMBER_DIVIDER));
     }

--- a/src/main/telemetry/frsky.c
+++ b/src/main/telemetry/frsky.c
@@ -199,9 +199,9 @@ static void sendThrottleOrBatterySizeAsRpm(void)
     sendDataHead(ID_RPM);
     if (ARMING_FLAG(ARMED)) {
         if((rcData[THROTTLE]) < masterConfig.rxConfig.mincheck && feature(FEATURE_MOTOR_STOP))
-			serialize16(masterConfig.escAndServoConfig.mincommand / BLADE_NUMBER_DIVIDER);
-		else
-			serialize16(rcCommand[THROTTLE] / BLADE_NUMBER_DIVIDER);
+            serialize16(masterConfig.escAndServoConfig.mincommand / BLADE_NUMBER_DIVIDER);
+        else
+            serialize16(rcCommand[THROTTLE] / BLADE_NUMBER_DIVIDER);
     } else {
         serialize16((batteryConfig->batteryCapacity / BLADE_NUMBER_DIVIDER));
     }


### PR DESCRIPTION
Fix RPM telemetry issue #562 - When MOTOR_STOP is is used, at the RPM used to report the minimum throttle value (the same as if motors were spinning, with this commit, RPM reports the minimum command (ie. motors stopped) if MOTOR_STOP is used and throttle minimum.
Only thing I'm not sure of - I was initially going to use 
    if(rcCommand[THROTTLE] <= rxConfig->mincheck)
but couldn't make it work - mincheck was returning a value ~2000
so switched to:
    if(rcCommand[THROTTLE] <= escAndServoConfig->minthrottle)
instead, which avoided referencing rxConfig at all, and from what I can tell, minthrottle is the minimum value that can be sent to the esc, so possibly works better.

If there's a better way, feel free to let me know