### PR TITLE
Allow magnetometer to be disabled by setting mag_hardware = MAG_NONE

### DIFF
--- a/src/main/sensors/initialisation.c
+++ b/src/main/sensors/initialisation.c
@@ -526,7 +526,7 @@ retry:
             break;
     }
 
-    if (magHardwareToUse != MAG_DEFAULT && magHardware == MAG_NONE) {
+    if ((magHardwareToUse != MAG_DEFAULT && magHardwareToUse != MAG_NONE) && magHardware == MAG_NONE) {
         // Nothing was found and we have a forced sensor that isn't present.
         magHardwareToUse = MAG_DEFAULT;
         goto retry;


### PR DESCRIPTION
I stumbled upon a bug, when I can not disable a connected magnetometer by setting mag_hardware to MAG_NONE. This PR fixes this.