### PR TITLE
Fix small_angle type to match CLI

### DIFF
--- a/src/main/flight/imu.h
+++ b/src/main/flight/imu.h
@@ -50,7 +50,7 @@ typedef struct imuRuntimeConfig_s {
     uint8_t acc_unarmedcal;
     float gyro_cmpf_factor;
     float gyro_cmpfm_factor;
-    int8_t small_angle;
+    uint8_t small_angle;
 } imuRuntimeConfig_t;
 
 void imuConfigure(


### PR DESCRIPTION
int8_t small_angle prevents using angles>128deg (and thus disabling it with small_angle=180)