### PR TITLE
Make failsafe disarm if motors armed and throttle low

### DIFF
--- a/src/main/flight/failsafe.c
+++ b/src/main/flight/failsafe.c
@@ -20,12 +20,20 @@
 
 #include "common/axis.h"
 
+#include "drivers/sensor.h"
+#include "drivers/accgyro.h"
+
+#include "sensors/sensors.h"
+#include "sensors/acceleration.h"
+
 #include "rx/rx.h"
 #include "io/escservo.h"
 #include "io/rc_controls.h"
 #include "config/runtime_config.h"
 
 #include "flight/failsafe.h"
+
+#include "mw.h"
 
 /*
  * Usage:
@@ -44,13 +52,19 @@ static failsafeConfig_t *failsafeConfig;
 
 static rxConfig_t *rxConfig;
 
+/**
+ * Called when valid data is received.  This function resets the
+ * failsafe counter that would otherwise be incremented by
+ * 'failsafeOnRxCycle()'.
+ */
 void failsafeReset(void)
 {
     failsafeState.counter = 0;
 }
 
 /*
- * Should called when the failsafe config needs to be changed - e.g. a different profile has been selected.
+ * Should be called when the failsafe config needs to be changed - e.g.
+ * a different profile has been selected.
  */
 void useFailsafeConfig(failsafeConfig_t *failsafeConfigToUse)
 {
@@ -58,19 +72,23 @@ void useFailsafeConfig(failsafeConfig_t *failsafeConfigToUse)
     failsafeReset();
 }
 
+/**
+ * Initializes the failsafe system.  Should only be called once.
+ */
 failsafeState_t* failsafeInit(rxConfig_t *intialRxConfig)
 {
     rxConfig = intialRxConfig;
 
     failsafeState.events = 0;
     failsafeState.enabled = false;
+    failsafeState.motorsCounter = 0;
 
     return &failsafeState;
 }
 
 bool failsafeIsIdle(void)
-{
-    return failsafeState.counter == 0;
+{             // <= 1 means 'failsafeOnValidDataReceived()' has been called
+    return failsafeState.counter <= 1;
 }
 
 bool failsafeIsEnabled(void)
@@ -105,6 +123,13 @@ static void failsafeAvoidRearm(void)
     ENABLE_ARMING_FLAG(PREVENT_ARMING);
 }
 
+/**
+ * Called when valid data is received.  This function decrements the
+ * failsafe counter that would otherwise be incremented by
+ * 'failsafeOnRxCycle()'.  Similar to 'failsafeReset()' but
+ * this function does a "softer" reset of the counter to make
+ * sure that enough newly-valid data has been received.
+ */
 static void failsafeOnValidDataReceived(void)
 {
     if (failsafeState.counter > 20)
@@ -113,6 +138,10 @@ static void failsafeOnValidDataReceived(void)
         failsafeState.counter = 0;
 }
 
+/**
+ * Called once each time RX data is processed by the system if
+ * the failsafe feature is enabled.
+ */
 void failsafeUpdateState(void)
 {
     uint8_t i;
@@ -126,7 +155,10 @@ void failsafeUpdateState(void)
         return;
     }
 
-    if (failsafeShouldForceLanding(ARMING_FLAG(ARMED))) { // Stabilize, and set Throttle to specified level
+    // if 'failsafe_delay' reached and motors have been
+    // above min throttle then execute failsafe landing
+    if (failsafeState.motorsCounter > 0 &&
+            failsafeShouldForceLanding(ARMING_FLAG(ARMED))) { // Stabilize, and set Throttle to specified level
         failsafeAvoidRearm();
 
         for (i = 0; i < 3; i++) {
@@ -136,17 +168,34 @@ void failsafeUpdateState(void)
         failsafeState.events++;
     }
 
-    if (failsafeShouldHaveCausedLandingByNow() || !ARMING_FLAG(ARMED)) {
+    // if 'failsafe_off_delay' reached or motors have
+    // not been above min throttle then disarm copter
+    if (failsafeShouldHaveCausedLandingByNow() || !ARMING_FLAG(ARMED) ||
+            failsafeState.motorsCounter <= 0) {
         mwDisarm();
     }
 }
 
 /**
  * Should be called once each time RX data is processed by the system.
+ * Increments the failsafe counter, which will be reset if valid data
+ * is received, via 'failsafeOnValidDataReceived()' or 'failsafeReset()'.
  */
 void failsafeOnRxCycle(void)
 {
     failsafeState.counter++;
+
+    // track if motors are staying above min throttle (if not plane)
+    if (!STATE(FIXED_WING)) {
+        if (rcCommand[THROTTLE] > getMasterConfigMinthrottle()) {
+            if (failsafeState.motorsCounter < 300)    // 300 = ~3 seconds
+                ++failsafeState.motorsCounter;
+        }
+        else {
+            if (failsafeState.motorsCounter > 0)
+                --failsafeState.motorsCounter;
+        }
+    }
 }
 
 #define REQUIRED_CHANNEL_MASK 0x0F // first 4 channels
@@ -169,4 +218,3 @@ void failsafeCheckPulse(uint8_t channel, uint16_t pulseDuration)
         failsafeOnValidDataReceived();
     }
 }
-

--- a/src/main/flight/failsafe.h
+++ b/src/main/flight/failsafe.h
@@ -30,6 +30,7 @@ typedef struct failsafeConfig_s {
 
 typedef struct failsafeState_s {
     int16_t counter;
+    int16_t motorsCounter;
     int16_t events;
     bool enabled;
 } failsafeState_t;

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -365,6 +365,12 @@ void mwArm(void)
     }
 }
 
+// Returns configured 'minthrottle' value.
+uint16_t getMasterConfigMinthrottle(void)
+{
+    return masterConfig.escAndServoConfig.minthrottle;
+}
+
 // Automatic ACC Offset Calibration
 bool AccInflightCalibrationArmed = false;
 bool AccInflightCalibrationMeasurementDone = false;

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -265,13 +265,14 @@ void annexCode(void)
             LED0_TOGGLE;
             DISABLE_ARMING_FLAG(OK_TO_ARM);
         }
-
-        if (!STATE(SMALL_ANGLE)) {
+        else if (!STATE(SMALL_ANGLE)) {
             DISABLE_ARMING_FLAG(OK_TO_ARM);
         }
-
-        if (IS_RC_MODE_ACTIVE(BOXAUTOTUNE)) {
+        else if (IS_RC_MODE_ACTIVE(BOXAUTOTUNE)) {
             DISABLE_ARMING_FLAG(OK_TO_ARM);
+        }
+        else if (failsafeHasTimerElapsed()) {  // if failsafe active then
+            DISABLE_ARMING_FLAG(OK_TO_ARM);    // don't allow BOXARM
         }
 
         if (ARMING_FLAG(OK_TO_ARM)) {

--- a/src/main/mw.h
+++ b/src/main/mw.h
@@ -24,3 +24,5 @@ void handleInflightCalibrationStickPosition();
 
 void mwDisarm(void);
 void mwArm(void);
+
+uint16_t getMasterConfigMinthrottle(void);


### PR DESCRIPTION
Currently, if the copter is armed, the throttle has not been raised, and radio contact is lost, a failsafe condition will occur and the motors will be commanded to the 'failsafe_throttle' value.  This is a safety issue, especially if MOTOR_STOP is enabled.  A wonky radio link could cause an unexpected spin-up of motors.  Even if MOTOR_STOP is disabled, there could be a significant increase in motor speed.

What should happen is that if the motors have not been "spun up," the copter should be disarmed.  (Other flight controllers operate this way.)  The easy / lazy way to make this happen would be to the have the failsafe code disarm if the throttle is down (low).  But there could be situations, like long descents or 3D flying, where this could be problematic.

So, what I've implemented is to have the code track the commanded state of the motors.  If the copter is armed and, during the previous three seconds, the motors have been consistently at or below the configured 'min_throttle' value and radio contact is lost, the copter is disarmed.  If the same condition happens except that the motors have been above 'min_throttle', the failsafe "landing" procedure happens.  This should account for situations where the copter is not flying (just disarm), while not being able to cause undesired failsafe-disarms in the air.

I've also fixed an issue with the 'failsafeIsIdle()' function where it would never show failsafe as 'idle' after it had been activated (causing failsafe beeping to continue after radio contact was restored).  The issue seemed to be that the counter was being polled after it was incremented by 'failsafeOnRxCycle()' but before it was reset by 'failsafeReset()' or 'failsafeOnValidDataReceived()'.  And, I improved some of the code documentation, as the logic in "failsafe.c" can be hard to follow.

--ET