### PR TITLE
GPS - NMEA - Add GNSS and GLONASS messages

### DIFF
--- a/docs/Gps.md
+++ b/docs/Gps.md
@@ -127,6 +127,15 @@ Click `CFG (Configuration` in the Configuration View.
 
 Select `Save current configuration` and click `Send`.
 
+### NMEA message configuration
+If you are running the NMEA protocol, make sure you disable all messages in the MSG tab of the U-Center Configuration view.
+
+Then proceed enabling the following messages on the UART1 output:
+
+    NMEA GxGGA
+    NMEA GxRMC
+    NMEA GxGSV
+
 ### UBlox Navigation model
 
 Cleanflight will use `Pedestrian` when gps auto config is used.

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -549,16 +549,16 @@ static bool gpsNewFrameNMEA(char c)
             if (param == 0) {       //frame identification
                  gps_frame = NO_FRAME;
                 if ((string[0] == 'G' && string[1] == 'P' && string[2] == 'G' && string[3] == 'G' && string[4] == 'A') // GPS
-					|| (string[0] == 'G' && string[1] == 'N' && string[2] == 'G' && string[3] == 'G' && string[4] == 'A') // GNSS 
-					|| (string[0] == 'G' && string[1] == 'L' && string[2] == 'G' && string[3] == 'G' && string[4] == 'A')) // GLONASS
+                    || (string[0] == 'G' && string[1] == 'N' && string[2] == 'G' && string[3] == 'G' && string[4] == 'A') // GNSS 
+                    || (string[0] == 'G' && string[1] == 'L' && string[2] == 'G' && string[3] == 'G' && string[4] == 'A')) // GLONASS
                     gps_frame = FRAME_GGA;
                 if ((string[0] == 'G' && string[1] == 'P' && string[2] == 'R' && string[3] == 'M' && string[4] == 'C') // GPS 
-					|| (string[0] == 'G' && string[1] == 'N' && string[2] == 'R' && string[3] == 'M' && string[4] == 'C') //GNSS
-					|| (string[0] == 'G' && string[1] == 'L' && string[2] == 'R' && string[3] == 'M' && string[4] == 'C')) // GLONASS 
+                    || (string[0] == 'G' && string[1] == 'N' && string[2] == 'R' && string[3] == 'M' && string[4] == 'C') //GNSS
+                    || (string[0] == 'G' && string[1] == 'L' && string[2] == 'R' && string[3] == 'M' && string[4] == 'C')) // GLONASS 
                     gps_frame = FRAME_RMC;
                 if ((string[0] == 'G' && string[1] == 'P' && string[2] == 'G' && string[3] == 'S' && string[4] == 'V') //GPS
-					|| (string[0] == 'G' && string[1] == 'N' && string[2] == 'G' && string[3] == 'S' && string[4] == 'V') //GNSS
-					|| (string[0] == 'G' && string[1] == 'L' && string[2] == 'G' && string[3] == 'S' && string[4] == 'V')) //GLONASS
+                    || (string[0] == 'G' && string[1] == 'N' && string[2] == 'G' && string[3] == 'S' && string[4] == 'V') //GNSS
+                    || (string[0] == 'G' && string[1] == 'L' && string[2] == 'G' && string[3] == 'S' && string[4] == 'V')) //GLONASS
                     gps_frame = FRAME_GSV;
             }
 

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -553,7 +553,7 @@ static bool gpsNewFrameNMEA(char c)
                 satSystem = string[1];
                 if (string[0] == 'G' && string[2] == 'G' && string[3] == 'G' && string[4] == 'A')
                     gps_frame = FRAME_GGA;
-                if (string[0] == 'G' && string[2] == 'R' && string[3] == 'M' && string[4] == 'C') 
+                if (string[0] == 'G' && string[2] == 'R' && string[3] == 'M' && string[4] == 'C')
                     gps_frame = FRAME_RMC;
                 if (string[0] == 'G' && string[2] == 'G' && string[3] == 'S' && string[4] == 'V')
                     gps_frame = FRAME_GSV;
@@ -586,11 +586,7 @@ static bool gpsNewFrameNMEA(char c)
                             }
                             break;
                         case 7:
-                            if (satSystem == 'P')
-                                GPS_gpsNumCh = grab_fields(string, 0);
-                            else if (satSystem == 'L')
-                                GPS_glonassNumCh = grab_fields(string, 0);
-                            gps_Msg.numSat = GPS_gpsNumCh + GPS_glonassNumCh;
+                            gps_Msg.numSat = grab_fields(string, 0);
                             break;
                         case 9:
                             gps_Msg.altitude = grab_fields(string, 0);     // altitude in meters added by Mis
@@ -678,21 +674,22 @@ static bool gpsNewFrameNMEA(char c)
                     *gpsPacketLogChar = LOG_IGNORED;
                     GPS_packetCount++;
                     switch (gps_frame) {
-                    case FRAME_GGA:
-                      *gpsPacketLogChar = LOG_NMEA_GGA;
-                      frameOK = 1;
-                      if (STATE(GPS_FIX)) {
-                            GPS_coord[LAT] = gps_Msg.latitude;
-                            GPS_coord[LON] = gps_Msg.longitude;
-                            GPS_numSat = gps_Msg.numSat;
-                            GPS_altitude = gps_Msg.altitude;
-                        }
-                        break;
-                    case FRAME_RMC:
-                        *gpsPacketLogChar = LOG_NMEA_RMC;
-                        GPS_speed = gps_Msg.speed;
-                        GPS_ground_course = gps_Msg.ground_course;
-                        break;
+                        case FRAME_GGA:
+                            *gpsPacketLogChar = LOG_NMEA_GGA;
+                            frameOK = 1;
+                            if (STATE(GPS_FIX)) {
+                                GPS_coord[LAT] = gps_Msg.latitude;
+                                GPS_coord[LON] = gps_Msg.longitude;
+                                GPS_numSat = gps_Msg.numSat;
+                                GPS_altitude = gps_Msg.altitude;
+                            }
+                            else GPS_numSat = gps_Msg.numSat;
+                            break;
+                        case FRAME_RMC:
+                            *gpsPacketLogChar = LOG_NMEA_RMC;
+                            GPS_speed = gps_Msg.speed;
+                            GPS_ground_course = gps_Msg.ground_course;
+                            break;
                     } // end switch
                 } else {
                     *gpsPacketLogChar = LOG_ERROR;

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -547,12 +547,18 @@ static bool gpsNewFrameNMEA(char c)
         case '*':
             string[offset] = 0;
             if (param == 0) {       //frame identification
-                gps_frame = NO_FRAME;
-                if (string[0] == 'G' && string[1] == 'P' && string[2] == 'G' && string[3] == 'G' && string[4] == 'A')
+                 gps_frame = NO_FRAME;
+                if ((string[0] == 'G' && string[1] == 'P' && string[2] == 'G' && string[3] == 'G' && string[4] == 'A') // GPS
+					|| (string[0] == 'G' && string[1] == 'N' && string[2] == 'G' && string[3] == 'G' && string[4] == 'A') // GNSS 
+					|| (string[0] == 'G' && string[1] == 'L' && string[2] == 'G' && string[3] == 'G' && string[4] == 'A')) // GLONASS
                     gps_frame = FRAME_GGA;
-                if (string[0] == 'G' && string[1] == 'P' && string[2] == 'R' && string[3] == 'M' && string[4] == 'C')
+                if ((string[0] == 'G' && string[1] == 'P' && string[2] == 'R' && string[3] == 'M' && string[4] == 'C') // GPS 
+					|| (string[0] == 'G' && string[1] == 'N' && string[2] == 'R' && string[3] == 'M' && string[4] == 'C') //GNSS
+					|| (string[0] == 'G' && string[1] == 'L' && string[2] == 'R' && string[3] == 'M' && string[4] == 'C')) // GLONASS 
                     gps_frame = FRAME_RMC;
-                if (string[0] == 'G' && string[1] == 'P' && string[2] == 'G' && string[3] == 'S' && string[4] == 'V')
+                if ((string[0] == 'G' && string[1] == 'P' && string[2] == 'G' && string[3] == 'S' && string[4] == 'V') //GPS
+					|| (string[0] == 'G' && string[1] == 'N' && string[2] == 'G' && string[3] == 'S' && string[4] == 'V') //GNSS
+					|| (string[0] == 'G' && string[1] == 'L' && string[2] == 'G' && string[3] == 'S' && string[4] == 'V')) //GLONASS
                     gps_frame = FRAME_GSV;
             }
 


### PR DESCRIPTION
Added support for NMEA protocol messages of different satellite systems.

This PR solves 3 issues:

1) add support for GNGGA and GNRMC messages
- GPS (P) 
- GNSS (N) <= GPS + GLONASS + Galileo + Baidou
- GLONASS (L)

Update:
2) display Glonass satellites in the configurator 
This is done by processing GLGSV messages and adding the info to the channels array.
If there are more satellites than the maximum number of channels, GPS satellites will be favored.

Update2:
3) Number of satellites used for navigation was only updating if a GPS fix was acquired.
