### PR TITLE
Bump API version to 2.0 as 1.10 is smaller than 1.2

### DIFF
--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -130,8 +130,8 @@ void useRcControlsConfig(modeActivationCondition_t *modeActivationConditions, es
 
 #define MSP_PROTOCOL_VERSION                0
 
-#define API_VERSION_MAJOR                   1 // increment when major changes are made
-#define API_VERSION_MINOR                   10 // increment when any change is made, reset to zero when major changes are released after changing API_VERSION_MAJOR
+#define API_VERSION_MAJOR                   2 // increment when major changes are made
+#define API_VERSION_MINOR                   0 // increment when any change is made, reset to zero when major changes are released after changing API_VERSION_MAJOR
 
 #define API_VERSION_LENGTH                  2
 


### PR DESCRIPTION
The version number length
#define API_VERSION_LENGTH                  2

So we need to go to 2 from 1.9 for the configurator