### PR TITLE
Add support for Winbond 64Mbit SPI flash chip

### DIFF
--- a/docs/Blackbox.md
+++ b/docs/Blackbox.md
@@ -134,9 +134,17 @@ tubing instead.
 ![OpenLog installed](Wiring/blackbox-installation-1.jpg "OpenLog installed with double-sided tape, SDCard slot pointing outward")
 
 ### Onboard dataflash storage
-The full version of the Naze32 and the CC3D have an onboard "m25p16" 2 megayte dataflash storage chip which can be used
-to store flight logs instead of using an OpenLog. This is a small chip with 8 fat legs, which can be found at the base
-of the Naze32's direction arrow. This chip is not present on the "Acro" version of the Naze32.
+Some flight controllers have an onboard SPI NOR flash chip which can be used to store flight logs instead of using an 
+OpenLog.
+
+The full version of the Naze32 and the CC3D have an onboard "m25p16" 2 megayte dataflash storage chip. This is a small
+chip with 8 fat legs, which can be found at the base of the Naze32's direction arrow. This chip is not present on the
+"Acro" version of the Naze32.
+
+These chips are also supported:
+
+* Micron/ST M25P16 - 16 Mbit
+* Winbond W25Q64 - 64 Mbit
 
 ## Enabling the Blackbox (CLI)
 In the [Cleanflight Configurator][] , enter the CLI tab. Enable the Blackbox feature by typing in `feature BLACKBOX` and

--- a/src/main/drivers/flash.h
+++ b/src/main/drivers/flash.h
@@ -20,12 +20,12 @@
 #include <stdint.h>
 
 typedef struct flashGeometry_t {
-    uint8_t sectors;
+    uint8_t sectors; // Count of the number of erasable blocks on the device
 
     uint16_t pagesPerSector;
-    uint16_t pageSize;
+    uint16_t pageSize; // In bytes
 
-    uint32_t sectorSize;
+    uint32_t sectorSize; // This is just pagesPerSector * pageSize
 
-    uint32_t totalSize;
+    uint32_t totalSize;  // This is just sectorSize * sectors
 } flashGeometry_t;


### PR DESCRIPTION
Adds support for Winbond W25Q64 64mbit flash, though it doesn't fit on the board without bending pins due to being a little too wide. A couple of users have installed it successfully, here's what it looks like installed on hdphilip's board:

![hdphilip - winbond 64mbit](https://cloud.githubusercontent.com/assets/1921411/6888831/45d1a064-d6e5-11e4-98c0-cdd87349173a.jpg)
