### PR TITLE
Corrected YAW_LOOKUP_LENGTH

### DIFF
--- a/src/main/io/rc_curves.c
+++ b/src/main/io/rc_curves.c
@@ -41,7 +41,7 @@ void generateYawCurve(controlRateConfig_t *controlRateConfig)
 {
     uint8_t i;
 
-    for (i = 0; i < PITCH_LOOKUP_LENGTH; i++)
+    for (i = 0; i < YAW_LOOKUP_LENGTH; i++)
         lookupYawRC[i] = (2500 + controlRateConfig->rcYawExpo8 * (i * i - 25)) * i / 25;
 }
 


### PR DESCRIPTION
Currently uses PITCH_LOOKUP_LENGTH when generating the yaw curve and should be using YAW_LOOKUP_LENGTH.