### PR TITLE
Fix tri_unarmed_servo (was broken by pid_at_min_throttle changes)

### DIFF
--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -702,7 +702,9 @@ void loop(void)
         // If we're armed, at minimum throttle, and we do arming via the
         // sticks, do not process yaw input from the rx.  We do this so the
         // motors do not spin up while we are trying to arm or disarm.
-        if (isUsingSticksForArming() && rcData[THROTTLE] <= masterConfig.rxConfig.mincheck) {
+        // Allow yaw control for tricopters if the user wants the servo to move even when unarmed.
+        if (isUsingSticksForArming() && rcData[THROTTLE] <= masterConfig.rxConfig.mincheck
+                && !(masterConfig.mixerMode == MIXER_TRI && masterConfig.mixerConfig.tri_unarmed_servo)) {
             rcCommand[YAW] = 0;
         }
 


### PR DESCRIPTION
The changes made in 1.8.0 to support `pid_at_min_throttle` prevented `tri_unarmed_servo=1` from having any effect. Here's what the yaw control worked like on 1.7.2:

<table>
<tr><th colspan="5">Is yaw control of the tricopter allowed? 1.7.2</th></tr>
<tr><th></th><th colspan="2">Disarmed</th><th colspan="2">Armed</th></tr>
<tr><th></th><th>Throttle low</th><th>Throttle normal</th><th>Throttle low</th><th>Throttle normal</th></tr>
<tr><td rowspan="2">tri_unarmed_servo = 0</td><td>No</td><td>No</td><td>Yes</td><td>Yes</td></tr>
<tr><td>No</td><td>No</td><td>Yes</td><td>Yes</td></tr>
<tr><td rowspan="2">tri_unarmed_servo = 1</td><td>Yes</td><td>Yes</td><td>Yes</td><td>Yes</td></tr>
<tr><td>Yes</td><td>Yes</td><td>Yes</td><td>Yes</td></tr>
</table>

The current behaviour on 1.8.1 is (tri_unarmed_servo is broken):

<table>
<tr><th colspan="5">Is yaw control of the tricopter allowed? 1.8.1</th></tr>
<tr><th></th><th colspan="2">Disarmed</th><th colspan="2">Armed</th></tr>
<tr><th></th><th>Throttle low</th><th>Throttle normal</th><th>Throttle low</th><th>Throttle normal</th></tr>
<tr><td rowspan="2">tri_unarmed_servo = 0</td><td>No</td><td>No</td><td>No</td><td>Yes</td></tr>
<tr><td>No</td><td>No</td><td>No</td><td>Yes</td></tr>
<tr><td rowspan="2">tri_unarmed_servo = 1</td><td>No</td><td>Yes</td><td>No</td><td>Yes</td></tr>
<tr><td>No</td><td>Yes</td><td>No</td><td>Yes</td></tr>
</table>

This fix brings us to this:

<table>
<tr><th colspan="5">Is yaw control of the tricopter allowed? Proposed</th></tr>
<tr><th></th><th colspan="2">Disarmed</th><th colspan="2">Armed</th></tr>
<tr><th></th><th>Throttle low</th><th>Throttle normal</th><th>Throttle low</th><th>Throttle normal</th></tr>
<tr><td rowspan="2">tri_unarmed_servo = 0</td><td>No</td><td>No</td><td>No</td><td>Yes</td></tr>
<tr><td>No</td><td>No</td><td>No</td><td>Yes</td></tr>
<tr><td rowspan="2">tri_unarmed_servo = 1</td><td>Yes</td><td>Yes</td><td>Yes</td><td>Yes</td></tr>
<tr><td>Yes</td><td>Yes</td><td>Yes</td><td>Yes</td></tr>
</table>

Tricopter pilots on #785 have tested out this proposed functionality and are enjoying it! Closes #785 