### PR TITLE
Fix for extreme D level term PID1 Horizon

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -680,12 +680,11 @@ static void pidRewrite(pidProfile_t *pidProfile, controlRateConfig_t *controlRat
 
         // PID D Level Term is used for Horizon Sensitivity. It is adjusted so the default value of 100 works pretty well.
         // Default Level D term of 100 equals to 80% sensitivity and 125 and above is 100% sensitivity. It is scaled to prevent too much truncating n integers
-        if(pidProfile->D8[PIDLEVEL] == 0){
-            horizonLevelStrength = 0;
-        } else if (pidProfile->D8[PIDLEVEL] >= 125){
-        	horizonLevelStrength = 100;
+
+        if (pidProfile->D8[PIDLEVEL] >= 125){
+            horizonLevelStrength = constrain((horizonLevelStrength - 100) + 100, 0, 100);
         } else {
-        	horizonLevelStrength = constrain((10 * (horizonLevelStrength - 100) * (10 * pidProfile->D8[PIDLEVEL] / 125) / 100) + 100, 0, 100);
+            horizonLevelStrength = constrain((10 * (horizonLevelStrength - 100) * (10 * pidProfile->D8[PIDLEVEL] / 125) / 100) + 100, 0, 100);
         }
     }
 

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -678,14 +678,9 @@ static void pidRewrite(pidProfile_t *pidProfile, controlRateConfig_t *controlRat
         // Progressively turn off the horizon self level strength as the stick is banged over
         horizonLevelStrength = (500 - mostDeflectedPos) / 5;  // 100 at centre stick, 0 = max stick deflection
 
-        // PID D Level Term is used for Horizon Sensitivity. It is adjusted so the default value of 100 works pretty well.
-        // Default Level D term of 100 equals to 80% sensitivity and 125 and above is 100% sensitivity. It is scaled to prevent too much truncating n integers
-
-        if (pidProfile->D8[PIDLEVEL] >= 125){
-            horizonLevelStrength = constrain((horizonLevelStrength - 100) + 100, 0, 100);
-        } else {
-            horizonLevelStrength = constrain((10 * (horizonLevelStrength - 100) * (10 * pidProfile->D8[PIDLEVEL] / 125) / 100) + 100, 0, 100);
-        }
+        // Using Level D as a Sensitivity for Horizon. 0 more level to 255 more rate. Default value of 100 seems to work fine.
+        // For more rate mode increase D and slower flips and rolls will be possible
+       	horizonLevelStrength = constrain((10 * (horizonLevelStrength - 100) * (10 * pidProfile->D8[PIDLEVEL] / 80) / 100) + 100, 0, 100);
     }
 
     // ----------PID controller----------


### PR DESCRIPTION
Slightly modified code to change the behaviour of the highest and the lowest selectable value for Angle Level D term, which is used for Horizon Sensitivity

Flight tested through the entire Level D range