### PR TITLE
fix for missing AUX1-4 signals on PWM5-8 outputs with LED_STRIP on NAZE

### DIFF
--- a/src/main/drivers/pwm_mapping.c
+++ b/src/main/drivers/pwm_mapping.c
@@ -455,9 +455,17 @@ pwmOutputConfiguration_t *pwmInit(drv_pwm_config_t *init)
         }
 
         if (init->extraServos && !init->airplane) {
-            // remap PWM5..8 as servos when used in extended servo mode
-            if (timerIndex >= PWM5 && timerIndex <= PWM8)
-                type = MAP_TO_SERVO_OUTPUT;
+#if defined(NAZE) && defined(LED_STRIP_TIMER)
+            // if LED strip is active, PWM5-8 are unavailable, so map AUX1+AUX2 to PWM13+PWM14
+            if (init->useLEDStrip) { 
+                if (timerIndex >= PWM13 && timerIndex <= PWM14) {
+                  type = MAP_TO_SERVO_OUTPUT;
+                }
+            } else
+#endif
+                // remap PWM5..8 as servos when used in extended servo mode
+                if (timerIndex >= PWM5 && timerIndex <= PWM8)
+                    type = MAP_TO_SERVO_OUTPUT;
         }
 #endif
 


### PR DESCRIPTION
When LED_STRIP feature is enabled on NAZE32 and gimbal_flags is set to 4 (to forward AUX1-4 to PWM5-8), no PWM waveforms appear on outputs PWM5-8.  This is because the LED driver uses timer TIM3 (also needed for PWM5-8).  As a workaround, this patch will route AUX1/AUX2 to PWM13/PWM14 (channels 5/6 of the headers that connect to ESCs).