### PR TITLE
^ Multiplying LuxFloat I term by ten to make it tuneable

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -184,7 +184,7 @@ static void pidLuxFloat(pidProfile_t *pidProfile, controlRateConfig_t *controlRa
         // -----calculate P component
         PTerm = RateError * pidProfile->P_f[axis];
         // -----calculate I component
-        errorGyroIf[axis] = constrainf(errorGyroIf[axis] + RateError * dT * pidProfile->I_f[axis], -250.0f, 250.0f);
+        errorGyroIf[axis] = constrainf(errorGyroIf[axis] + RateError * dT * pidProfile->I_f[axis] * 10, -250.0f, 250.0f);
 
         // limit maximum integrator value to prevent WindUp - accumulating extreme values when system is saturated.
         // I coefficient (I8) moved before integration to make limiting independent from PID settings
@@ -391,7 +391,7 @@ static void pidMultiWii23(pidProfile_t *pidProfile, controlRateConfig_t *control
     errorGyroI[FD_YAW]  = constrain(errorGyroI[FD_YAW], 2 - ((int32_t)1 << 28), -2 + ((int32_t)1 << 28));
     if (ABS(rc) > 50) errorGyroI[FD_YAW] = 0;
 
-    PTerm = (int32_t)error * pidProfile->P8[FD_YAW] >> 6;
+    PTerm = (int32_t)error * pidProfile->P8[FD_YAW] >> 6; // TODO: Bitwise shift on a signed integer is not recommended
 
     // Constrain YAW by D value if not servo driven in that case servolimits apply
     if(motorCount > 3) {


### PR DESCRIPTION
The default tuning range for the LuxFloat PID controller is not high enough, meaning that even with the max value in the GUI, it's not possible to get enough I effect.  This change simply multiplies this value by ten, which allows the I component to be tuned effectively.