### PR TITLE
Fix for some 1.9.0 boards not booting up

### DIFF
--- a/src/main/drivers/barometer_bmp085.c
+++ b/src/main/drivers/barometer_bmp085.c
@@ -192,29 +192,29 @@ bool bmp085Detect(const bmp085Config_t *config, baro_t *baro)
 
     ack = i2cRead(BMP085_I2C_ADDR, BMP085_CHIP_ID__REG, 1, &data); /* read Chip Id */ 
     if (ack) {
-	    bmp085.chip_id = BMP085_GET_BITSLICE(data, BMP085_CHIP_ID);
-	    bmp085.oversampling_setting = 3;
+        bmp085.chip_id = BMP085_GET_BITSLICE(data, BMP085_CHIP_ID);
+        bmp085.oversampling_setting = 3;
 
-	    if (bmp085.chip_id == BMP085_CHIP_ID) { /* get bitslice */
-		i2cRead(BMP085_I2C_ADDR, BMP085_VERSION_REG, 1, &data); /* read Version reg */
-		bmp085.ml_version = BMP085_GET_BITSLICE(data, BMP085_ML_VERSION); /* get ML Version */
-		bmp085.al_version = BMP085_GET_BITSLICE(data, BMP085_AL_VERSION); /* get AL Version */
-		bmp085_get_cal_param(); /* readout bmp085 calibparam structure */
-		bmp085InitDone = true;
-		baro->ut_delay = 6000; // 1.5ms margin according to the spec (4.5ms T conversion time)
-		baro->up_delay = 27000; // 6000+21000=27000 1.5ms margin according to the spec (25.5ms P conversion time with OSS=3)
-		baro->start_ut = bmp085_start_ut;
-		baro->get_ut = bmp085_get_ut;
-		baro->start_up = bmp085_start_up;
-		baro->get_up = bmp085_get_up;
-		baro->calculate = bmp085_calculate;
-		return true;
-	    }
+        if (bmp085.chip_id == BMP085_CHIP_ID) { /* get bitslice */
+        i2cRead(BMP085_I2C_ADDR, BMP085_VERSION_REG, 1, &data); /* read Version reg */
+        bmp085.ml_version = BMP085_GET_BITSLICE(data, BMP085_ML_VERSION); /* get ML Version */
+        bmp085.al_version = BMP085_GET_BITSLICE(data, BMP085_AL_VERSION); /* get AL Version */
+        bmp085_get_cal_param(); /* readout bmp085 calibparam structure */
+        bmp085InitDone = true;
+        baro->ut_delay = 6000; // 1.5ms margin according to the spec (4.5ms T conversion time)
+        baro->up_delay = 27000; // 6000+21000=27000 1.5ms margin according to the spec (25.5ms P conversion time with OSS=3)
+        baro->start_ut = bmp085_start_ut;
+        baro->get_ut = bmp085_get_ut;
+        baro->start_up = bmp085_start_up;
+        baro->get_up = bmp085_get_up;
+        baro->calculate = bmp085_calculate;
+        return true;
+        }
     }
 
 #ifdef BARO_EOC_GPIO
     EXTI_InitTypeDef EXTI_InitStructure;
-    // Disable EXTI interrupt for barometer EOC
+    EXTI_StructInit(&EXTI_InitStructure);
     EXTI_InitStructure.EXTI_Line = EXTI_Line14;
     EXTI_InitStructure.EXTI_LineCmd = DISABLE;
     EXTI_Init(&EXTI_InitStructure);

--- a/src/main/drivers/barometer_bmp085.c
+++ b/src/main/drivers/barometer_bmp085.c
@@ -149,9 +149,14 @@ void bmp085Disable(const bmp085Config_t *config)
 bool bmp085Detect(const bmp085Config_t *config, baro_t *baro)
 {
     uint8_t data;
+    bool ack;
 
     if (bmp085InitDone)
         return true;
+
+    ack = i2cRead(BMP085_I2C_ADDR, BMP085_CHIP_ID__REG, 1, &data); /* read Chip Id */
+    if(!ack)
+        return false;
 
 #if defined(BARO_XCLR_GPIO) && defined(BARO_EOC_GPIO)
     if (config) {
@@ -187,9 +192,6 @@ bool bmp085Detect(const bmp085Config_t *config, baro_t *baro)
     UNUSED(config);
 #endif
 
-    delay(20); // datasheet says 10ms, we'll be careful and do 20.
-
-    i2cRead(BMP085_I2C_ADDR, BMP085_CHIP_ID__REG, 1, &data); /* read Chip Id */
     bmp085.chip_id = BMP085_GET_BITSLICE(data, BMP085_CHIP_ID);
     bmp085.oversampling_setting = 3;
 

--- a/src/main/drivers/barometer_bmp085.c
+++ b/src/main/drivers/barometer_bmp085.c
@@ -154,6 +154,7 @@ bool bmp085Detect(const bmp085Config_t *config, baro_t *baro)
     if (bmp085InitDone)
         return true;
 
+    delay(20); // datasheet says 10ms, we'll be careful and do 20.
     ack = i2cRead(BMP085_I2C_ADDR, BMP085_CHIP_ID__REG, 1, &data); /* read Chip Id */
     if(!ack)
         return false;

--- a/src/main/drivers/barometer_bmp085.c
+++ b/src/main/drivers/barometer_bmp085.c
@@ -154,11 +154,6 @@ bool bmp085Detect(const bmp085Config_t *config, baro_t *baro)
     if (bmp085InitDone)
         return true;
 
-    delay(20); // datasheet says 10ms, we'll be careful and do 20.
-    ack = i2cRead(BMP085_I2C_ADDR, BMP085_CHIP_ID__REG, 1, &data); /* read Chip Id */
-    if(!ack)
-        return false;
-
 #if defined(BARO_XCLR_GPIO) && defined(BARO_EOC_GPIO)
     if (config) {
         EXTI_InitTypeDef EXTI_InitStructure;
@@ -193,26 +188,37 @@ bool bmp085Detect(const bmp085Config_t *config, baro_t *baro)
     UNUSED(config);
 #endif
 
-    bmp085.chip_id = BMP085_GET_BITSLICE(data, BMP085_CHIP_ID);
-    bmp085.oversampling_setting = 3;
+    delay(20); // datasheet says 10ms, we'll be careful and do 20.
 
-    if (bmp085.chip_id == BMP085_CHIP_ID) { /* get bitslice */
-        i2cRead(BMP085_I2C_ADDR, BMP085_VERSION_REG, 1, &data); /* read Version reg */
-        bmp085.ml_version = BMP085_GET_BITSLICE(data, BMP085_ML_VERSION); /* get ML Version */
-        bmp085.al_version = BMP085_GET_BITSLICE(data, BMP085_AL_VERSION); /* get AL Version */
-        bmp085_get_cal_param(); /* readout bmp085 calibparam structure */
-        bmp085InitDone = true;
-        baro->ut_delay = 6000; // 1.5ms margin according to the spec (4.5ms T conversion time)
-        baro->up_delay = 27000; // 6000+21000=27000 1.5ms margin according to the spec (25.5ms P conversion time with OSS=3)
-        baro->start_ut = bmp085_start_ut;
-        baro->get_ut = bmp085_get_ut;
-        baro->start_up = bmp085_start_up;
-        baro->get_up = bmp085_get_up;
-        baro->calculate = bmp085_calculate;
-        return true;
+    ack = i2cRead(BMP085_I2C_ADDR, BMP085_CHIP_ID__REG, 1, &data); /* read Chip Id */ 
+    if (ack) {
+	    bmp085.chip_id = BMP085_GET_BITSLICE(data, BMP085_CHIP_ID);
+	    bmp085.oversampling_setting = 3;
+
+	    if (bmp085.chip_id == BMP085_CHIP_ID) { /* get bitslice */
+		i2cRead(BMP085_I2C_ADDR, BMP085_VERSION_REG, 1, &data); /* read Version reg */
+		bmp085.ml_version = BMP085_GET_BITSLICE(data, BMP085_ML_VERSION); /* get ML Version */
+		bmp085.al_version = BMP085_GET_BITSLICE(data, BMP085_AL_VERSION); /* get AL Version */
+		bmp085_get_cal_param(); /* readout bmp085 calibparam structure */
+		bmp085InitDone = true;
+		baro->ut_delay = 6000; // 1.5ms margin according to the spec (4.5ms T conversion time)
+		baro->up_delay = 27000; // 6000+21000=27000 1.5ms margin according to the spec (25.5ms P conversion time with OSS=3)
+		baro->start_ut = bmp085_start_ut;
+		baro->get_ut = bmp085_get_ut;
+		baro->start_up = bmp085_start_up;
+		baro->get_up = bmp085_get_up;
+		baro->calculate = bmp085_calculate;
+		return true;
+	    }
     }
 
 #ifdef BARO_EOC_GPIO
+    EXTI_InitTypeDef EXTI_InitStructure;
+    // Disable EXTI interrupt for barometer EOC
+    EXTI_InitStructure.EXTI_Line = EXTI_Line14;
+    EXTI_InitStructure.EXTI_LineCmd = DISABLE;
+    EXTI_Init(&EXTI_InitStructure);
+
     unregisterExti15_10_CallbackHandler(BMP085_EOC_EXTI_Handler);
 #endif
 


### PR DESCRIPTION
Prevents bmp085 interrupts being set up when no bmp085 is present so the board will boot correctly.

Also removed delay(20) as there is already a delay(100) in main.c

Tested on an acro board but not on a board with a baro.