### PR TITLE
A fix for bmp085 baro driver not using EOC flag

### DIFF
--- a/src/main/drivers/barometer_bmp085.c
+++ b/src/main/drivers/barometer_bmp085.c
@@ -193,8 +193,10 @@ bool bmp085Detect(const bmp085Config_t *config, baro_t *baro)
         bmp085.al_version = BMP085_GET_BITSLICE(data, BMP085_AL_VERSION); /* get AL Version */
         bmp085_get_cal_param(); /* readout bmp085 calibparam structure */
         bmp085InitDone = true;
-        baro->ut_delay = 6000; // 1.5ms margin according to the spec (4.5ms T convetion time)
-        baro->up_delay = 27000; // 6000+21000=27000 1.5ms margin according to the spec (25.5ms P convetion time with OSS=3)
+        //baro->ut_delay = 6000; // 1.5ms margin according to the spec (4.5ms T convetion time)
+        //baro->up_delay = 27000; // 6000+21000=27000 1.5ms margin according to the spec (25.5ms P convetion time with OSS=3)
+        baro->ut_delay = 10000; // 1.5ms margin according to the spec (4.5ms T convetion time)
+        baro->up_delay = 40000; // 6000+21000=27000 1.5ms margin according to the spec (25.5ms P convetion time with OSS=3)
         baro->start_ut = bmp085_start_ut;
         baro->get_ut = bmp085_get_ut;
         baro->start_up = bmp085_start_up;
@@ -311,9 +313,9 @@ static void bmp085_calculate(int32_t *pressure, int32_t *temperature)
     temp = bmp085_get_temperature(bmp085_ut);
     press = bmp085_get_pressure(bmp085_up);
     if (pressure)
-        *pressure = 100325 + press % 511;//press;
+        *pressure = press;
     if (temperature)
-        *temperature = 2500;//temp;
+        *temperature = temp;
 }
 
 static void bmp085_get_cal_param(void)

--- a/src/main/drivers/barometer_bmp085.c
+++ b/src/main/drivers/barometer_bmp085.c
@@ -285,8 +285,10 @@ static void bmp085_get_ut(void)
 
 #if defined(BARO) && defined(BARO_EOC_GPIO)
     // wait in case of cockup
-    if (!convDone)
+    if (!convDone) {
         convOverrun++;
+        return; // keep old value
+    }
 #endif
 
     i2cRead(BMP085_I2C_ADDR, BMP085_ADC_OUT_MSB_REG, 2, data);
@@ -316,8 +318,10 @@ static void bmp085_get_up(void)
 
 #if defined(BARO) && defined(BARO_EOC_GPIO)
     // wait in case of cockup
-    if (!convDone)
+    if (!convDone) {
         convOverrun++;
+        return; // keep old value
+    }
 #endif
 
     i2cRead(BMP085_I2C_ADDR, BMP085_ADC_OUT_MSB_REG, 3, data);

--- a/src/main/drivers/barometer_bmp085.c
+++ b/src/main/drivers/barometer_bmp085.c
@@ -195,16 +195,8 @@ bool bmp085Detect(const bmp085Config_t *config, baro_t *baro)
         bmp085.al_version = BMP085_GET_BITSLICE(data, BMP085_AL_VERSION); /* get AL Version */
         bmp085_get_cal_param(); /* readout bmp085 calibparam structure */
         bmp085InitDone = true;
-        
-#if defined(BARO_EOC_GPIO)        
-        // Stick to datasheet, EOC interrupt will handle the possible cockup in hardware
         baro->ut_delay = 6000; // 1.5ms margin according to the spec (4.5ms T conversion time)
         baro->up_delay = 27000; // 6000+21000=27000 1.5ms margin according to the spec (25.5ms P conversion time with OSS=3)
-#else
-        // Increase margins to minimise chance of bad data when conversion takes longer than usual (issue #569)
-        baro->ut_delay = 10000; // 4ms margin (4.5ms T conversion time)
-        baro->up_delay = 40000; // 25500+14500=27000 + 14.5ms margin (25.5ms P conversion time with OSS=3)
-#endif
         baro->start_ut = bmp085_start_ut;
         baro->get_ut = bmp085_get_ut;
         baro->start_up = bmp085_start_up;

--- a/src/main/drivers/barometer_bmp085.c
+++ b/src/main/drivers/barometer_bmp085.c
@@ -311,9 +311,9 @@ static void bmp085_calculate(int32_t *pressure, int32_t *temperature)
     temp = bmp085_get_temperature(bmp085_ut);
     press = bmp085_get_pressure(bmp085_up);
     if (pressure)
-        *pressure = press;
+        *pressure = 100325 + press % 511;//press;
     if (temperature)
-        *temperature = temp;
+        *temperature = 2500;//temp;
 }
 
 static void bmp085_get_cal_param(void)


### PR DESCRIPTION
Partially fixes issue #569 when bad values are being read from bmp085 due to the fact that sometimes pressure conversion takes longer than specified in the datasheet.