### PR TITLE
various: reduce flash usage by fixing accidental uses of double and the heap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -564,6 +564,7 @@ CFLAGS		 = $(ARCH_FLAGS) \
 		   $(DEBUG_FLAGS) \
 		   -std=gnu99 \
 		   -Wall -Wextra -Wunsafe-loop-optimizations -Wdouble-promotion \
+		   -ffast-math \
 		   -ffunction-sections \
 		   -fdata-sections \
 		   $(DEVICE_FLAGS) \

--- a/Makefile
+++ b/Makefile
@@ -564,7 +564,6 @@ CFLAGS		 = $(ARCH_FLAGS) \
 		   $(DEBUG_FLAGS) \
 		   -std=gnu99 \
 		   -Wall -Wextra -Wunsafe-loop-optimizations -Wdouble-promotion \
-		   -ffast-math \
 		   -ffunction-sections \
 		   -fdata-sections \
 		   $(DEVICE_FLAGS) \

--- a/src/main/flight/autotune.c
+++ b/src/main/flight/autotune.c
@@ -184,10 +184,10 @@ static void autotuneLogAngleTargets(float currentAngle)
         eventData.targetAngleAtPeak = (int) targetAngleAtPeak;
 
         // currentAngle is integer decidegrees divided by 10, so just reverse that process to get an integer again:
-        eventData.currentAngle = round(currentAngle * 10);
+        eventData.currentAngle = roundf(currentAngle * 10);
         // the peak angles are only ever set to currentAngle, so they get the same treatment:
-        eventData.firstPeakAngle = round(firstPeakAngle * 10);
-        eventData.secondPeakAngle = round(secondPeakAngle * 10);
+        eventData.firstPeakAngle = roundf(firstPeakAngle * 10);
+        eventData.secondPeakAngle = roundf(secondPeakAngle * 10);
 
         blackboxLogEvent(FLIGHT_LOG_EVENT_AUTOTUNE_TARGETS, (flightLogEventData_t*)&eventData);
     }

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -1296,13 +1296,14 @@ static void cliMotor(char *cmdline)
     int motor_value = 0;
     int index = 0;
     char *pch = NULL;
+    char *saveptr;
 
     if (isEmpty(cmdline)) {
         cliPrint("Usage:\r\nmotor index [value] - show [or set] motor value\r\n");
         return;
     }
 
-    pch = strtok(cmdline, " ");
+    pch = strtok_r(cmdline, " ", &saveptr);
     while (pch != NULL) {
         switch (index) {
             case 0:
@@ -1313,7 +1314,7 @@ static void cliMotor(char *cmdline)
                 break;
         }
         index++;
-        pch = strtok(NULL, " ");
+        pch = strtok_r(NULL, " ", &saveptr);
     }
 
     if (motor_index < 0 || motor_index >= MAX_SUPPORTED_MOTORS) {

--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -154,5 +154,5 @@ uint8_t calculateBatteryCapacityRemainingPercentage(void)
 {
     uint16_t batteryCapacity = batteryConfig->batteryCapacity;
 
-    return constrain((batteryCapacity - constrain(mAhDrawn, 0, 0xFFFF)) * 100.0 / batteryCapacity , 0, 100);
+    return constrain((batteryCapacity - constrain(mAhDrawn, 0, 0xFFFF)) * 100.0f / batteryCapacity , 0, 100);
 }

--- a/src/main/telemetry/frsky.c
+++ b/src/main/telemetry/frsky.c
@@ -230,7 +230,7 @@ static void sendSatalliteSignalQualityAsTemperature2(void)
     if (telemetryConfig->frsky_unit == FRSKY_UNIT_METRICS) {
         serialize16(satellite);
     } else {
-        float tmp = (satellite - 32) / 1.8;
+        float tmp = (satellite - 32) / 1.8f;
         //Round the value
         tmp += (tmp < 0) ? -0.5f : 0.5f;
         serialize16(tmp);


### PR DESCRIPTION
This branch has three patches that should mildly improve performance and saves ~700 bytes of flash.  They are:

build: enable -ffast-math (allows the compiler to optimise more)
serial_cli: use the reentrant version of strtok() (stops accidental usage of the heap)
various: use float instead of double.