### PR TITLE
Fixes to merged refactored beeper code

### DIFF
--- a/src/main/flight/failsafe.c
+++ b/src/main/flight/failsafe.c
@@ -75,8 +75,6 @@ failsafePhase_e failsafePhase()
     return failsafeState.phase;
 }
 
-#define MAX_COUNTER_VALUE_WHEN_RX_IS_RECEIVED_AFTER_RX_CYCLE 1
-
 bool failsafeIsReceivingRxData(void)
 {
     return failsafeState.counter <= MAX_COUNTER_VALUE_WHEN_RX_IS_RECEIVED_AFTER_RX_CYCLE;
@@ -154,15 +152,18 @@ void failsafeUpdateState(void)
 
         switch (failsafeState.phase) {
             case FAILSAFE_IDLE:
-                if (!receivingRxData && armed) {
-                    failsafeState.phase = FAILSAFE_RX_LOSS_DETECTED;
+                if (!receivingRxData) {
+                    beeper(BEEPER_TX_LOST);      //beep even if disarmed
+                    if (armed) {
+                        failsafeState.phase = FAILSAFE_RX_LOSS_DETECTED;
 
-                    reprocessState = true;
+                        reprocessState = true;
+                    }
                 }
                 break;
 
             case FAILSAFE_RX_LOSS_DETECTED:
-                beeper(BEEPER_TX_LOST_ARMED);
+                beeper(BEEPER_TX_LOST);
 
                 if (failsafeShouldForceLanding(armed)) {
                     // Stabilize, and set Throttle to specified level
@@ -173,6 +174,8 @@ void failsafeUpdateState(void)
                 break;
 
             case FAILSAFE_LANDING:
+                beeper(BEEPER_TX_LOST_LANDING);
+
                 if (armed) {
                     failsafeApplyControlInput();
                 }
@@ -187,7 +190,6 @@ void failsafeUpdateState(void)
                 break;
 
             case FAILSAFE_LANDED:
-
                 beeper(BEEPER_TX_LOST);
 
                 if (!armed) {

--- a/src/main/flight/failsafe.h
+++ b/src/main/flight/failsafe.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #define FAILSAFE_POWER_ON_DELAY_US (1000 * 1000 * 5)
+#define MAX_COUNTER_VALUE_WHEN_RX_IS_RECEIVED_AFTER_RX_CYCLE 10
 
 typedef struct failsafeConfig_s {
     uint8_t failsafe_delay;                 // Guard time for failsafe activation after signal lost. 1 step = 0.1sec - 1sec in example (10)

--- a/src/main/io/beeper.c
+++ b/src/main/io/beeper.c
@@ -174,7 +174,7 @@ void beeper(uint8_t mode)
             beeperPtr = beep_3shortBeeps;
             beeperMode = mode;
             break;
-        case BEEPER_TX_LOST_ARMED:
+        case BEEPER_TX_LOST_LANDING:
             beeperPtr = beep_sos;
             beeperMode = mode;
             beeperNextToggleTime = 0;

--- a/src/main/io/beeper.h
+++ b/src/main/io/beeper.h
@@ -24,8 +24,8 @@ uint32_t getArmingBeepTimeMicros(void);
 
 /* Beeper different modes: (lower number is higher priority)
  * BEEPER_STOP - Stops beeping
- * BEEPER_TX_LOST_ARMED - Beeps SOS when armed and TX is turned off or signal lost (autolanding/autodisarm)
- * BEEPER_TX_LOST - Beeps when TX is turned off or signal lost (repeat until TX is okay)
+ * BEEPER_TX_LOST_LANDING - Beeps SOS when armed, TX signal lost and autolanding in progress
+ * BEEPER_TX_LOST - Beeps when TX signal lost (repeat until TX is okay)
  * BEEPER_DISARMING - Beep when disarming the board
  * BEEPER_ARMING - Beep when arming the board
  * BEEPER_ARMING_GPS_FIX - Beep a tone when arming the board and GPS has fix
@@ -42,7 +42,7 @@ uint32_t getArmingBeepTimeMicros(void);
  */
 enum {
     BEEPER_STOP = 0, // Highest priority command which is used only for stopping the beeper
-    BEEPER_TX_LOST_ARMED,
+    BEEPER_TX_LOST_LANDING,
     BEEPER_TX_LOST,
     BEEPER_DISARMING,
     BEEPER_ARMING,

--- a/src/test/unit/flight_failsafe_unittest.cc
+++ b/src/test/unit/flight_failsafe_unittest.cc
@@ -197,7 +197,11 @@ TEST(FlightFailsafeTest, TestFailsafeDetectsRxLossAndStartsLanding)
         failsafeUpdateState();
 
         // then
-        EXPECT_EQ(FAILSAFE_RX_LOSS_DETECTED, failsafePhase());
+        if (i < MAX_COUNTER_VALUE_WHEN_RX_IS_RECEIVED_AFTER_RX_CYCLE-1) {
+            EXPECT_EQ(FAILSAFE_IDLE, failsafePhase());
+        } else {
+            EXPECT_EQ(FAILSAFE_RX_LOSS_DETECTED, failsafePhase());
+        }
         EXPECT_EQ(false, failsafeIsActive());
 
     }
@@ -312,6 +316,10 @@ bool feature(uint32_t mask) {
 
 void mwDisarm(void) {
     callCounts[COUNTER_MW_DISARM]++;
+}
+
+void beeper(uint8_t mode) {
+    UNUSED(mode);
 }
 
 }


### PR DESCRIPTION
Followup to PR #730 

There were failsafe tones sounding all the time while the copter was armed.  The fix was to increase the MAX_COUNTER_VALUE_WHEN_RX_IS_RECEIVED_AFTER_RX_CYCLE value.  At 3 it was marginal (occasional tones), to I went with 10.  I also moved it to "failsafe.h" to support "flight_failsafe_unittest.cc".

The failsafe tones were not sounding during auto-landing; fix was to add "beeper(BEEPER_TX_LOST_ARMED)" to "case FAILSAFE_LANDING".

To get the RX-lost tone while copter disarmed, I changed "case FAILSAFE_IDLE" to call "beeper(BEEPER_TX_LOST)".

I renamed BEEPER_TX_LOST_ARMED to BEEPER_TX_LOST_LANDING to improve clarity.

In "flight_failsafe_unittest.cc" I modified 'TestFailsafeDetectsRxLossAndStartsLanding' to use the MAX_COUNTER_VALUE_WHEN_RX_IS_RECEIVED_AFTER_RX_CYCLE value.  Seems to be compiling and running OK now.

(One other thing I noticed is that in "failsafe.c" it looks like 'failsafeState.monitoring' is setup but not used.)

--ET