### PR TITLE
Improved tricopter yaw for PID controller 0 (MultiWii)

### DIFF
--- a/src/main/config/config.h
+++ b/src/main/config/config.h
@@ -41,7 +41,8 @@ typedef enum {
     FEATURE_LED_STRIP = 1 << 16,
     FEATURE_DISPLAY = 1 << 17,
     FEATURE_ONESHOT125 = 1 << 18,
-    FEATURE_BLACKBOX = 1 << 19
+    FEATURE_BLACKBOX = 1 << 19,
+    FEATURE_NEW_TRICOPTER_YAW = 1 << 20
 } features_e;
 
 bool feature(uint32_t mask);

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -45,6 +45,7 @@
 #include "flight/imu.h"
 
 #include "config/runtime_config.h"
+#include "config/config.h"
 
 int16_t accSmooth[XYZ_AXIS_COUNT];
 int32_t accSum[XYZ_AXIS_COUNT];
@@ -315,7 +316,7 @@ void imuUpdate(rollAndPitchTrims_t *accelerometerTrims, uint8_t mixerMode)
     gyroData[FD_ROLL] = gyroADC[FD_ROLL];
     gyroData[FD_PITCH] = gyroADC[FD_PITCH];
 
-    if (mixerMode == MIXER_TRI) {
+    if (!feature(FEATURE_NEW_TRICOPTER_YAW && mixerMode == MIXER_TRI)) {
         gyroData[FD_YAW] = (gyroYawSmooth * 2 + gyroADC[FD_YAW]) / 3;
         gyroYawSmooth = gyroData[FD_YAW];
     } else {

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -316,7 +316,7 @@ void imuUpdate(rollAndPitchTrims_t *accelerometerTrims, uint8_t mixerMode)
     gyroData[FD_ROLL] = gyroADC[FD_ROLL];
     gyroData[FD_PITCH] = gyroADC[FD_PITCH];
 
-    if (!feature(FEATURE_NEW_TRICOPTER_YAW && mixerMode == MIXER_TRI)) {
+    if (!feature(FEATURE_NEW_TRICOPTER_YAW) && mixerMode == MIXER_TRI) {
         gyroData[FD_YAW] = (gyroYawSmooth * 2 + gyroADC[FD_YAW]) / 3;
         gyroYawSmooth = gyroData[FD_YAW];
     } else {

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -44,6 +44,7 @@
 #include "flight/autotune.h"
 
 #include "config/runtime_config.h"
+#include "config/config.h"
 
 extern uint16_t cycleTime;
 extern uint8_t motorCount;
@@ -262,8 +263,13 @@ static void pidMultiWii(pidProfile_t *pidProfile, controlRateConfig_t *controlRa
             PTermGYRO = rcCommand[axis];
 
             errorGyroI[axis] = constrain(errorGyroI[axis] + error, -16000, +16000); // WindUp
-            if ((ABS(gyroData[axis]) > (640 * 4)) || (axis == FD_YAW && ABS(rcCommand[axis]) > 100))
-                errorGyroI[axis] = 0;
+	    if (!feature(FEATURE_NEW_TRICOPTER_YAW) && ((ABS(gyroData[axis]) > (640 * 4)) || (axis == FD_YAW && ABS(rcCommand[axis]) > 100))) {
+		errorGyroI[axis] = 0;
+	    } else {
+            	if (feature(FEATURE_NEW_TRICOPTER_YAW) && rcData[THROTTLE] < rxConfig->mincheck) {
+                	errorGyroI[axis] = 0;
+		}
+	    } 
 
             ITermGYRO = (errorGyroI[axis] / 125 * pidProfile->I8[axis]) / 64;
         }

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -155,7 +155,7 @@ static const char * const featureNames[] = {
     "SERVO_TILT", "SOFTSERIAL", "GPS", "FAILSAFE",
     "SONAR", "TELEMETRY", "CURRENT_METER", "3D", "RX_PARALLEL_PWM",
     "RX_MSP", "RSSI_ADC", "LED_STRIP", "DISPLAY", "ONESHOT125",
-    "BLACKBOX", NULL
+    "BLACKBOX", "NEW_TRICOPTER_YAW", NULL
 };
 
 #ifndef CJMCU

--- a/src/test/unit/flight_imu_unittest.cc
+++ b/src/test/unit/flight_imu_unittest.cc
@@ -38,6 +38,7 @@ extern "C" {
     #include "sensors/barometer.h"
 
     #include "config/runtime_config.h"
+    #include "config/config.h"
 
     #include "rx/rx.h"
 

--- a/src/test/unit/flight_imu_unittest.cc
+++ b/src/test/unit/flight_imu_unittest.cc
@@ -122,3 +122,7 @@ bool isBaroCalibrationComplete(void) { return true; }
 void performBaroCalibrationCycle(void) {}
 int32_t baroCalculateAltitude(void) { return 0; }
 }
+
+bool feature(uint32_t mask) {
+return (mask & testFeatureMask);
+}

--- a/src/test/unit/flight_imu_unittest.cc
+++ b/src/test/unit/flight_imu_unittest.cc
@@ -50,6 +50,8 @@ extern "C" {
 #include "unittest_macros.h"
 #include "gtest/gtest.h"
 
+uint32_t testFeatureMask = 0;
+
 #define DOWNWARDS_THRUST true
 #define UPWARDS_THRUST false
 
@@ -121,8 +123,10 @@ uint32_t micros(void) { return 0; }
 bool isBaroCalibrationComplete(void) { return true; }
 void performBaroCalibrationCycle(void) {}
 int32_t baroCalculateAltitude(void) { return 0; }
-}
 
 bool feature(uint32_t mask) {
 return (mask & testFeatureMask);
 }
+
+}
+


### PR DESCRIPTION
I have been working with David Windestål to improve the yaw error control for tricopters and this is the result. Enabling the feature NEW_TRICOPTER_YAW, via the CLI, it will remove the yaw gyro smoothing in imu.c and, when using PID controller 0 (MultiWii), it will not reset the yaw I term if you are commanding the tricopter to yaw.  This is close to the way the KK control loop works and now provides a much better, "locked in" feel.  David has extensively test flown this modification and is extremely happy with it.