### PR TITLE
A cleaner way of detecting a soft-reset

### DIFF
--- a/src/main/drivers/system.c
+++ b/src/main/drivers/system.c
@@ -76,6 +76,8 @@ void EXTI15_10_IRQHandler(void)
 static uint32_t usTicks = 0;
 // current uptime for 1kHz systick timer. will rollover after 49 days. hopefully we won't care.
 static volatile uint32_t sysTickUptime = 0;
+// cached value of RCC->CSR
+uint32_t cachedRccCsrValue;
 
 static void cycleCounterInit(void)
 {
@@ -123,6 +125,8 @@ void systemInit(void)
     RCC_APB2PeriphClockCmd(RCC_APB2Periph_AFIO, ENABLE);
 #endif
 
+    // cache RCC->CSR value to use it in isMPUSoftreset() and others
+    cachedRccCsrValue = RCC->CSR;
     RCC_ClearFlag();
 
 

--- a/src/main/drivers/system.h
+++ b/src/main/drivers/system.h
@@ -40,3 +40,5 @@ typedef void extiCallbackHandler(void);
 
 void registerExti15_10_CallbackHandler(extiCallbackHandler *fn);
 void unregisterExti15_10_CallbackHandler(extiCallbackHandler *fn);
+
+extern uint32_t cachedRccCsrValue;

--- a/src/main/drivers/system_stm32f10x.c
+++ b/src/main/drivers/system_stm32f10x.c
@@ -25,16 +25,9 @@
 #include "system.h"
 
 #define AIRCR_VECTKEY_MASK    ((uint32_t)0x05FA0000)
-#define BKP_SOFTRESET (0x50F7B007)
 
 void systemReset(void)
 {
-    // write magic value that we're doing a soft reset
-    RCC_APB1PeriphClockCmd(RCC_APB1Periph_PWR | RCC_APB1Periph_BKP, ENABLE);
-    PWR->CR |= PWR_CR_DBP;
-    *((uint16_t *)BKP_BASE + 0x04) = BKP_SOFTRESET & 0xffff;
-    *((uint16_t *)BKP_BASE + 0x08) = (BKP_SOFTRESET & 0xffff0000) >> 16;
-
     // Generate system reset
     SCB->AIRCR = AIRCR_VECTKEY_MASK | (uint32_t)0x04;
 }
@@ -63,7 +56,7 @@ void enableGPIOPowerUsageAndNoiseReductions(void)
 
 bool isMPUSoftReset(void)
 {
-    if ((*((uint16_t *)BKP_BASE + 0x04) | *((uint16_t *)BKP_BASE + 0x08) << 16) == BKP_SOFTRESET)
+    if (cachedRccCsrValue & RCC_CSR_SFTRSTF)
         return true;
     else
         return false;

--- a/src/main/drivers/system_stm32f30x.c
+++ b/src/main/drivers/system_stm32f30x.c
@@ -22,6 +22,7 @@
 #include "platform.h"
 
 #include "gpio.h"
+#include "system.h"
 
 #define AIRCR_VECTKEY_MASK    ((uint32_t)0x05FA0000)
 
@@ -70,7 +71,7 @@ void enableGPIOPowerUsageAndNoiseReductions(void)
 
 bool isMPUSoftReset(void)
 {
-    if (RCC->CSR & RCC_CSR_SFTRSTF)
+    if (cachedRccCsrValue & RCC_CSR_SFTRSTF)
         return true;
     else
         return false;


### PR DESCRIPTION
Switched to a cleaner way of detecting a soft-reset on STM32F103 based targets using RCC->CSR register. Also saved a few bytes of flash and freed two backup registers for other usages.