### PR TITLE
Add incl_fact_horizon parameter (LuxFloat)

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -187,6 +187,7 @@ static void resetPidProfile(pidProfile_t *pidProfile)
     pidProfile->A_level = 5.0f;
     pidProfile->H_level = 3.0f;
     pidProfile->H_sensitivity = 75;
+    pidProfile->incl_fact_horizon = 75;
 }
 
 #ifdef GPS

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -65,6 +65,7 @@ typedef struct pidProfile_s {
     uint8_t dterm_cut_hz;                   // (default 17Hz, Range 1-50Hz) Used for PT1 element in PID1, PID2 and PID5
     uint8_t pterm_cut_hz;                   // Used for fitlering Pterm noise on noisy frames
     uint8_t gyro_cut_hz;                    // Used for soft gyro filtering
+    uint8_t incl_fact_horizon;              // inclination factor for Horizon mode
 } pidProfile_t;
 
 #define DEGREES_TO_DECIDEGREES(angle) (angle * 10)

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -476,6 +476,7 @@ const clivalue_t valueTable[] = {
     { "level_horizon",              VAR_FLOAT  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.H_level, 0, 10 },
     { "level_angle",                VAR_FLOAT  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.A_level, 0, 10 },
     { "sensitivity_horizon",        VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.H_sensitivity, 0, 250 },
+    { "incl_fact_horizon",          VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.incl_fact_horizon, 0, 250 },
 
     { "p_alt",                      VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.P8[PIDALT], 0, 200 },
     { "i_alt",                      VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.I8[PIDALT], 0, 200 },


### PR DESCRIPTION
This modification adds a new CLI parameter, 'incl_fact_horizon' ("inclination factor"), which controls the effect the current inclination has on self-leveling in the Horizon flight mode.  The current inclination is the number of degrees of pitch or roll that the vehicle is away from level (whichever is greater).  The modification only effects PID controller 2 ("LuxFloat").

The idea for this came from ctzsnooze (see issue #695); I've expanded on it and turned it into a configurable option.  The problem with the existing v1.9.0 horizon mode is that the strength of the self-leveling is solely dependent on the stick position.  This is problematic when trying to do maneuvers like large loops and fast-forward flight.  Adding a factor that takes into account the current inclination of the craft provides a big improvement for these maneuvers and improves the "feel" of horizon mode.

One characteristic of horizon mode I made a point of retaining is that, when the vehicle is flat and the sticks are near center, the self-leveling effect is not diminished by larger 'incl_fact_horizon' settings.  Like in the existing v1.9.0 horizon mode, the strength of the self-leveling can be effectively managed using the 'level_horizon' parameter.  Also, the 'H_sensitivity' parameter operates the same as before.

Setting 'incl_fact_horizon' to 0 will run the current v1.9.0 horizon-mode behavior.  For other values, there are two ranges for the 'incl_fact_horizon' parameter:

1 to 99 => Range 1 - leveling always active when sticks centered:
This is the "safer" range because the self-leveling is always active when the sticks are centered.  So, when the vehicle is upside down (180 degrees) and the sticks are then centered, the vehicle will immediately be self-leveled to upright and flat.  This is similar to the current v1.9.0 horizon-mode behavior.  (Note that after this kind of very-fast 180-degree self-leveling, the heading of the vehicle can be unpredictable.)  Larger values result in less self-leveling in response to large inclinations.  The 'incl_fact_horizon' value is combined with the 'level_horizon' parameter to control the self-leveling effect.  The default value of 75 should provide significant improvements in horizon-mode flight characteristics.

100 to 250 => Range 2 - leveling can be totally off when inverted:
In this range, the inclination of the vehicle can fully "override" the self-leveling.  When the parameter set to around 150, and the vehicle is upside down (180 degrees) and the sticks are then centered, the vehicle is not self-leveled.  This can be desirable for performing more-acrobatic maneuvers and for 3D-mode flying.

The 'incl_fact_horizon' parameter value is different for each profile.

So far I've only implemented this in PID controller 2 ("LuxFloat").  I'm planning on doing a version of it for the "integer-math-based" controllers.

Note that after loading this firmware the controller's configuration will be reset to factory-default values, so the configuration should be backed up before and restored after the firmware update.

I've posted a firmware file with this modification here:  http://www.etheli.com/CF/addInclFactHorizonCmd

--ET