### PR TITLE
Added support for configurable led colours for armed/unarmed state.

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -477,6 +477,7 @@ static void resetConf(void)
 #ifdef LED_STRIP
     applyDefaultColors(masterConfig.colors, CONFIGURABLE_COLOR_COUNT);
     applyDefaultLedStripConfig(masterConfig.ledConfigs);
+    applyDefaultStateColors(masterConfig.stateColors);
 #endif
 
 #ifdef BLACKBOX

--- a/src/main/config/config_master.h
+++ b/src/main/config/config_master.h
@@ -82,6 +82,7 @@ typedef struct master_t {
 #ifdef LED_STRIP
     ledConfig_t ledConfigs[MAX_LED_STRIP_LENGTH];
     hsvColor_t colors[CONFIGURABLE_COLOR_COUNT];
+    uint8_t stateColors[STATE_COLOR_COUNT];
 #endif
 
     profile_t profile[MAX_PROFILE_COUNT];

--- a/src/main/io/ledstrip.h
+++ b/src/main/io/ledstrip.h
@@ -19,6 +19,7 @@
 
 #define MAX_LED_STRIP_LENGTH 32
 #define CONFIGURABLE_COLOR_COUNT 16
+#define STATE_COLOR_COUNT 2
 
 #define LED_X_BIT_OFFSET 4
 #define LED_Y_BIT_OFFSET 0
@@ -81,8 +82,6 @@ typedef struct ledConfig_s {
 extern uint8_t ledCount;
 extern uint8_t ledsInRingCount;
 
-
-
 bool parseLedStripConfig(uint8_t ledIndex, const char *config);
 void updateLedStrip(void);
 void updateLedRing(void);
@@ -92,6 +91,10 @@ void generateLedConfig(uint8_t ledIndex, char *ledConfigBuffer, size_t bufferSiz
 
 bool parseColor(uint8_t index, const char *colorConfig);
 void applyDefaultColors(hsvColor_t *colors, uint8_t colorCount);
+void applyDefaultStateColors(uint8_t *stateColors);
+
+bool parseStateColor(const char* colorConfig);
+void formatStateColor(uint8_t stateColorIndex, char *stateColorBuffer, size_t bufferSize);
 
 void ledStripEnable(void);
 void reevalulateLedConfig(void);

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -117,6 +117,7 @@ static void cliMap(char *cmdline);
 #ifdef LED_STRIP
 static void cliLed(char *cmdline);
 static void cliColor(char *cmdline);
+static void cliStateColor(char *cmdline);
 #endif
 
 #ifndef USE_QUAD_MIXER_ONLY
@@ -218,6 +219,9 @@ const clicmd_t cmdTable[] = {
     { "servo", "servo config", cliServo },
 #endif
     { "set", "name=value or blank or * for list", cliSet },
+#ifdef LED_STRIP
+    { "state_color", "configure state colors", cliStateColor },
+#endif
     { "status", "show system status", cliStatus },
     { "version", "", cliVersion },
 };
@@ -787,6 +791,23 @@ static void cliColor(char *cmdline)
         }
     }
 }
+
+static void cliStateColor(char* cmdline)
+{
+    uint8_t i;
+    char *ptr;
+    char stateColorBuffer[5];
+
+    if (isEmpty(cmdline)) {
+        for (i = 0; i < STATE_COLOR_COUNT; i++) {
+            formatStateColor(i, stateColorBuffer, sizeof(stateColorBuffer));
+            printf("state_color %s\r\n", stateColorBuffer);
+        }
+    } else {
+        if (!parseStateColor(cmdline))
+            cliPrint("Parse error\r\n");
+    }
+}
 #endif
 
 static void cliServo(char *cmdline)
@@ -1059,6 +1080,9 @@ static void cliDump(char *cmdline)
 
         cliPrint("\r\n\r\n# color\r\n");
         cliColor("");
+
+        cliPrint("\r\n\r\n# state_color\r\n");
+        cliStateColor("");
 #endif
         printSectionBreak();
         dumpValues(MASTER_VALUE);

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -114,7 +114,7 @@ void navigationInit(gpsProfile_t *initialGpsProfile, pidProfile_t *pidProfile);
 bool sensorsAutodetect(sensorAlignmentConfig_t *sensorAlignmentConfig, uint16_t gyroLpf, uint8_t accHardwareToUse, int8_t magHardwareToUse, int16_t magDeclinationFromConfig);
 void imuInit(void);
 void displayInit(rxConfig_t *intialRxConfig);
-void ledStripInit(ledConfig_t *ledConfigsToUse, hsvColor_t *colorsToUse);
+void ledStripInit(ledConfig_t *ledConfigsToUse, hsvColor_t *colorsToUse, uint8_t *stateColorsToUse);
 void loop(void);
 void spektrumBind(rxConfig_t *rxConfig);
 
@@ -372,7 +372,7 @@ void init(void)
 #endif
 
 #ifdef LED_STRIP
-    ledStripInit(masterConfig.ledConfigs, masterConfig.colors);
+    ledStripInit(masterConfig.ledConfigs, masterConfig.colors, masterConfig.stateColors);
 
     if (feature(FEATURE_LED_STRIP)) {
         ledStripEnable();


### PR DESCRIPTION
Added the ability to configure the led colour index to be used for the armed/unarmed state. Colour index can be specified via the CLI using the state_color command with 2 parameters, the first parameter is a letter indicating the state code and the second parameter a colour index. Currently the armed and unarmed state colour index can be set using A and U state codes respectively, but the code could easily be extended to add support for other states such as indicators and warnings.

Example:-

state_color A 10
state_color U 5

Using the state_color command from the CLI without any parameters will output the current configuration as per other CLI commands.
