### PR TITLE
Move wiki pages to docs folder

### DIFF
--- a/docs/development/Building in Eclipse.md
+++ b/docs/development/Building in Eclipse.md
@@ -1,0 +1,49 @@
+# Short Version
+Install the latest Eclipse Standard/SDK and install the **C/C++ developments Tools** plugins
+![plugin eclipse](http://i.imgur.com/IdJ8ki1.png)
+
+Import the project using the wizard **Existing Code as Makefile Project**
+![](http://i.imgur.com/XsVCwe2.png)
+
+Adjust your build option if necessary
+![](https://camo.githubusercontent.com/64a1d32400d6be64dd4b5d237df1e7f1b817f61b/687474703a2f2f692e696d6775722e636f6d2f6641306d30784d2e706e67)
+
+Make sure you have a valid ARM toolchain in the path
+![](http://i.imgur.com/dAbscJo.png)
+
+# Long version
+* First you need an ARM toolchain. Good choices are **GCC ARM Embedded** (https://launchpad.net/gcc-arm-embedded) or **Yagarto** (http://www.yagarto.de).
+* Now download Eclipse and unpack it somewhere. At the time of writing Eclipse 4.2 was the latest stable version.
+* To work with ARM projects in Eclipse you need a few plugins:
+	+ **Eclipse C Development Tools** (CDT) (available via *Help > Install new Software*).
+	+ **Zylin Embedded CDT Plugin** (http://opensource.zylin.com/embeddedcdt.html).
+	+ **GNU ARM Eclipse** (http://sourceforge.net/projects/gnuarmeclipse/).
+	+ If you want to hook up an SWD debugger you also need the **GDB Hardware Debugging** plugin (Also available via *Install new Software*).
+* Now clone the project to your harddrive.
+* Create a new C project in Eclipse and choose ARM Cross Target Application and your ARM toolchain.
+* Import the Git project into the C project in Eclipse via *File > Import > General > File System*.
+* Activate Git via *Project > Team > Share Project*.
+* Switch to the master branch in Eclipse (*Project > Team > Switch To > master*).
+* The next thing you need to do is adjust the project configuration. There is a Makefile included that works but you might want to use GNU ARM Eclipse's automatic Makefile generation. Open the Project configuration and go to *C/C++ Build > Settings*
+	* Under *Target Processor* choose "cortex-m3"
+	* Under *ARM Yagarto [Windows/Mac OS] Linker > General* (or whatever toolchain you chose)
+		+ Browse to the Script file *stm32_flash.ld*
+		+ Uncheck "Do not use standard start files"
+		+ Check "Remove unused sections"	
+	* Under *ARM Yagarto [Windows/Mac OS] Linker > Libraries*
+		+ Add "m" for the math library
+	* Under *ARM Yagarto [Windows/Mac OS] Compiler > Preprocessor* add the following 2 items to "Defined Symbols":
+		+ STM32F10X_MD
+		+ USE_STDPERIPH_DRIVER
+	* Under *ARM Yagarto [Windows/Mac OS] Compiler > Directories* add the following 3 items
+		+ ${workspace_loc:/${ProjName}/lib/CMSIS/CM3/CoreSupport}
+		+ ${workspace_loc:/${ProjName}/lib/CMSIS/CM3/DeviceSupport/ST/STM32F10x}
+		+ ${workspace_loc:/${ProjName}/lib/STM32F10x_StdPeriph_Driver/inc}
+	* Under *ARM Yagarto [Windows/Mac OS] Compiler > Miscellaneous* add the following item to "Other flags":
+		+ -fomit-frame-pointer
+* The code in the support directory is for uploading firmware to the board and is meant for your host machine. Hence, it must not be included in the build process. Just right-click on it to open its properties and choose "Exclude from build" under *C/C++ Build > Settings*
+* The last thing you need to do is adding your toolchain to the PATH environment variable.
+	+ Go to *Project > Properties > C/C++ Build > Environment*, add a variable named "PATH" and fill in the full path of your toolchain's binaries.
+	+ Make sure "Append variables to native environment" is selected.		   
+* Try to build the project via *Project > Build Project*.
+* **Note**: If you're getting "...could not be resolved" errors for data types like int32_t etc. try to disable and re-enable the Indexer under *Project > Properties > C/C++ General > Indexer*.

--- a/docs/development/Hardware Debugging in Eclipse.md
+++ b/docs/development/Hardware Debugging in Eclipse.md
@@ -1,0 +1,169 @@
+# Hardware
+
+Various debugging hardware solutions exist, the Segger J-Link clones are cheap and are known to work on Windows with both the Naze and Olimexino platforms.
+
+USB-MiniJTAG J-Link JTAG/SWD Debugger/Emulator
+
+http://www.hotmcu.com/usbminijtag-jlink-jtagswd-debuggeremula%E2%80%8Btor-p-29.html?cPath=3_25&zenid=fdefvpnod186umrhsek225dc10
+
+![](https://raw.github.com/wiki/hydra/cleanflight/images/hardware/THAOYU USB-MiniJTAG.jpg)
+
+ARM-JTAG-20-10 adapter
+
+https://www.olimex.com/Products/ARM/JTAG/ARM-JTAG-20-10/
+http://uk.farnell.com/jsp/search/productdetail.jsp?sku=2144328
+
+![](https://raw.github.com/wiki/hydra/cleanflight/images/hardware/OLIMEX ARM-JTAG ADAPTER 2144328-40.jpg)
+
+The Segger J-Link server can be obtained from here
+
+http://www.segger.com/jlink-software.html
+
+# Build with DEBUG=GDB
+
+## Naze target (default)
+
+### via Command line
+
+```
+make clean TARGET=NAZE
+make TARGET=NAZE DEBUG=GDB
+```
+
+### via Eclipse make target
+
+![](https://raw.github.com/wiki/hydra/cleanflight/images/eclipse-gdb-debugging/make 2 - NAZE GDB.PNG)
+
+
+### via configuration
+use this method if you want to build automatically when launching the debug configuration
+
+![make debug](http://i.imgur.com/fA0m0xM.png)
+
+## Olimexino target
+
+### via command line
+```
+make clean TARGET=OLIMEXINO
+make TARGET=OLIMEXINO DEBUG=GDB
+```
+
+### via Eclipse make target
+
+![](https://raw.github.com/wiki/hydra/cleanflight/images/eclipse-gdb-debugging/make 1 - OLIMEXINO GDB.PNG)
+
+# GDB and OpenOCD
+
+start openocd:
+
+      openocd -f /usr/share/openocd/scripts/board/stm32vldiscovery.cfg
+
+Create a new debug configuration in eclipse :
+![connect to openocd](http://i.imgur.com/somJLnq.png)
+![use workspace default](http://i.imgur.com/LTtioaF.png)
+
+you can control openocd with a telnet connection:
+
+     telnet localhost 4444
+
+stop the board, flash the firmware, restart:
+
+     reset halt
+     wait_halt 
+     sleep 100
+     poll
+     flash probe 0
+     flash write_image erase /home/user/git/cleanflight/obj/cleanflight_NAZE.hex 0x08000000
+     sleep 200
+     soft_reset_halt
+     wait_halt
+     poll
+     reset halt
+
+A this point you can launch the debug in Eclispe.
+![](http://i.imgur.com/u7wDgxv.png)
+
+# GDB and J Link
+
+Here are some screenshots showing Hydra's configuration of Eclipse (Kepler)
+
+If you use cygwin to build the binaries then be sure to have configured your common `Source Lookup Path`, `Path Mappings` first, like this:
+
+![](https://raw.github.com/wiki/cleanflight/cleanflight/images/eclipse-gdb-debugging/config 7.PNG)
+
+
+Create a new `GDB Hardware Debugging` launch configuration from the `Run` menu
+
+It's important to have build the executable compiled with GDB debugging information first.
+Select the appropriate .elf file (not hex file) - In these examples the target platform is an OLIMEXINO, not a naze32.
+
+DISABLE auto-build
+
+![](https://raw.github.com/wiki/cleanflight/cleanflight/images/eclipse-gdb-debugging/config 1.PNG)
+
+Choose the appropriate gdb executable - ideally from the same toolchain that you use to build the executable.
+
+![](https://raw.github.com/wiki/cleanflight/cleanflight/images/eclipse-gdb-debugging/config 2.PNG)
+
+Configure Startup as follows
+
+Initialization commands
+
+```
+target remote localhost:2331
+monitor interface SWD
+monitor speed 2000
+monitor flash device = STM32F103RB
+monitor flash download = 1
+monitor flash breakpoints = 1
+monitor endian little
+monitor reset
+```
+
+
+![](https://raw.github.com/wiki/cleanflight/cleanflight/images/eclipse-gdb-debugging/config 3.PNG)
+
+![](https://raw.github.com/wiki/cleanflight/cleanflight/images/eclipse-gdb-debugging/config 4.PNG)
+
+It may be useful to specify run commands too:
+
+```
+monitor reg r13 = (0x00000000)
+monitor reg pc = (0x00000004)
+continue
+```
+
+![](https://raw.github.com/wiki/cleanflight/cleanflight/images/eclipse-gdb-debugging/config 13.PNG)
+
+If you use cygwin an additional entry should be shown on the Source tab (not present in this screenshot)
+
+![](https://raw.github.com/wiki/cleanflight/cleanflight/images/eclipse-gdb-debugging/config 5.PNG)
+
+Nothing to change from the defaults on the Common tab
+
+![](https://raw.github.com/wiki/cleanflight/cleanflight/images/eclipse-gdb-debugging/config 6.PNG)
+
+Start up the J-Link server in USB mode
+
+![](https://raw.github.com/wiki/cleanflight/cleanflight/images/eclipse-gdb-debugging/config 9.PNG)
+
+If it connects to your target device it should look like this
+
+![](https://raw.github.com/wiki/cleanflight/cleanflight/images/eclipse-gdb-debugging/config 10.PNG)
+
+From Eclipse launch the application using the Run/Debug Configurations..., Eclipse should upload the compiled file to the target device which looks like this
+ 
+![](https://raw.github.com/wiki/cleanflight/cleanflight/images/eclipse-gdb-debugging/config 11.PNG)
+
+When it's running the J-Link server should look like this.
+
+![](https://raw.github.com/wiki/cleanflight/cleanflight/images/eclipse-gdb-debugging/config 12.PNG)
+
+Then finally you can use Eclipse debug features to inspect variables, memory, stacktrace, set breakpoints, step over code, etc.
+
+![](https://raw.github.com/wiki/cleanflight/cleanflight/images/eclipse-gdb-debugging/debugging.PNG)
+
+If Eclipse can't find your breakpoints and they are ignored then check your path mappings (if using cygwin) or use the other debugging launcher as follows.  Note the 'Select other...' at the bottom of the configuration window.
+
+![](https://raw.github.com/wiki/cleanflight/cleanflight/images/eclipse-gdb-debugging/config 8 - If breakpoints do not work.PNG)
+

--- a/docs/development/Hardware Debugging.md
+++ b/docs/development/Hardware Debugging.md
@@ -2,11 +2,13 @@
 
 The code can be compiled with debugging information, you can then upload a debug version to a board via a JLink/St-Link debug adapter and step through the code in your IDE.
 
-More information about the necessary hardware can and setting up the eclipse IDE can be found int the wiki:
-https://github.com/cleanflight/cleanflight/wiki/Debugging-in-Eclipse
+More information about the necessary hardware and setting up the eclipse IDE can be found [here](Hardware Debugging in Eclipse.md)
 
 A guide for visual studio can be found here:
 http://visualgdb.com/tutorials/arm/st-link/
+
+This video is also helpful in understanding the proces:
+https://www.youtube.com/watch?v=kjvqySyNw20
 
 ## Compilation options
 


### PR DESCRIPTION
Since the documentation is all located in the docs folder and only the Buidling in Eclipse and Hardware Debugging pages are in the wiki, it would be nice to consolidate the information on hardware debugging.

This would move all wiki content to the docs/development folder.