### PR TITLE
System - Lock active features after init

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -940,9 +940,11 @@ void changeControlRateProfile(uint8_t profileIndex)
 
 void handleOneshotFeatureChangeOnRestart(void)
 {
-    // When OneShot125 feature changed state, shutdown PWM on all motors and apply a delay before
+    // Shutdown PWM on all motors prior to soft restart
+    StopPwmAllMotors();
+    delay(50);
+    // When OneShot125 feature changed state apply additional delay
     if ((masterConfig.enabledFeatures ^ activeFeaturesLatch) & FEATURE_ONESHOT125) {
-        StopPwmAllMotors();
         delay(ONESHOT_FEATURE_CHANGED_DELAY_ON_BOOT_MS);
     }
 }

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -943,8 +943,8 @@ void handleOneshotFeatureChangeOnRestart(void)
     // Shutdown PWM on all motors prior to soft restart
     StopPwmAllMotors();
     delay(50);
-    // When OneShot125 feature changed state apply additional delay
-    if ((masterConfig.enabledFeatures ^ activeFeaturesLatch) & FEATURE_ONESHOT125) {
+    // Apply additional delay when OneShot125 feature changed from on to off state
+    if (feature(FEATURE_ONESHOT125) && !featureConfigured(FEATURE_ONESHOT125)) {
         delay(ONESHOT_FEATURE_CHANGED_DELAY_ON_BOOT_MS);
     }
 }

--- a/src/main/config/config.h
+++ b/src/main/config/config.h
@@ -19,6 +19,7 @@
 
 #define MAX_PROFILE_COUNT 3
 #define MAX_CONTROL_RATE_PROFILE_COUNT 3
+#define ONESHOT_FEATURE_CHANGED_DELAY_ON_BOOT_MS 1500
 
 
 typedef enum {
@@ -44,6 +45,9 @@ typedef enum {
     FEATURE_BLACKBOX = 1 << 19
 } features_e;
 
+void handleOneshotFeatureChangeOnRestart(void);
+void latchActiveFeatures(void);
+bool featureConfigured(uint32_t mask);
 bool feature(uint32_t mask);
 void featureSet(uint32_t mask);
 void featureClear(uint32_t mask);

--- a/src/main/drivers/pwm_mapping.c
+++ b/src/main/drivers/pwm_mapping.c
@@ -528,7 +528,7 @@ pwmOutputConfiguration_t *pwmInit(drv_pwm_config_t *init)
             channelIndex++;
         } else if (type == MAP_TO_MOTOR_OUTPUT) {
             if (init->useOneshot) {
-                pwmOneshotMotorConfig(timerHardwarePtr, pwmOutputConfiguration.motorCount, init->idlePulse);
+                pwmOneshotMotorConfig(timerHardwarePtr, pwmOutputConfiguration.motorCount, 0);
             } else if (init->motorPwmRate > 500) {
                 pwmBrushedMotorConfig(timerHardwarePtr, pwmOutputConfiguration.motorCount, init->motorPwmRate, init->idlePulse);
             } else {

--- a/src/main/drivers/pwm_output.c
+++ b/src/main/drivers/pwm_output.c
@@ -142,6 +142,16 @@ void pwmWriteMotor(uint8_t index, uint16_t value)
         motors[index]->pwmWritePtr(index, value);
 }
 
+void pwmShutdownPulsesForAllMotors(uint8_t motorCount)
+{
+    uint8_t index;
+
+    for(index = 0; index < motorCount; index++){
+        // Set the compare register to 0, which stops the output pulsing if the timer overflows
+        *motors[index]->ccr = 0;
+    }
+}
+
 void pwmCompleteOneshotMotorUpdate(uint8_t motorCount)
 {
     uint8_t index;

--- a/src/main/drivers/pwm_output.h
+++ b/src/main/drivers/pwm_output.h
@@ -18,6 +18,7 @@
 #pragma once
 
 void pwmWriteMotor(uint8_t index, uint16_t value);
+void pwmShutdownPulsesForAllMotors(uint8_t motorCount);
 void pwmCompleteOneshotMotorUpdate(uint8_t motorCount);
 
 void pwmWriteServo(uint8_t index, uint16_t value);

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -513,6 +513,11 @@ void stopMotors(void)
     delay(50); // give the timers and ESCs a chance to react.
 }
 
+void StopPwmAllMotors()
+{
+    pwmShutdownPulsesForAllMotors(motorCount);
+}
+
 #ifndef USE_QUAD_MIXER_ONLY
 static void airplaneMixer(void)
 {

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -115,3 +115,4 @@ void mixerResetMotors(void);
 void mixTable(void);
 void writeMotors(void);
 void stopMotors(void);
+void StopPwmAllMotors(void);

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -1410,6 +1410,7 @@ static void cliReboot(void) {
     cliPrint("\r\nRebooting");
     waitForSerialPortToFinishTransmitting(cliPort);
     stopMotors();
+    handleOneshotFeatureChangeOnRestart();
     systemReset();
 }
 

--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -1750,6 +1750,7 @@ void mspProcess(void)
                 delay(50);
             }
             stopMotors();
+            handleOneshotFeatureChangeOnRestart();
             systemReset();
         }
     }

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -168,6 +168,9 @@ void init(void)
 
     systemInit();
 
+    // Set active features to be used for feature() in the remainder of init().
+    latchActiveFeatures();
+
     ledInit();
 
 #ifdef SPEKTRUM_BIND
@@ -450,6 +453,9 @@ void init(void)
 #ifdef CJMCU
     LED2_ON;
 #endif
+
+    // Set active features AGAIN since some may be modified by init().
+    latchActiveFeatures();
 
     systemState |= SYSTEM_STATE_READY;
 }

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -90,6 +90,7 @@
 #include "debug.h"
 
 extern uint32_t previousTime;
+extern uint8_t motorControlEnable;
 
 #ifdef SOFTSERIAL_LOOPBACK
 serialPort_t *loopbackPort;
@@ -240,6 +241,9 @@ void init(void)
     pwmOutputConfiguration_t *pwmOutputConfiguration = pwmInit(&pwm_params);
 
     mixerUsePWMOutputConfiguration(pwmOutputConfiguration);
+
+    if (!feature(FEATURE_ONESHOT125))
+        motorControlEnable = true;
 
     systemState |= SYSTEM_STATE_MOTORS_READY;
 
@@ -456,6 +460,7 @@ void init(void)
 
     // Latch active features AGAIN since some may be modified by init().
     latchActiveFeatures();
+    motorControlEnable = true;
 
     systemState |= SYSTEM_STATE_READY;
 }

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -168,7 +168,7 @@ void init(void)
 
     systemInit();
 
-    // Set active features to be used for feature() in the remainder of init().
+    // Latch active features to be used for feature() in the remainder of init().
     latchActiveFeatures();
 
     ledInit();
@@ -454,7 +454,7 @@ void init(void)
     LED2_ON;
 #endif
 
-    // Set active features AGAIN since some may be modified by init().
+    // Latch active features AGAIN since some may be modified by init().
     latchActiveFeatures();
 
     systemState |= SYSTEM_STATE_READY;

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -97,6 +97,8 @@ uint16_t cycleTime = 0;         // this is the number in micro second to achieve
 int16_t magHold;
 int16_t headFreeModeHold;
 
+uint8_t motorControlEnable = false;
+
 int16_t telemTemperature1;      // gyro sensor temperature
 static uint32_t disarmAt;     // Time of automatic disarm when "Don't spin the motors when armed" is enabled and auto_disarm_delay is nonzero
 
@@ -801,7 +803,9 @@ void loop(void)
         writeServos();
 #endif
 
-        writeMotors();
+        if (motorControlEnable) {
+            writeMotors();
+        }
 
 #ifdef BLACKBOX
         if (!cliMode && feature(FEATURE_BLACKBOX)) {

--- a/src/test/unit/flight_mixer_unittest.cc
+++ b/src/test/unit/flight_mixer_unittest.cc
@@ -315,6 +315,15 @@ void pwmWriteMotor(uint8_t index, uint16_t value) {
     motors[index].value = value;
 }
 
+void pwmShutdownPulsesForAllMotors(uint8_t motorCount)
+{
+    uint8_t index;
+
+    for(index = 0; index < motorCount; index++){
+        motors[index].value = 0;
+    }
+}
+
 void pwmCompleteOneshotMotorUpdate(uint8_t motorCount) {
     lastOneShotUpdateMotorCount = motorCount;
 }

--- a/src/test/unit/rc_controls_unittest.cc
+++ b/src/test/unit/rc_controls_unittest.cc
@@ -242,6 +242,7 @@ TEST(RcControlsTest, processRcAdjustmentsSticksInMiddle)
             .thrExpo8 = 0,
             .rates = {0,0,0},
             .dynThrPID = 0,
+            .rcYawExpo8 = 0,
             .tpa_breakpoint = 0
     };
 
@@ -285,6 +286,7 @@ TEST(RcControlsTest, processRcAdjustmentsWithRcRateFunctionSwitchUp)
             .thrExpo8 = 0,
             .rates = {0,0,0},
             .dynThrPID = 0,
+            .rcYawExpo8 = 0,
             .tpa_breakpoint = 0
     };
 
@@ -451,6 +453,7 @@ TEST(RcControlsTest, processRcRateProfileAdjustments)
             .thrExpo8 = 0,
             .rates = {0,0,0},
             .dynThrPID = 0,
+            .rcYawExpo8 = 0,
             .tpa_breakpoint = 0
     };
 


### PR DESCRIPTION
This is to resolve issue #358 including the delay for oneshot feature changes on reboot, and is a replacement for earlier PR #893.

Instead of trying to latch the desired features and apply them after a soft reset (which also required an additional write to flash), it is now such that:
* The active features are latched after initialization completes and not modified until the next startup.
* The latched features are used  by `feature()` to report what feature is active.

Changes to features ordered via MSP or CLI commands are applied to the configuration that gets saved to flash. This guarantees that all saved modifications are persistent even when power is switched off.

Prior to a soft reset, the latched (active) features and the currently configured features are used to detect if the `ONESHOT125` feature has changed state, in which case motor PWM outputs are stopped and a soft reset is done after a 1.5 second delay.

The required effect of modifying features without changing the actions in the running mainloop is achieved. The user needs to be aware that changes to features are not applied immidiatly.