### PR TITLE
Fix upper limit on mag_hardware and acc_hardware CLI variables

### DIFF
--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -407,7 +407,7 @@ const clivalue_t valueTable[] = {
     { "gimbal_flags",               VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].gimbalConfig.gimbal_flags, 0, 255},
 #endif
 
-    { "acc_hardware",               VAR_UINT8  | MASTER_VALUE,  &masterConfig.acc_hardware, 0, ACC_NONE },
+    { "acc_hardware",               VAR_UINT8  | MASTER_VALUE,  &masterConfig.acc_hardware, 0, ACC_MAX },
     { "acc_lpf_factor",             VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].acc_lpf_factor, 0, 250 },
     { "accxy_deadband",             VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].accDeadband.xy, 0, 100 },
     { "accz_deadband",              VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].accDeadband.z, 0, 100 },
@@ -421,7 +421,7 @@ const clivalue_t valueTable[] = {
     { "baro_cf_vel",                VAR_FLOAT  | PROFILE_VALUE, &masterConfig.profile[0].barometerConfig.baro_cf_vel, 0, 1 },
     { "baro_cf_alt",                VAR_FLOAT  | PROFILE_VALUE, &masterConfig.profile[0].barometerConfig.baro_cf_alt, 0, 1 },
 
-    { "mag_hardware",               VAR_UINT8  | MASTER_VALUE,  &masterConfig.mag_hardware, 0, MAG_NONE },
+    { "mag_hardware",               VAR_UINT8  | MASTER_VALUE,  &masterConfig.mag_hardware, 0, MAG_MAX },
     { "mag_declination",            VAR_INT16  | PROFILE_VALUE, &masterConfig.profile[0].mag_declination, -18000, 18000 },
 
     { "pid_controller",             VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.pidController, 0, 5 },

--- a/src/main/sensors/acceleration.h
+++ b/src/main/sensors/acceleration.h
@@ -29,9 +29,9 @@ typedef enum {
     ACC_SPI_MPU6000 = 7,
     ACC_SPI_MPU6500 = 8,
     ACC_FAKE = 9,
-
-    ACC_MAX = ACC_FAKE
 } accelerationSensor_e;
+
+#define ACC_MAX  ACC_FAKE
 
 extern sensor_align_e accAlign;
 extern acc_t acc;

--- a/src/main/sensors/acceleration.h
+++ b/src/main/sensors/acceleration.h
@@ -29,6 +29,8 @@ typedef enum {
     ACC_SPI_MPU6000 = 7,
     ACC_SPI_MPU6500 = 8,
     ACC_FAKE = 9,
+
+    ACC_MAX = ACC_FAKE
 } accelerationSensor_e;
 
 extern sensor_align_e accAlign;

--- a/src/main/sensors/compass.h
+++ b/src/main/sensors/compass.h
@@ -17,15 +17,15 @@
 
 #pragma once
 
-// Type of accelerometer used/detected
+// Type of magnetometer used/detected
 typedef enum {
     MAG_DEFAULT = 0,
     MAG_NONE = 1,
     MAG_HMC5883 = 2,
-    MAG_AK8975 = 3,
-
-    MAG_MAX = MAG_AK8975
+    MAG_AK8975 = 3
 } magSensor_e;
+
+#define MAG_MAX  MAG_AK8975
 
 #ifdef MAG
 void compassInit(void);

--- a/src/main/sensors/compass.h
+++ b/src/main/sensors/compass.h
@@ -23,6 +23,8 @@ typedef enum {
     MAG_NONE = 1,
     MAG_HMC5883 = 2,
     MAG_AK8975 = 3,
+
+    MAG_MAX = MAG_AK8975
 } magSensor_e;
 
 #ifdef MAG


### PR DESCRIPTION
The upper bound on these variables has been too small since 1.7.2 (which moved the previous maximum NONE value to below the last entry).