### PR TITLE
AlienWii F1 VBAT fix

### DIFF
--- a/src/main/target/NAZE/target.h
+++ b/src/main/target/NAZE/target.h
@@ -175,6 +175,7 @@
 #ifdef ALIENWII32
 #undef TARGET_BOARD_IDENTIFIER
 #define TARGET_BOARD_IDENTIFIER "AWF1" // AlienWii32 F1.
+#undef BOARD_HAS_VOLTAGE_DIVIDER
 #define HARDWARE_BIND_PLUG
 
 // Hardware bind plug at PB5 (Pin 41)


### PR DESCRIPTION
AlienWii F1 variants don't have an voltage divider. Disable feature
VBAT.