### PR TITLE
Patch Gimli to fix underscores_inside_words in PDF manuals

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -9,12 +9,20 @@ TARGET_FILE=obj/cleanflight_${TARGET}
 if [ $RUNTESTS ] ; then
 	cd ./src/test && make test
 
-	# A hacky way of running the unit tests at the same time as the normal builds.
+# A hacky way of building the docs at the same time as the normal builds.
 elif [ $PUBLISHDOCS ] ; then
 	if [ $PUBLISH_URL ] ; then
 
 		sudo apt-get install zlib1g-dev libssl-dev wkhtmltopdf libxml2-dev libxslt-dev #ruby-rvm
-    rvmsudo gem install gimli
+		
+		# Patch Gimli to fix underscores_inside_words
+		curl -L https://github.com/walle/gimli/archive/v0.5.9.tar.gz | tar zxf -
+		
+		sed -i 's/).render(/, :no_intra_emphasis => true).render(/' gimli-0.5.9/ext/github_markup.rb
+		
+		cd gimli-0.5.9/
+		gem build gimli.gemspec && rvmsudo gem install gimli
+		cd ../
 
 		./build_docs.sh
 


### PR DESCRIPTION
Previously the words in the centre of a underscores_inside_words compound would be wrapped in &lt;em&gt; tags and the underscores would be removed, this fixes that by tweaking the Markdown dialect.

Fixes #860 