### PR TITLE
Allow yaw at low throttle for airplane mixes

### DIFF
--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -756,6 +756,8 @@ void loop(void)
         if (isUsingSticksForArming() && rcData[THROTTLE] <= masterConfig.rxConfig.mincheck
 #ifndef USE_QUAD_MIXER_ONLY
                 && !(masterConfig.mixerMode == MIXER_TRI && masterConfig.mixerConfig.tri_unarmed_servo)
+                && masterConfig.mixerMode != MIXER_AIRPLANE
+                && masterConfig.mixerMode != MIXER_FLYING_WING
 #endif
         ) {
             rcCommand[YAW] = 0;


### PR DESCRIPTION
Fixes #824

This restores the 1.7.2 yaw behaviour for aircraft. 