### PR TITLE
Add failsafe-test TX-AUX-switch mode

### DIFF
--- a/src/main/flight/failsafe.c
+++ b/src/main/flight/failsafe.c
@@ -20,12 +20,20 @@
 
 #include "common/axis.h"
 
+#include "drivers/sensor.h"
+#include "drivers/accgyro.h"
+
+#include "sensors/sensors.h"
+#include "sensors/acceleration.h"
+
 #include "rx/rx.h"
 #include "io/escservo.h"
 #include "io/rc_controls.h"
 #include "config/runtime_config.h"
 
 #include "flight/failsafe.h"
+
+#include "mw.h"
 
 /*
  * Usage:
@@ -44,13 +52,19 @@ static failsafeConfig_t *failsafeConfig;
 
 static rxConfig_t *rxConfig;
 
+/**
+ * Called when valid data is received.  This function resets the
+ * failsafe counter that would otherwise be incremented by
+ * 'failsafeOnRxCycle()'.
+ */
 void failsafeReset(void)
 {
     failsafeState.counter = 0;
 }
 
 /*
- * Should called when the failsafe config needs to be changed - e.g. a different profile has been selected.
+ * Should be called when the failsafe config needs to be changed - e.g.
+ * a different profile has been selected.
  */
 void useFailsafeConfig(failsafeConfig_t *failsafeConfigToUse)
 {
@@ -58,19 +72,23 @@ void useFailsafeConfig(failsafeConfig_t *failsafeConfigToUse)
     failsafeReset();
 }
 
+/**
+ * Initializes the failsafe system.  Should only be called once.
+ */
 failsafeState_t* failsafeInit(rxConfig_t *intialRxConfig)
 {
     rxConfig = intialRxConfig;
 
     failsafeState.events = 0;
     failsafeState.enabled = false;
+    failsafeState.motorsCounter = 0;
 
     return &failsafeState;
 }
 
 bool failsafeIsIdle(void)
-{
-    return failsafeState.counter == 0;
+{             // <= 1 means 'failsafeOnValidDataReceived()' has been called
+    return failsafeState.counter <= 1;
 }
 
 bool failsafeIsEnabled(void)
@@ -105,6 +123,13 @@ static void failsafeAvoidRearm(void)
     ENABLE_ARMING_FLAG(PREVENT_ARMING);
 }
 
+/**
+ * Called when valid data is received.  This function decrements the
+ * failsafe counter that would otherwise be incremented by
+ * 'failsafeOnRxCycle()'.  Similar to 'failsafeReset()' but
+ * this function does a "softer" reset of the counter to make
+ * sure that enough newly-valid data has been received.
+ */
 static void failsafeOnValidDataReceived(void)
 {
     if (failsafeState.counter > 20)
@@ -113,6 +138,10 @@ static void failsafeOnValidDataReceived(void)
         failsafeState.counter = 0;
 }
 
+/**
+ * Called once each time RX data is processed by the system if
+ * the failsafe feature is enabled.
+ */
 void failsafeUpdateState(void)
 {
     uint8_t i;
@@ -126,7 +155,10 @@ void failsafeUpdateState(void)
         return;
     }
 
-    if (failsafeShouldForceLanding(ARMING_FLAG(ARMED))) { // Stabilize, and set Throttle to specified level
+    // if 'failsafe_delay' reached and motors have been
+    // above min throttle then execute failsafe landing
+    if (failsafeState.motorsCounter > 0 &&
+            failsafeShouldForceLanding(ARMING_FLAG(ARMED))) { // Stabilize, and set Throttle to specified level
         failsafeAvoidRearm();
 
         for (i = 0; i < 3; i++) {
@@ -136,17 +168,34 @@ void failsafeUpdateState(void)
         failsafeState.events++;
     }
 
-    if (failsafeShouldHaveCausedLandingByNow() || !ARMING_FLAG(ARMED)) {
+    // if 'failsafe_off_delay' reached or motors have
+    // not been above min throttle then disarm copter
+    if (failsafeShouldHaveCausedLandingByNow() || !ARMING_FLAG(ARMED) ||
+            failsafeState.motorsCounter <= 0) {
         mwDisarm();
     }
 }
 
 /**
  * Should be called once each time RX data is processed by the system.
+ * Increments the failsafe counter, which will be reset if valid data
+ * is received, via 'failsafeOnValidDataReceived()' or 'failsafeReset()'.
  */
 void failsafeOnRxCycle(void)
 {
     failsafeState.counter++;
+
+    // track if motors are staying above min throttle (if not plane)
+    if (!STATE(FIXED_WING)) {
+        if (rcCommand[THROTTLE] > getMasterConfigMinthrottle()) {
+            if (failsafeState.motorsCounter < 300)    // 300 = ~3 seconds
+                ++failsafeState.motorsCounter;
+        }
+        else {
+            if (failsafeState.motorsCounter > 0)
+                --failsafeState.motorsCounter;
+        }
+    }
 }
 
 #define REQUIRED_CHANNEL_MASK 0x0F // first 4 channels
@@ -169,4 +218,3 @@ void failsafeCheckPulse(uint8_t channel, uint16_t pulseDuration)
         failsafeOnValidDataReceived();
     }
 }
-

--- a/src/main/flight/failsafe.h
+++ b/src/main/flight/failsafe.h
@@ -30,6 +30,7 @@ typedef struct failsafeConfig_s {
 
 typedef struct failsafeState_s {
     int16_t counter;
+    int16_t motorsCounter;
     int16_t events;
     bool enabled;
 } failsafeState_t;

--- a/src/main/io/rc_controls.h
+++ b/src/main/io/rc_controls.h
@@ -43,6 +43,7 @@ typedef enum {
     BOXTELEMETRY,
     BOXAUTOTUNE,
     BOXSONAR,
+    BOXFAILSAFE,
     CHECKBOX_ITEM_COUNT
 } boxId_e;
 

--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -337,6 +337,7 @@ static const box_t const boxes[CHECKBOX_ITEM_COUNT + 1] = {
     { BOXTELEMETRY, "TELEMETRY;", 20 },
     { BOXAUTOTUNE, "AUTOTUNE;", 21 },
     { BOXSONAR, "SONAR;", 22 },
+    { BOXFAILSAFE, "FAILSAFE;", 23 },
     { CHECKBOX_ITEM_COUNT, NULL, 0xFF }
 };
 
@@ -691,6 +692,9 @@ void mspInit(serialConfig_t *serialConfig)
         activeBoxIds[activeBoxIdCount++] = BOXSONAR;
     }
 
+    if (feature(FEATURE_FAILSAFE))
+        activeBoxIds[activeBoxIdCount++] = BOXFAILSAFE;
+
     memset(mspPorts, 0x00, sizeof(mspPorts));
     mspAllocateSerialPorts(serialConfig);
 }
@@ -811,6 +815,7 @@ static bool processOutCommand(uint8_t cmdMSP)
             IS_ENABLED(IS_RC_MODE_ACTIVE(BOXTELEMETRY)) << BOXTELEMETRY |
             IS_ENABLED(IS_RC_MODE_ACTIVE(BOXAUTOTUNE)) << BOXAUTOTUNE |
             IS_ENABLED(FLIGHT_MODE(SONAR_MODE)) << BOXSONAR |
+            IS_ENABLED(IS_RC_MODE_ACTIVE(BOXFAILSAFE)) << BOXFAILSAFE |
             IS_ENABLED(ARMING_FLAG(ARMED)) << BOXARM;
         for (i = 0; i < activeBoxIdCount; i++) {
             int flag = (tmp & (1 << activeBoxIds[i]));

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -365,6 +365,12 @@ void mwArm(void)
     }
 }
 
+// Returns configured 'minthrottle' value.
+uint16_t getMasterConfigMinthrottle(void)
+{
+    return masterConfig.escAndServoConfig.minthrottle;
+}
+
 // Automatic ACC Offset Calibration
 bool AccInflightCalibrationArmed = false;
 bool AccInflightCalibrationMeasurementDone = false;

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -265,13 +265,14 @@ void annexCode(void)
             LED0_TOGGLE;
             DISABLE_ARMING_FLAG(OK_TO_ARM);
         }
-
-        if (!STATE(SMALL_ANGLE)) {
+        else if (!STATE(SMALL_ANGLE)) {
             DISABLE_ARMING_FLAG(OK_TO_ARM);
         }
-
-        if (IS_RC_MODE_ACTIVE(BOXAUTOTUNE)) {
+        else if (IS_RC_MODE_ACTIVE(BOXAUTOTUNE)) {
             DISABLE_ARMING_FLAG(OK_TO_ARM);
+        }
+        else if (failsafeHasTimerElapsed()) {  // if failsafe active then
+            DISABLE_ARMING_FLAG(OK_TO_ARM);    // don't allow BOXARM
         }
 
         if (ARMING_FLAG(OK_TO_ARM)) {

--- a/src/main/mw.h
+++ b/src/main/mw.h
@@ -24,3 +24,5 @@ void handleInflightCalibrationStickPosition();
 
 void mwDisarm(void);
 void mwArm(void);
+
+uint16_t getMasterConfigMinthrottle(void);


### PR DESCRIPTION
Adds a new TX-AUX-switch mode named FAILSAFE for testing of failsafe functionality.  This allows the operator to simulate a failsafe without turning off the transmitter, and regain control instantly by resetting the TX switch.

This PR also has the "failsafe disarm motors armed throttle low" (#717) changes.

--ET