### PR TITLE
Fix HORIZON mode in Pid controller = 1

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -686,7 +686,7 @@ static void pidRewrite(pidProfile_t *pidProfile, controlRateConfig_t *controlRat
                 AngleRateTmp = ((int32_t)(rate + 27) * rcCommand[axis]) >> 4;
                 if (FLIGHT_MODE(HORIZON_MODE)) {
                     // mix up angle error to desired AngleRateTmp to add a little auto-level feel
-                    AngleRateTmp += (errorAngle * pidProfile->I8[PIDLEVEL]) >> 8;
+                    AngleRateTmp += (errorAngle * pidProfile->I8[PIDLEVEL]) >> 4;
                 }
             } else { // it's the ANGLE mode - control is angle based, so control loop is needed
                 AngleRateTmp = (errorAngle * pidProfile->P8[PIDLEVEL]) >> 4;


### PR DESCRIPTION
The I gain was shifted right 8 times (= divide by 256) rather than 4 when used in HORIZON mode, that cause even the max I value of 255 (0.255 in the UI due to the bizzare scaling goin on) be too little levelling...

I fixed this by using a right shift of 4 (divide by 16) like is done for the other leveling gains, to make it useable.

So whatever value you had in your I level gain on PID=1, you now need to re-tune (start by dividing it by 16 to get back to the "old behavior") but it is quite likely you want to turn it up to something close to the same as your leveling gain for ANGLE mode. However, due to the way the UI scales numbers, a P gain of 4.0 is the same as an I gain of 0.04 .... don't ask me why, it's a leftover from MultiWii UI logic..... :) 

In the CLI, the values make sense (and are the same when they are.. the same)