### PR TITLE
Fix sparky smartport

### DIFF
--- a/src/main/drivers/serial_uart_stm32f30x.c
+++ b/src/main/drivers/serial_uart_stm32f30x.c
@@ -116,13 +116,15 @@ uartPort_t *serialUSART1(uint32_t baudRate, portMode_t mode, portOptions_t optio
     GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AF;
     GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
     GPIO_InitStructure.GPIO_OType = GPIO_OType_PP;
-    GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_UP;
+    GPIO_InitStructure.GPIO_PuPd = (options & SERIAL_INVERTED) ? GPIO_PuPd_DOWN : GPIO_PuPd_UP;
 
     if (options & SERIAL_BIDIR) {
         GPIO_InitStructure.GPIO_Pin = UART1_TX_PIN;
-        GPIO_InitStructure.GPIO_OType = GPIO_OType_OD;
+        GPIO_InitStructure.GPIO_OType = (options & SERIAL_INVERTED) ? GPIO_OType_PP : GPIO_OType_OD;
         GPIO_PinAFConfig(UART1_GPIO, UART1_TX_PINSOURCE, UART1_GPIO_AF);
         GPIO_Init(UART1_GPIO, &GPIO_InitStructure);
+        if(!(options & SERIAL_INVERTED))
+            GPIO_SetBits(UART1_GPIO, UART1_TX_PIN);   // OpenDrain output should be inactive
     } else {
         if (mode & MODE_TX) {
             GPIO_InitStructure.GPIO_Pin = UART1_TX_PIN;
@@ -195,13 +197,15 @@ uartPort_t *serialUSART2(uint32_t baudRate, portMode_t mode, portOptions_t optio
     GPIO_InitStructure.GPIO_Mode  = GPIO_Mode_AF;
     GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
     GPIO_InitStructure.GPIO_OType = GPIO_OType_PP;
-    GPIO_InitStructure.GPIO_PuPd  = GPIO_PuPd_UP;
+    GPIO_InitStructure.GPIO_PuPd  = (options & SERIAL_INVERTED) ? GPIO_PuPd_DOWN : GPIO_PuPd_UP;
 
     if (options & SERIAL_BIDIR) {
         GPIO_InitStructure.GPIO_Pin = UART2_TX_PIN;
-        GPIO_InitStructure.GPIO_OType = GPIO_OType_OD;
+        GPIO_InitStructure.GPIO_OType = (options & SERIAL_INVERTED) ? GPIO_OType_PP : GPIO_OType_OD;
         GPIO_PinAFConfig(UART2_GPIO, UART2_TX_PINSOURCE, UART2_GPIO_AF);
         GPIO_Init(UART2_GPIO, &GPIO_InitStructure);
+        if(!(options & SERIAL_INVERTED))
+            GPIO_SetBits(UART2_GPIO, UART2_TX_PIN);   // OpenDrain output should be inactive
     } else {
         if (mode & MODE_TX) {
             GPIO_InitStructure.GPIO_Pin = UART2_TX_PIN;
@@ -276,13 +280,15 @@ uartPort_t *serialUSART3(uint32_t baudRate, portMode_t mode, portOptions_t optio
     GPIO_InitStructure.GPIO_Mode  = GPIO_Mode_AF;
     GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
     GPIO_InitStructure.GPIO_OType = GPIO_OType_PP;
-    GPIO_InitStructure.GPIO_PuPd  = GPIO_PuPd_UP;
+    GPIO_InitStructure.GPIO_PuPd  = (options & SERIAL_INVERTED) ? GPIO_PuPd_DOWN : GPIO_PuPd_UP;
 
     if (options & SERIAL_BIDIR) {
         GPIO_InitStructure.GPIO_Pin = UART3_TX_PIN;
-        GPIO_InitStructure.GPIO_OType = GPIO_OType_OD;
+        GPIO_InitStructure.GPIO_OType = (options & SERIAL_INVERTED) ? GPIO_OType_PP : GPIO_OType_OD;
         GPIO_PinAFConfig(UART3_GPIO, UART3_TX_PINSOURCE, UART3_GPIO_AF);
         GPIO_Init(UART3_GPIO, &GPIO_InitStructure);
+        if(!(options & SERIAL_INVERTED))
+            GPIO_SetBits(UART3_GPIO, UART3_TX_PIN);   // OpenDrain output should be inactive
     } else {
         if (mode & MODE_TX) {
             GPIO_InitStructure.GPIO_Pin = UART3_TX_PIN;

--- a/src/main/target/SPARKY/target.h
+++ b/src/main/target/SPARKY/target.h
@@ -91,6 +91,7 @@
 #define GPS
 #define DISPLAY
 #define USE_SERVOS
+#define TELEMETRY
 
 #define LED_STRIP
 #if 1

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -162,10 +162,7 @@ static void smartPortDataReceive(uint16_t c)
     if (lastChar == FSSP_START_STOP) {
         smartPortState = SPSTATE_WORKING;
         smartPortLastRequestTime = now;
-        if ((c == FSSP_SENSOR_ID1) ||
-            (c == FSSP_SENSOR_ID2) ||
-            (c == FSSP_SENSOR_ID3) ||
-            (c == FSSP_SENSOR_ID4)) {
+        if (c == FSSP_SENSOR_ID1) {
             smartPortHasRequest = 1;
             // we only responde to these IDs
             // the X4R-SB does send other IDs, we ignore them, but take note of the time


### PR DESCRIPTION
SBUS + SPORT works on Sparky + FrSky X8R (UART2 sbus; UART3 sport, with `set telemetry_inversion = 1`)