### PR TITLE
removed multiple declaration of function mixerUseConfigs

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -73,17 +73,6 @@
 #define BRUSHED_MOTORS_PWM_RATE 16000
 #define BRUSHLESS_MOTORS_PWM_RATE 400
 
-void mixerUseConfigs(
-#ifdef USE_SERVOS
-        servoParam_t *servoConfToUse,
-        gimbalConfig_t *gimbalConfigToUse,
-#endif
-        flight3DConfig_t *flight3DConfigToUse,
-        escAndServoConfig_t *escAndServoConfigToUse,
-        mixerConfig_t *mixerConfigToUse,
-        airplaneConfig_t *airplaneConfigToUse,
-        rxConfig_t *rxConfig
-);
 void useRcControlsConfig(modeActivationCondition_t *modeActivationConditions, escAndServoConfig_t *escAndServoConfigToUse, pidProfile_t *pidProfileToUse);
 
 #define FLASH_TO_RESERVE_FOR_CONFIG 0x800

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -96,6 +96,10 @@ typedef struct servoParam_t {
     int8_t forwardFromChannel;              // RX channel index, 0 based.  See CHANNEL_FORWARDING_DISABLED
 } servoParam_t;
 
+struct gimbalConfig_s;
+struct escAndServoConfig_s;
+struct rxConfig_s;
+
 extern int16_t servo[MAX_SUPPORTED_SERVOS];
 bool isMixerUsingServos(void);
 void writeServos(void);
@@ -104,6 +108,17 @@ void filterServos(void);
 
 extern int16_t motor[MAX_SUPPORTED_MOTORS];
 extern int16_t motor_disarmed[MAX_SUPPORTED_MOTORS];
+
+void mixerUseConfigs(
+#ifdef USE_SERVOS
+        servoParam_t *servoConfToUse,
+        struct gimbalConfig_s *gimbalConfigToUse,
+#endif
+        flight3DConfig_t *flight3DConfigToUse,
+		struct escAndServoConfig_s *escAndServoConfigToUse,
+        mixerConfig_t *mixerConfigToUse,
+        airplaneConfig_t *airplaneConfigToUse,
+		struct rxConfig_s *rxConfigToUse);
 
 void writeAllMotors(int16_t mc);
 void mixerLoadMix(int index, motorMixer_t *customMixers);

--- a/src/test/unit/flight_mixer_unittest.cc
+++ b/src/test/unit/flight_mixer_unittest.cc
@@ -46,18 +46,6 @@ extern "C" {
     extern uint8_t servoCount;
     void forwardAuxChannelsToServos(void);
 
-    void mixerUseConfigs(
-#ifdef USE_SERVOS
-            servoParam_t *servoConfToUse,
-            gimbalConfig_t *gimbalConfigToUse,
-#endif
-            flight3DConfig_t *flight3DConfigToUse,
-            escAndServoConfig_t *escAndServoConfigToUse,
-            mixerConfig_t *mixerConfigToUse,
-            airplaneConfig_t *airplaneConfigToUse,
-            rxConfig_t *rxConfigToUse
-    );
-
     void mixerInit(mixerMode_e mixerMode, motorMixer_t *initialCustomMixers);
     void mixerUsePWMOutputConfiguration(pwmOutputConfiguration_t *pwmOutputConfiguration);
 }


### PR DESCRIPTION
remove multiple declaration of the function mixerUseConfigs, so if get modified and you don't update all the callers you get a compilation error instad of segfault