### PR TITLE
Updates sonar so that it can be used together with ADC current meter

### DIFF
--- a/docs/Sonar.md
+++ b/docs/Sonar.md
@@ -14,10 +14,10 @@ Currently the only supported sensor is the HCSR04 sensor.
 
 ### Naze/Flip32+
 
-| Mode          | Trigger       | Echo          | Inline 1k resistors |
-| ------------- | ------------- | ------------- | ------------------- |
-| Parallel PWM  | PB8 / Motor 5 | PB9 / Motor 6 | NO (5v tolerant)    |
-| PPM/Serial RX | PB0 / RC7     | PB1 / RC8     | YES (3.3v input)    |
+| Mode                            | Trigger       | Echo          | Inline 1k resistors |
+| ------------------------------- | ------------- | ------------- | ------------------- |
+| Parallel PWM/ADC current sensor | PB8 / Motor 5 | PB9 / Motor 6 | NO (5v tolerant)    |
+| PPM/Serial RX                   | PB0 / RC7     | PB1 / RC8     | YES (3.3v input)    |
 
 Current meter cannot be used in conjunction with Parallel PWM and Sonar.
 

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -367,7 +367,7 @@ void init(void)
 
 #ifdef SONAR
     if (feature(FEATURE_SONAR)) {
-        sonarInit();
+        sonarInit(&masterConfig.batteryConfig);
     }
 #endif
 

--- a/src/main/sensors/sonar.c
+++ b/src/main/sensors/sonar.c
@@ -37,7 +37,7 @@
 
 static int32_t calculatedAltitude;
 
-void sonarInit(void)
+void sonarInit(batteryConfig_t *batteryConfig)
 {
 #if defined(NAZE) || defined(EUSTM32F103RC) || defined(PORT103R)
     static const sonarHardware_t const sonarPWM56 = {
@@ -54,8 +54,8 @@ void sonarInit(void)
         .exti_pin_source = GPIO_PinSource1,
         .exti_irqn = EXTI1_IRQn
     };
-    // If we are using parallel PWM for our receiver, then use motor pins 5 and 6 for sonar, otherwise use rc pins 7 and 8
-    if (feature(FEATURE_RX_PARALLEL_PWM)) {
+    // If we are using parallel PWM for our receiver or ADC current sensor, then use motor pins 5 and 6 for sonar, otherwise use rc pins 7 and 8
+    if (feature(FEATURE_RX_PARALLEL_PWM ) || (feature(FEATURE_CURRENT_METER) && batteryConfig->currentMeterType == CURRENT_SENSOR_ADC) ) {
         hcsr04_init(&sonarPWM56);
     } else {
         hcsr04_init(&sonarRC78);

--- a/src/main/sensors/sonar.h
+++ b/src/main/sensors/sonar.h
@@ -16,8 +16,9 @@
  */
 
 #pragma once
+#include "sensors/battery.h"
 
-void sonarInit(void);
+void sonarInit(batteryConfig_t *batteryConfig);
 void sonarUpdate(void);
 
 int32_t sonarRead(void);


### PR DESCRIPTION
Check if ADC current sensor is enabled in sonarInit() and change sonar pins to pwm 5 and 6 if it is. Same as when RX_PARALLEL is enabled.