### PR TITLE
FrSky RPM Telemetry Motor_Stop Bugfix

### DIFF
--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -747,7 +747,7 @@ void loop(void)
 
 #ifdef TELEMETRY
     if (!cliMode && feature(FEATURE_TELEMETRY)) {
-        handleTelemetry();
+        handleTelemetry(&masterConfig.rxConfig, masterConfig.flight3DConfig.deadband3d_throttle);
     }
 #endif
 

--- a/src/main/telemetry/frsky.h
+++ b/src/main/telemetry/frsky.h
@@ -15,6 +15,8 @@
  * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "rx/rx.h"
+
 #ifndef TELEMETRY_FRSKY_H_
 #define TELEMETRY_FRSKY_H_
 
@@ -23,7 +25,7 @@ typedef enum {
     FRSKY_VFAS_PRECISION_HIGH
 } frskyVFasPrecision_e;
 
-void handleFrSkyTelemetry(void);
+void handleFrSkyTelemetry(rxConfig_t *rxConfig, uint16_t deadband3d_throttle);
 void checkFrSkyTelemetryState(void);
 
 void initFrSkyTelemetry(telemetryConfig_t *telemetryConfig);

--- a/src/main/telemetry/telemetry.c
+++ b/src/main/telemetry/telemetry.c
@@ -80,9 +80,9 @@ void checkTelemetryState(void)
     checkSmartPortTelemetryState();
 }
 
-void handleTelemetry(void)
+void handleTelemetry(rxConfig_t *rxConfig, uint16_t deadband3d_throttle)
 {
-    handleFrSkyTelemetry();
+    handleFrSkyTelemetry(rxConfig, deadband3d_throttle);
     handleHoTTTelemetry();
     handleMSPTelemetry();
     handleSmartPortTelemetry();

--- a/src/main/telemetry/telemetry.h
+++ b/src/main/telemetry/telemetry.h
@@ -21,6 +21,7 @@
  *  Created on: 6 Apr 2014
  *      Author: Hydra
  */
+#include "rx/rx.h"
 
 #ifndef TELEMETRY_COMMON_H_
 #define TELEMETRY_COMMON_H_
@@ -46,7 +47,7 @@ typedef struct telemetryConfig_s {
 } telemetryConfig_t;
 
 void checkTelemetryState(void);
-void handleTelemetry(void);
+void handleTelemetry(rxConfig_t *rxConfig, uint16_t deadband3d_throttle);
 
 bool determineNewTelemetryEnabledState(portSharing_e portSharing);
 


### PR DESCRIPTION
using calculateThrottleStatus this time, send 0 as RPM when THROTTLE_LOW and
MOTOR_STOP.
rxConfig and deadband3d_throttle are passed from mw.c through telemetry.c

closes #562 

replaces original PR (#577) which I've closed