### PR TITLE
fix voltage calculation for smartport telemetry

### DIFF
--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -322,8 +322,7 @@ void handleSmartPortTelemetry(void)
                 break;
 #endif
             case FSSP_DATAID_VFAS       :
-                smartPortSendPackage(id, vbat * 83); // supposedly given in 0.1V, unknown requested unit
-                // multiplying by 83 seems to make Taranis read correctly
+                smartPortSendPackage(id, vbat * 10); // given in 0.1V, convert to volts
                 smartPortHasRequest = 0;
                 break;
             case FSSP_DATAID_CURRENT    :


### PR DESCRIPTION
Correct voltage calculation for smartport telemetry

see also:

https://github.com/cleanflight/cleanflight/commit/0000d3e65e85b3d31412b0125a336618c6aac686#commitcomment-10682832