### PR TITLE
SmartPort - Some fixes

### DIFF
--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -161,8 +161,8 @@ static void smartPortDataReceive(uint16_t c)
     static uint8_t lastChar;
     if (lastChar == FSSP_START_STOP) {
         smartPortState = SPSTATE_WORKING;
-        smartPortLastRequestTime = now;
-        if (c == FSSP_SENSOR_ID1) {
+        if (c == FSSP_SENSOR_ID1 && (serialTotalBytesWaiting(smartPortSerialPort) == 0)) {
+            smartPortLastRequestTime = now;
             smartPortHasRequest = 1;
             // we only responde to these IDs
             // the X4R-SB does send other IDs, we ignore them, but take note of the time

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -299,7 +299,7 @@ void handleSmartPortTelemetry(void)
     if ((now - smartPortLastServiceTime) < SMARTPORT_SERVICE_DELAY_MS)
         return;
 
-    if (smartPortHasRequest) {
+    while (smartPortHasRequest) {
         // we can send back any data we want, our table keeps track of the order and frequency of each data type we send
         uint16_t id = frSkyDataIdTable[smartPortIdCnt];
         if (id == 0) { // end of table reached, loop back
@@ -469,7 +469,7 @@ void handleSmartPortTelemetry(void)
 #endif
             default:
                 break;
-                // if nothing is sent, smartPortHasRequest isn't cleared, we already incremented the counter, just wait for the next loop
+                // if nothing is sent, smartPortHasRequest isn't cleared, we already incremented the counter, just loop back to the start
         }
     }
 }

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -322,21 +322,29 @@ void handleSmartPortTelemetry(void)
                 break;
 #endif
             case FSSP_DATAID_VFAS       :
-                smartPortSendPackage(id, vbat * 10); // given in 0.1V, convert to volts
-                smartPortHasRequest = 0;
+                if (feature(FEATURE_VBAT)) {
+                    smartPortSendPackage(id, vbat * 10); // given in 0.1V, convert to volts
+                    smartPortHasRequest = 0;
+                }
                 break;
             case FSSP_DATAID_CURRENT    :
-                smartPortSendPackage(id, amperage); // given in 10mA steps, unknown requested unit
-                smartPortHasRequest = 0;
+                if (feature(FEATURE_CURRENT_METER)) {
+                    smartPortSendPackage(id, amperage); // given in 10mA steps, unknown requested unit
+                    smartPortHasRequest = 0;
+                }
                 break;
             //case FSSP_DATAID_RPM        :
             case FSSP_DATAID_ALTITUDE   :
-                smartPortSendPackage(id, BaroAlt); // unknown given unit, requested 100 = 1 meter
-                smartPortHasRequest = 0;
+                if (sensors(SENSOR_BARO)) {
+                    smartPortSendPackage(id, BaroAlt); // unknown given unit, requested 100 = 1 meter
+                    smartPortHasRequest = 0;
+                }
                 break;
             case FSSP_DATAID_FUEL       :
-                smartPortSendPackage(id, mAhDrawn); // given in mAh, unknown requested unit
-                smartPortHasRequest = 0;
+                if (feature(FEATURE_CURRENT_METER)) {
+                    smartPortSendPackage(id, mAhDrawn); // given in mAh, unknown requested unit
+                    smartPortHasRequest = 0;
+                }
                 break;
             //case FSSP_DATAID_ADC1       :
             //case FSSP_DATAID_ADC2       :
@@ -369,8 +377,10 @@ void handleSmartPortTelemetry(void)
 #endif
             //case FSSP_DATAID_CAP_USED   :
             case FSSP_DATAID_VARIO      :
-                smartPortSendPackage(id, vario); // unknown given unit but requested in 100 = 1m/s
-                smartPortHasRequest = 0;
+                if (sensors(SENSOR_BARO)) {
+                    smartPortSendPackage(id, vario); // unknown given unit but requested in 100 = 1m/s
+                    smartPortHasRequest = 0;
+                }
                 break;
             case FSSP_DATAID_HEADING    :
                 smartPortSendPackage(id, heading * 100); // given in deg, requested in 10000 = 100 deg
@@ -444,7 +454,7 @@ void handleSmartPortTelemetry(void)
                     smartPortHasRequest = 0;
 #endif
                 }
-                else {
+                else if (feature(FEATURE_GPS)) {
                     smartPortSendPackage(id, 0);
                     smartPortHasRequest = 0;
                 }


### PR DESCRIPTION
- Suppress messages for disabled features and unavailable sensors (save bandwidth and clutter/storage on OpenTX 2.1)
- Fix stray responses to outdated requests from the receiver (sometimes especially shortly after boot the board would be too slow to service incoming serial data, and subsequent parsing of the buffer would trigger a request when the receiver had already sent IDs other than the one the board is supposed to answer to, leading to the board stepping over someone else's slot and being detected as a new sensor).
- A smart port request is only valid for a few ms, so the current way of looping through the ID list was not valid. One solution would be to just discard the slot and wait for the next one, the other is to loop straight away while we're there. I implemented the latter as the former would cause a loss of bandwidth and the code seems light enough to me not to cause an unacceptable delay, but feel free to correct me if I'm mistaken.
- I removed the service delay that IMO is useless, it was checking that we don't answer twice in <5ms to a request that can't come more frequently than every 12ms in theory anyway (24ms in practice). Again feel free to object and discard the commit if it was only meant as a safety precaution.

Everything now seems to play nice and within spec, including when connected to the same bus with other sensors.
Good job on the implementation BTW, I overhauled my mini H that was still on Baseflight a few weeks ago and wired the smart port to SOFTSERIAL1 without hardware inverter and together with my 40A smart port FrSky current sensor in the way I *thought* it should be good to make it work hoping to get to the implementation at some point, but had no time. When I came back and flashed 1.8.1 it just worked.

![screenshot-2015-04-26-19-07-55](https://cloud.githubusercontent.com/assets/6065069/7337687/fff549aa-ec43-11e4-8d18-1c417560e5eb.jpg)

![screenshot-2015-04-26-19-07-58](https://cloud.githubusercontent.com/assets/6065069/7337688/015e0408-ec44-11e4-86cb-53130319db32.jpg)
