### PR TITLE
Initial config of pwm does not use min_command setting

### DIFF
--- a/src/main/main.c
+++ b/src/main/main.c
@@ -227,7 +227,6 @@ void init(void)
     pwm_params.useOneshot = feature(FEATURE_ONESHOT125);
     pwm_params.motorPwmRate = masterConfig.motor_pwm_rate;
     pwm_params.idlePulse = = masterConfig.escAndServoConfig.mincommand;
-    //pwm_params.idlePulse = PULSE_1MS; // standard PWM for brushless ESC (default, overridden below)
     if (feature(FEATURE_3D))
         pwm_params.idlePulse = masterConfig.flight3DConfig.neutral3d;
     if (pwm_params.motorPwmRate > 500)

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -226,7 +226,8 @@ void init(void)
 
     pwm_params.useOneshot = feature(FEATURE_ONESHOT125);
     pwm_params.motorPwmRate = masterConfig.motor_pwm_rate;
-    pwm_params.idlePulse = PULSE_1MS; // standard PWM for brushless ESC (default, overridden below)
+    pwm_params.idlePulse = = masterConfig.escAndServoConfig.mincommand;
+    //pwm_params.idlePulse = PULSE_1MS; // standard PWM for brushless ESC (default, overridden below)
     if (feature(FEATURE_3D))
         pwm_params.idlePulse = masterConfig.flight3DConfig.neutral3d;
     if (pwm_params.motorPwmRate > 500)

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -226,7 +226,7 @@ void init(void)
 
     pwm_params.useOneshot = feature(FEATURE_ONESHOT125);
     pwm_params.motorPwmRate = masterConfig.motor_pwm_rate;
-    pwm_params.idlePulse = = masterConfig.escAndServoConfig.mincommand;
+    pwm_params.idlePulse = masterConfig.escAndServoConfig.mincommand;
     if (feature(FEATURE_3D))
         pwm_params.idlePulse = masterConfig.flight3DConfig.neutral3d;
     if (pwm_params.motorPwmRate > 500)


### PR DESCRIPTION
During boot up ~1sec of pwm is sent out at 1ms pulse width, for most ESC this is not a problem but for some where the min_command is set lower this causes the motors to spin up for ~1sec. 
This is my case where I'm running WiiESC with a 18->2000us range.

This change just initialises the PWM with the configured min_command 

Possible fix for https://github.com/cleanflight/cleanflight/issues/123 as the OP had a min_command of 900.