### PR TITLE
 Free up USART2 while using PPM on Sparky

### DIFF
--- a/docs/Board - Sparky.md
+++ b/docs/Board - Sparky.md
@@ -176,6 +176,11 @@ USB VCP *can* be used at the same time as other serial ports (unlike Naze32).
 
 All USART ports all support automatic hardware inversion which allows direct connection of serial rx receivers like the FrSky X4RSB - no external inverter needed.
 
+# PPM RX
+
+| Pin  | Signal | Function        |
+| ---- | ------ | --------------- |
+| PWM10| PA1    | PPM Input       |
 
 # Battery Monitoring Connections
 

--- a/src/main/drivers/pwm_mapping.c
+++ b/src/main/drivers/pwm_mapping.c
@@ -243,7 +243,7 @@ static const uint16_t airPWM[] = {
 
 #if defined(SPARKY) || defined(ALIENWIIF3)
 static const uint16_t multiPPM[] = {
-    PWM11 | (MAP_TO_PPM_INPUT << 8), // PPM input
+    PWM10 | (MAP_TO_PPM_INPUT << 8), // PPM input
 
     PWM1  | (MAP_TO_MOTOR_OUTPUT << 8), // TIM15
     PWM2  | (MAP_TO_MOTOR_OUTPUT << 8), // TIM15
@@ -254,7 +254,7 @@ static const uint16_t multiPPM[] = {
     PWM7  | (MAP_TO_MOTOR_OUTPUT << 8), // TIM3
     PWM8  | (MAP_TO_MOTOR_OUTPUT << 8), // TIM17
     PWM9  | (MAP_TO_MOTOR_OUTPUT << 8), // TIM3
-    PWM10 | (MAP_TO_MOTOR_OUTPUT << 8), // TIM2
+//  PWM10 | (MAP_TO_MOTOR_OUTPUT << 8), // TIM2
     0xFFFF
 };
 

--- a/src/main/drivers/timer.c
+++ b/src/main/drivers/timer.c
@@ -196,7 +196,7 @@ const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
     { TIM3,  GPIOB, Pin_1,  TIM_Channel_4, TIM3_IRQn,               0, Mode_AF_PP, GPIO_PinSource1,  GPIO_AF_2}, // PWM7  - PB1  - *TIM3_CH4, TIM1_CH3N, TIM8_CH3N
     { TIM17, GPIOA, Pin_7,  TIM_Channel_1, TIM1_TRG_COM_TIM17_IRQn, 1, Mode_AF_PP, GPIO_PinSource7,  GPIO_AF_1}, // PWM8  - PA7  - !TIM3_CH2, *TIM17_CH1, TIM1_CH1N, TIM8_CH1
     { TIM3,  GPIOA, Pin_4,  TIM_Channel_2, TIM3_IRQn,               0, Mode_AF_PP, GPIO_PinSource4,  GPIO_AF_2}, // PWM9  - PA4  - *TIM3_CH2
-    { TIM2,  GPIOA, Pin_1,  TIM_Channel_2, TIM2_IRQn,               0, Mode_AF_PP, GPIO_PinSource1,  GPIO_AF_1}, // PWM10 - PA1  - *TIM2_CH2, TIM15_CH1N
+    { TIM2,  GPIOA, Pin_1,  TIM_Channel_2, TIM2_IRQn,               0, Mode_AF_PP_PD, GPIO_PinSource1,  GPIO_AF_1}, // PWM10 - PA1  - *TIM2_CH2, TIM15_CH1N
 
     //
     // PPM PORT - Also USART2 RX (AF5)


### PR DESCRIPTION
This moves the PPM pin off UART2 so UART2 can be used for other things while using PPM on the Sparky board. Remap is to PWM10. Docs are also updated to show the change for PPM. UART2 can be used for RX only.

This is a resubmit of PR #  808. (Had to do do cleanup on my repo)

Original closed PR can be found here...
https://github.com/cleanflight/cleanflight/pull/808