### PR TITLE
Tidy up the fake lat/long heading tidyup

### DIFF
--- a/src/main/telemetry/frsky.c
+++ b/src/main/telemetry/frsky.c
@@ -313,7 +313,7 @@ static void sendFakeLatLong(void)
     sendLatLong(coord);
 }
 
-static void sendFakeLatLongThaAllowsHeadingDisplay(void)
+static void sendFakeLatLongThatAllowsHeadingDisplay(void)
 {
     // Heading is only displayed on OpenTX if non-zero lat/long is also sent
     int32_t coord[2] = {
@@ -532,10 +532,10 @@ void handleFrSkyTelemetry(rxConfig_t *rxConfig, uint16_t deadband3d_throttle)
             sendGPSLatLong();
         }
         else {
-            sendFakeLatLongThaAllowsHeadingDisplay();
+            sendFakeLatLongThatAllowsHeadingDisplay();
         }
 #else
-        sendFakeLatLong(false);
+        sendFakeLatLongThatAllowsHeadingDisplay();
 #endif
 
         sendTelemetryTail();


### PR DESCRIPTION
After 802218b77bcbcb5ec6d805577998067720c975df, changes a missed invocation of sendFakeLatLong(bool) to sendFakeLatLongThatAllowsHeadingDisplay().

Fixes spelling in sendFakeLatLongThatAllowsHeadingDisplay function name.