### PR TITLE
Restore previous rate limit for yaw of 2.55

### DIFF
--- a/src/main/io/rc_controls.h
+++ b/src/main/io/rc_controls.h
@@ -103,10 +103,8 @@ typedef enum {
 // Roll/pitch rates are a proportion used for mixing, so it tops out at 1.0:
 #define CONTROL_RATE_CONFIG_ROLL_PITCH_RATE_MAX  100
 
-/* Meaningful yaw rates are effectively unbounded because they are treated as a rotation rate multiplier,
- * but we'll limit it to 1.0:
- */
-#define CONTROL_RATE_CONFIG_YAW_RATE_MAX         100
+/* Meaningful yaw rates are effectively unbounded because they are treated as a rotation rate multiplier: */
+#define CONTROL_RATE_CONFIG_YAW_RATE_MAX         255
 
 #define CONTROL_RATE_CONFIG_TPA_MAX              100
 

--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -1221,6 +1221,7 @@ static bool processInCommand(void)
 {
     uint32_t i;
     uint16_t tmp;
+    uint8_t rate;
 #ifdef GPS
     uint8_t wp_no;
     int32_t lat = 0, lon = 0, alt = 0;
@@ -1331,9 +1332,11 @@ static bool processInCommand(void)
             currentControlRateProfile->rcRate8 = read8();
             currentControlRateProfile->rcExpo8 = read8();
             for (i = 0; i < 3; i++) {
-                currentControlRateProfile->rates[i] = MIN(read8(), i == FD_YAW ? CONTROL_RATE_CONFIG_YAW_RATE_MAX : CONTROL_RATE_CONFIG_ROLL_PITCH_RATE_MAX);
+                rate = read8();
+                currentControlRateProfile->rates[i] = MIN(rate, i == FD_YAW ? CONTROL_RATE_CONFIG_YAW_RATE_MAX : CONTROL_RATE_CONFIG_ROLL_PITCH_RATE_MAX);
             }
-            currentControlRateProfile->dynThrPID = MIN(read8(), CONTROL_RATE_CONFIG_TPA_MAX);
+            rate = read8();
+            currentControlRateProfile->dynThrPID = MIN(rate, CONTROL_RATE_CONFIG_TPA_MAX);
             currentControlRateProfile->thrMid8 = read8();
             currentControlRateProfile->thrExpo8 = read8();
             currentControlRateProfile->tpa_breakpoint = read16();


### PR DESCRIPTION
Since some people are indeed using yaw > 1.0 (noted on RCGroups).

Also fixes bug in my merged commit where the SET_RC_TUNING message wouldn't be read properly due to the expansion of the MIN() macro.