### PR TITLE
Enable battery monitoring for Sparky and ALIENWII F3

### DIFF
--- a/docs/Board - AlienWii32.md
+++ b/docs/Board - AlienWii32.md
@@ -6,18 +6,19 @@ Here are the hardware specifications:
 
 - STM32F103CBT6 MCU (ALIENWIIF1)
 - STM32F303CCT6 MCU (ALIENWIIF3)
-- optional integrated serial/ppm receiver (ALIENWIIF3 only, future enhancement)
 - MPU6050 accelerometer/gyro sensor unit
 - 8x 4.2A brushed ESCs, integrated, to run the strongest micro motors
 - extra-wide traces on the PCB, for maximum power throughput
 - USB port, integrated
-- (*) serial connection for external DSM2/DSMX sat receiver (e.g. Spektrum SAT, OrangeRx R100 or Lemon RX)
-- alternatively PPM receiver connection (i.e. Deltang Rx31)
+- (*) serial connection for external DSM2/DSMX sat receiver (e.g. Spektrum SAT, OrangeRx R100, Lemon RX or Deltang Rx31)
 - ground and 3.3V for the receiver
 - hardware bind plug for easy binding
 - motor connections are at the corners for a clean look with reduced wiring
 - dimensions: 29x33mm
 - direct operation from an single cell lipoly battery
+- 3.3V LDO power regulator (ALIENWIIF1 only)
+- 3.3V buck-boost power converter (ALIENWIIF3 only)
+- battery monitoring with an white LED for buzzer functionality (ALIENWIIF3 only)
 
 (*) Spektrum Compatible DSM2 satellites are supported out of the box. DSMX sat will work with DSM2 protocol with default settings (DSM2, 11bit, 11ms is preset). 
 

--- a/docs/Board - Sparky.md
+++ b/docs/Board - Sparky.md
@@ -17,11 +17,14 @@ Flyable!
 Tested with revision 1 board. 
 
 ## TODO
-* ADC
 * Sonar
 * Display (via Flex port)
 * SoftSerial - though having 3 hardware serial ports makes it a little redundant.
 * Airplane PWM mappings.
+
+# Voltage and current monitoring (ADC support)
+
+Voltage monitoring is possible when enabled via PWM9 pin and current can be monitored via PWM8 pin. The voltage divider and current sensor need to be connected externally. The vbatscale cli parameter need to be adjusted to fit the sensor specification. For more details regarding the sensor hardware you can check here: https://github.com/TauLabs/TauLabs/wiki/User-Guide:-Battery-Configuration
 
 # Flashing
 
@@ -165,11 +168,11 @@ Flashing cleanflight will erase the TauLabs bootloader, this is not a problem an
 
 # Serial Ports
 
-| Value | Identifier   | RX        | TX         | Notes                                                                                       |
-| ----- | ------------ | --------- | ---------- | ------------------------------------------------------------------------------------------- |
-| 1     | USB VCP      | RX (USB)  | TX (USB)   |  |
-| 2     | USART1       | RX / PB7  | TX / PB6   | Conn1 / Flexi Port. |
-| 3     | USART2       | RX / PA3  | PWM6 / PA2 | On RX is on INPUT header.  Best port for Serial RX input |
+| Value | Identifier   | RX        | TX         | Notes                                                          |
+| ----- | ------------ | --------- | ---------- | -------------------------------------------------------------- |
+| 1     | USB VCP      | RX (USB)  | TX (USB)   |                                                                |
+| 2     | USART1       | RX / PB7  | TX / PB6   | Conn1 / Flexi Port.                                            |
+| 3     | USART2       | RX / PA3  | PWM6 / PA2 | On RX is on INPUT header.  Best port for Serial RX input       |
 | 4     | USART3       | RX / PB11 | TX / PB10  | RX/TX is on one end of the 6-pin header about the PWM outputs. |
 
 USB VCP *can* be used at the same time as other serial ports (unlike Naze32).

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -490,10 +490,11 @@ static void resetConf(void)
     featureSet(FEATURE_RX_SERIAL);
     featureSet(FEATURE_MOTOR_STOP);
     featureSet(FEATURE_FAILSAFE);
-    featureClear(FEATURE_VBAT);
 #ifdef ALIENWIIF3
     masterConfig.serialConfig.portConfigs[2].functionMask = FUNCTION_RX_SERIAL;
+    masterConfig.batteryConfig.vbatscale = 20;
 #else
+    featureClear(FEATURE_VBAT);
     masterConfig.serialConfig.portConfigs[1].functionMask = FUNCTION_RX_SERIAL;
 #endif
     masterConfig.rxConfig.serialrx_provider = 1;

--- a/src/main/target/ALIENWIIF3/target.h
+++ b/src/main/target/ALIENWIIF3/target.h
@@ -25,6 +25,9 @@
 #define LED1_GPIO   GPIOB
 #define LED1_PIN    Pin_5  // Green LEDs - PB5
 #define LED1_PERIPHERAL RCC_AHBPeriph_GPIOB
+#define BEEP_GPIO   GPIOA
+#define BEEP_PIN    Pin_5  // White LEDs - PA5
+#define BEEP_PERIPHERAL RCC_AHBPeriph_GPIOA
 
 #define USABLE_TIMER_CHANNEL_COUNT 11
 
@@ -49,6 +52,7 @@
 
 #define MAG_AK8975_ALIGN CW0_DEG_FLIP
 
+#define BEEPER
 #define LED0
 #define LED1
 
@@ -86,6 +90,16 @@
 #define I2C2_SDA_PIN         GPIO_Pin_10
 #define I2C2_SDA_PIN_SOURCE  GPIO_PinSource10
 #define I2C2_SDA_CLK_SOURCE  RCC_AHBPeriph_GPIOA
+
+#define USE_ADC
+
+#define ADC_INSTANCE         ADC2
+#define ADC_DMA_CHANNEL      DMA2_Channel1
+#define ADC_AHB_PERIPHERAL   RCC_AHBPeriph_DMA2
+
+#define VBAT_ADC_GPIO        GPIOA
+#define VBAT_ADC_GPIO_PIN    GPIO_Pin_4
+#define VBAT_ADC_CHANNEL     ADC_Channel_1
 
 #define BLACKBOX
 #define SERIAL_RX

--- a/src/main/target/ALIENWIIF3/target.h
+++ b/src/main/target/ALIENWIIF3/target.h
@@ -101,9 +101,9 @@
 #define VBAT_ADC_GPIO_PIN    GPIO_Pin_4
 #define VBAT_ADC_CHANNEL     ADC_Channel_1
 
-#define BLACKBOX
+//#define BLACKBOX
 #define SERIAL_RX
-#define GPS
+//#define GPS
 //#define DISPLAY
 #define AUTOTUNE
 #define USE_SERVOS

--- a/src/main/target/SPARKY/target.h
+++ b/src/main/target/SPARKY/target.h
@@ -86,6 +86,20 @@
 #define I2C2_SDA_PIN_SOURCE  GPIO_PinSource10
 #define I2C2_SDA_CLK_SOURCE  RCC_AHBPeriph_GPIOA
 
+#define USE_ADC
+
+#define ADC_INSTANCE                ADC2
+#define ADC_DMA_CHANNEL             DMA2_Channel1
+#define ADC_AHB_PERIPHERAL          RCC_AHBPeriph_DMA2
+
+#define VBAT_ADC_GPIO               GPIOA
+#define VBAT_ADC_GPIO_PIN           GPIO_Pin_4
+#define VBAT_ADC_CHANNEL            ADC_Channel_1
+
+#define CURRENT_METER_ADC_GPIO      GPIOA
+#define CURRENT_METER_ADC_GPIO_PIN  GPIO_Pin_7
+#define CURRENT_METER_ADC_CHANNEL   ADC_Channel_4
+
 #define BLACKBOX
 #define SERIAL_RX
 #define GPS


### PR DESCRIPTION
Voltage monitoring is tested for an AlienWii32 F3 prototype. For Sparky it should also work. Documentation is updated accordingly.

This is related to issue #523