### PR TITLE
Add 'play_sound' CLI command

### DIFF
--- a/docs/Buzzer.md
+++ b/docs/Buzzer.md
@@ -14,6 +14,24 @@ If the arm/disarm is via the control stick, holding the stick in the disarm posi
 
 There is a special arming tone used if a GPS fix has been attained, and there's a "ready" tone sounded after a GPS fix has been attained (only happens once).  The tone sounded via the TX-AUX-switch will count out the number of satellites (if GPS fix).
 
+The CLI command `play_sound` is useful for demonstrating the buzzer tones. Repeatedly entering the command will play the various tones in turn. Entering the command with a numeric-index parameter will play the associated tone.
+
+Available buzzer tones include the following:
+
+    RX_LOST_LANDING       Beeps SOS when armed and TX is turned off or signal lost (autolanding/autodisarm)
+    RX_LOST               Beeps when TX is turned off or signal lost (repeat until TX is okay)
+    DISARMING             Beep when disarming the board
+    ARMING                Beep when arming the board
+    ARMING_GPS_FIX        Beep a special tone when arming the board and GPS has fix
+    BAT_CRIT_LOW          Longer warning beeps when battery is critically low (repeats)
+    BAT_LOW               Warning beeps when battery is getting low (repeats)
+    RX_SET                Beeps when aux channel is set for beep or beep sequence how many satellites has found if GPS enabled
+    DISARM_REPEAT         Beeps sounded while stick held in disarm position
+    ACC_CALIBRATION       ACC inflight calibration completed confirmation
+    ACC_CALIBRATION_FAIL  ACC inflight calibration failed
+    READY_BEEP            Ring a tone when GPS is locked and ready
+    ARMED                 Warning beeps when board is armed (repeats until board is disarmed or throttle is increased)
+
 Buzzer is enabled by default on platforms that have buzzer connections.
 
 ## Types of buzzer supported

--- a/docs/Cli.md
+++ b/docs/Cli.md
@@ -88,6 +88,7 @@ Re-apply any new defaults as desired.
 | map            | mapping of rc channel order                    |
 | mixer          | mixer name or list                             |
 | motor          | get/set motor output value                     |
+| play_sound     | index, or none for next                        |
 | profile        | index (0 to 2)                                 |
 | rateprofile    | index (0 to 2)                                 |
 | save           | save and reboot                                |

--- a/src/main/io/beeper.h
+++ b/src/main/io/beeper.h
@@ -25,17 +25,17 @@ typedef enum {
     BEEPER_RX_LOST,                 // Beeps when TX is turned off or signal lost (repeat until TX is okay)
     BEEPER_DISARMING,               // Beep when disarming the board
     BEEPER_ARMING,                  // Beep when arming the board
-    BEEPER_ARMING_GPS_FIX,          // Beep a tone when arming the board and GPS has fix
-    BEEPER_BAT_CRIT_LOW,            // Faster warning beeps when battery is critically low (repeats)
+    BEEPER_ARMING_GPS_FIX,          // Beep a special tone when arming the board and GPS has fix
+    BEEPER_BAT_CRIT_LOW,            // Longer warning beeps when battery is critically low (repeats)
     BEEPER_BAT_LOW,                 // Warning beeps when battery is getting low (repeats)
     BEEPER_GPS_STATUS,
-    BEEPER_RX_SET,                  // Beeps when aux channel is set for beep or beep sequence how many satellites has found if GPS enabled.
+    BEEPER_RX_SET,                  // Beeps when aux channel is set for beep or beep sequence how many satellites has found if GPS enabled
     BEEPER_DISARM_REPEAT,           // Beeps sounded while stick held in disarm position
     BEEPER_ACC_CALIBRATION,         // ACC inflight calibration completed confirmation
     BEEPER_ACC_CALIBRATION_FAIL,    // ACC inflight calibration failed
-    BEEPER_READY_BEEP,              // Ring a tone when board is ready to flight (GPS ready).
+    BEEPER_READY_BEEP,              // Ring a tone when GPS is locked and ready
     BEEPER_MULTI_BEEPS,             // Internal value used by 'beeperConfirmationBeeps()'.
-    BEEPER_ARMED,                   // Warning beeps when board is armed. (repeats until board is disarmed or throttle is increased)
+    BEEPER_ARMED,                   // Warning beeps when board is armed (repeats until board is disarmed or throttle is increased)
 } beeperMode_e;
 
 void beeper(beeperMode_e mode);
@@ -43,3 +43,6 @@ void beeperSilence(void);
 void beeperUpdate(void);
 void beeperConfirmationBeeps(uint8_t beepCount);
 uint32_t getArmingBeepTimeMicros(void);
+beeperMode_e beeperModeForTableIndex(int idx);
+const char *beeperNameForTableIndex(int idx);
+int beeperTableEntryCount(void);


### PR DESCRIPTION
Added 'play_sound' CLI command, which may be used to demonstrate the buzzer tones. Repeatedly entering the command will play the various tones in turn. Entering the command with a numeric-index parameter will play the associated tone.

Improved ACC_CALIBRATION_FAIL sound (to make it less like ACC_CALIBRATION sound).

Updated docs.

--ET