### PR TITLE
This fix is for avoiding yaw overshoot and bounce back for some configurations

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -180,6 +180,8 @@ static void resetPidProfile(pidProfile_t *pidProfile)
     pidProfile->I8[PIDVEL] = 45;
     pidProfile->D8[PIDVEL] = 1;
 
+    pidProfile->yaw_p_limit = 0;
+
     pidProfile->P_f[ROLL] = 2.5f;     // new PID with preliminary defaults test carefully
     pidProfile->I_f[ROLL] = 0.6f;
     pidProfile->D_f[ROLL] = 0.06f;
@@ -317,6 +319,7 @@ void resetRcControlsConfig(rcControlsConfig_t *rcControlsConfig) {
 void resetMixerConfig(mixerConfig_t *mixerConfig) {
     mixerConfig->pid_at_min_throttle = 1;
     mixerConfig->yaw_direction = 1;
+    mixerConfig->yaw_jump_prevention_limit = 0;
 #ifdef USE_SERVOS
     mixerConfig->tri_unarmed_servo = 1;
     mixerConfig->servo_lowpass_freq = 400;

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -564,9 +564,9 @@ void mixTable(void)
 {
     uint32_t i;
 
-    if (motorCount > 3) {
+    if (motorCount >= 4 &&  mixerConfig->yaw_jump_prevention_limit) {
         // prevent "yaw jump" during yaw correction
-        axisPID[YAW] = constrain(axisPID[YAW], -100 - ABS(rcCommand[YAW]), +100 + ABS(rcCommand[YAW]));
+        axisPID[YAW] = constrain(axisPID[YAW], -mixerConfig->yaw_jump_prevention_limit - ABS(rcCommand[YAW]), mixerConfig->yaw_jump_prevention_limit + ABS(rcCommand[YAW]));
     }
 
     // motors for non-servo mixes

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -66,7 +66,7 @@ typedef struct mixer_t {
 typedef struct mixerConfig_s {
     uint8_t pid_at_min_throttle;            // when enabled pids are used at minimum throttle
     int8_t yaw_direction;
-    int8_t yaw_jump_prevention_limit;       // make limit configurable (original fixed value was 100)
+    uint16_t yaw_jump_prevention_limit;      // make limit configurable (original fixed value was 100)
 #ifdef USE_SERVOS
     uint8_t tri_unarmed_servo;              // send tail servo correction pulses even when unarmed
     int16_t servo_lowpass_freq;             // lowpass servo filter frequency selection; 1/1000ths of loop freq

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -66,6 +66,7 @@ typedef struct mixer_t {
 typedef struct mixerConfig_s {
     uint8_t pid_at_min_throttle;            // when enabled pids are used at minimum throttle
     int8_t yaw_direction;
+    int8_t yaw_jump_prevention_limit;       // make limit configurable (original fixed value was 100)
 #ifdef USE_SERVOS
     uint8_t tri_unarmed_servo;              // send tail servo correction pulses even when unarmed
     int16_t servo_lowpass_freq;             // lowpass servo filter frequency selection; 1/1000ths of loop freq

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -47,6 +47,7 @@ typedef struct pidProfile_s {
     float A_level;
     float H_level;
     uint8_t H_sensitivity;
+    uint16_t yaw_p_limit;                   // set P term limit (fixed value was 300)
 } pidProfile_t;
 
 #define DEGREES_TO_DECIDEGREES(angle) (angle * 10)

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -387,7 +387,7 @@ const clivalue_t valueTable[] = {
 
     { "pid_at_min_throttle",        VAR_UINT8  | MASTER_VALUE, &masterConfig.mixerConfig.pid_at_min_throttle, 0, 1 },
     { "yaw_direction",              VAR_INT8   | MASTER_VALUE, &masterConfig.mixerConfig.yaw_direction, -1, 1 },
-    { "yaw_jump_prevention_limit",  VAR_INT8   | MASTER_VALUE, &masterConfig.mixerConfig.yaw_jump_prevention_limit, 0, 250 },
+    { "yaw_jump_prevention_limit",  VAR_UINT16 | MASTER_VALUE, &masterConfig.mixerConfig.yaw_jump_prevention_limit, 0, 500 },
 #ifdef USE_SERVOS
     { "tri_unarmed_servo",          VAR_INT8   | MASTER_VALUE, &masterConfig.mixerConfig.tri_unarmed_servo, 0, 1 },
     { "servo_lowpass_freq",         VAR_INT16  | MASTER_VALUE, &masterConfig.mixerConfig.servo_lowpass_freq, 10, 400},

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -387,6 +387,7 @@ const clivalue_t valueTable[] = {
 
     { "pid_at_min_throttle",        VAR_UINT8  | MASTER_VALUE, &masterConfig.mixerConfig.pid_at_min_throttle, 0, 1 },
     { "yaw_direction",              VAR_INT8   | MASTER_VALUE, &masterConfig.mixerConfig.yaw_direction, -1, 1 },
+    { "yaw_jump_prevention_limit",  VAR_INT8   | MASTER_VALUE, &masterConfig.mixerConfig.yaw_jump_prevention_limit, 0, 250 },
 #ifdef USE_SERVOS
     { "tri_unarmed_servo",          VAR_INT8   | MASTER_VALUE, &masterConfig.mixerConfig.tri_unarmed_servo, 0, 1 },
     { "servo_lowpass_freq",         VAR_INT16  | MASTER_VALUE, &masterConfig.mixerConfig.servo_lowpass_freq, 10, 400},
@@ -469,6 +470,8 @@ const clivalue_t valueTable[] = {
     { "p_vel",                      VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.P8[PIDVEL], 0, 200 },
     { "i_vel",                      VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.I8[PIDVEL], 0, 200 },
     { "d_vel",                      VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.D8[PIDVEL], 0, 200 },
+
+    { "yaw_p_limit",                VAR_UINT16 | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.yaw_p_limit, 0, 500 },
 
 #ifdef BLACKBOX
     { "blackbox_rate_num",          VAR_UINT8  | MASTER_VALUE,  &masterConfig.blackbox_rate_num, 1, 32 },


### PR DESCRIPTION
The hardcoded limit in the mixer and PID controllers 3-5 would be removed
by default and will be configurable by CLI variables:

yaw_jump_prevention_limit, global setting (original fixed value was 100)
yaw_p_limit, per profile setting (fixed value was 300)

The following CLI commands will set the exact behavior as before the change if there is someone relying on this limiters.

set yaw_jump_prevention_limit = 100
set  yaw_p_limit = 300