### PR TITLE
Some mods to CLI command interpretation and output

### DIFF
--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -1717,15 +1717,14 @@ void cliProcess(void)
                 bufferIndex = (uint32_t)(p - cliBuffer);
             }
 
+            // Strip trailing whitespace
+            while (bufferIndex > 0 && cliBuffer[bufferIndex - 1] == ' ') {
+                bufferIndex--;
+            }
+
             // Process non-empty lines
             if (bufferIndex > 0) {
-                // Strip trailing whitespace
-                while (bufferIndex > 0 && cliBuffer[bufferIndex - 1] == ' ') {
-                    bufferIndex--;
-                }
-
                 cliBuffer[bufferIndex] = 0; // null terminate
-
                 target.name = cliBuffer;
                 target.param = NULL;
 
@@ -1734,10 +1733,10 @@ void cliProcess(void)
                     cmd->func(cliBuffer + strlen(cmd->name) + 1);
                 else
                     cliPrint("Unknown command, try 'help'");
+                bufferIndex = 0;
             }
 
             memset(cliBuffer, 0, sizeof(cliBuffer));
-            bufferIndex = 0;
 
             // 'exit' will reset this flag, so we don't need to print prompt again
             if (!cliMode)

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -1712,19 +1712,20 @@ void cliProcess(void)
 
             // Strip comment starting with # from line
             char *p = cliBuffer;
-            p = strchr(++p, '#');
+            p = strchr(p, '#');
             if (NULL != p) {
                 bufferIndex = (uint32_t)(p - cliBuffer);
             }
 
-            // Strip trailing whitespace
-            while (bufferIndex > 0 && cliBuffer[bufferIndex - 1] == ' ') {
-                bufferIndex--;
-            }
+            // Process non-empty lines
+            if (bufferIndex > 0) {
+                // Strip trailing whitespace
+                while (bufferIndex > 0 && cliBuffer[bufferIndex - 1] == ' ') {
+                    bufferIndex--;
+                }
 
-            cliBuffer[bufferIndex] = 0; // null terminate
+                cliBuffer[bufferIndex] = 0; // null terminate
 
-            if (cliBuffer[0] != '#') {
                 target.name = cliBuffer;
                 target.param = NULL;
 

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -1644,7 +1644,7 @@ static void cliVersion(char *cmdline)
 {
     UNUSED(cmdline);
 
-    printf("Cleanflight/%s %s %s / %s (%s)",
+    printf("# Cleanflight/%s %s %s / %s (%s)",
         targetName,
         FC_VERSION_STRING,
         buildDate,
@@ -1709,6 +1709,13 @@ void cliProcess(void)
             clicmd_t *cmd = NULL;
             clicmd_t target;
             cliPrint("\r\n");
+
+            // Strip comment starting with # from line
+            char *p = cliBuffer;
+            p = strchr(++p, '#');
+            if (NULL != p) {
+                bufferIndex = (uint32_t)(p - cliBuffer);
+            }
 
             // Strip trailing whitespace
             while (bufferIndex > 0 && cliBuffer[bufferIndex - 1] == ' ') {


### PR DESCRIPTION
Prepended the version string with a # to avoid the CLI from interpreting the version string as a command when pasting a dump file back (restore in CLI). It is the __only__ line written by the dump command that is not a command but does not start with a #.

Strip comments starting with `# comment` from lines. This is to allow adding (per line) comments to CLI dumped backup files. For this i have an automated addition of comments and/or manual comments by the user in mind.