### PR TITLE
Decouple vbatt

### DIFF
--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -87,8 +87,10 @@ enum {
     ALIGN_MAG = 2
 };
 
-/* for VBAT monitoring frequency */
-#define VBATFREQ 6        // to read battery voltage - nth number of loop iterations
+/* VBAT monitoring interval (in microseconds) - 1s*/
+#define VBATINTERVAL 1000000       
+/* IBat monitoring interval (in microseconds) - 6 default looptimes */
+#define IBATINTERVAL (6 * 3500)       
 
 uint32_t currentTime = 0;
 uint32_t previousTime = 0;
@@ -172,9 +174,9 @@ void annexCode(void)
     int32_t axis, prop1 = 0, prop2;
 
     static batteryState_e batteryState = BATTERY_OK;
-    static uint8_t vbatTimer = 0;
-    static int32_t vbatCycleTime = 0;
-
+    static uint32_t vbatLastServiced = 0;
+    static uint32_t ibatLastServiced = 0;
+    uint32_t ibatTimeSinceLastServiced;
     // PITCH & ROLL only dynamic PID adjustment,  depending on throttle value
     if (rcData[THROTTLE] < currentControlRateProfile->tpa_breakpoint) {
         prop2 = 100;
@@ -244,10 +246,10 @@ void annexCode(void)
         rcCommand[PITCH] = rcCommand_PITCH;
     }
 
-    if (feature(FEATURE_VBAT | FEATURE_CURRENT_METER)) {
-        vbatCycleTime += cycleTime;
-        if (!(++vbatTimer % VBATFREQ)) {
-
+    if (feature(FEATURE_VBAT)) {
+        /* currentTime will rollover @ 70 minutes */
+        if ((currentTime - vbatLastServiced) >= VBATINTERVAL) {
+           vbatLastServiced = currentTime;
             if (feature(FEATURE_VBAT)) {
                 updateBatteryVoltage();
                 batteryState = calculateBatteryState();
@@ -257,11 +259,15 @@ void annexCode(void)
                 else if (batteryState == BATTERY_WARNING)
                     beeper(BEEPER_BAT_LOW);         //low battery
             }
+        }
+    }
 
-            if (feature(FEATURE_CURRENT_METER)) {
-                updateCurrentMeter(vbatCycleTime, &masterConfig.rxConfig, masterConfig.flight3DConfig.deadband3d_throttle);
-            }
-            vbatCycleTime = 0;
+    if (feature(FEATURE_CURRENT_METER)) {
+        /* currentTime will rollover @ 70 minutes */
+        ibatTimeSinceLastServiced = (currentTime - ibatLastServiced);
+        if (ibatTimeSinceLastServiced >= IBATINTERVAL) {
+            ibatLastServiced = currentTime;
+            updateCurrentMeter((ibatTimeSinceLastServiced / 1000), &masterConfig.rxConfig, masterConfig.flight3DConfig.deadband3d_throttle);
         }
     }
 

--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -59,6 +59,7 @@ void updateBatteryVoltage(void)
 {
     static uint16_t vbatSamples[BATTERY_SAMPLE_COUNT];
     static uint8_t currentSampleIndex = 0;
+    static uint8_t currentSampleCount = 0;
     uint8_t index;
     uint16_t vbatSampleTotal = 0;
 
@@ -69,7 +70,12 @@ void updateBatteryVoltage(void)
     for (index = 0; index < BATTERY_SAMPLE_COUNT; index++) {
         vbatSampleTotal += vbatSamples[index];
     }
-    vbat = batteryAdcToVoltage(vbatSampleTotal / BATTERY_SAMPLE_COUNT);
+
+    if(currentSampleCount < BATTERY_SAMPLE_COUNT) {
+        currentSampleCount++;
+    }
+
+    vbat = batteryAdcToVoltage(vbatSampleTotal / currentSampleCount);
 }
 
 batteryState_e calculateBatteryState(void)


### PR DESCRIPTION
Changes to:

-Call VBatt monitoring code at a fixed interval (with a resolution of looptime) instead of every VBATFREQ loops. 
-Separate V & I monitoring to prevent increasing V monitoring interval degrading the accuracy of the I monitoring
-Increased the VBatt monitoring interval to 1 second.
-Fixed VBatt averaging code because average ramping up over first BATTERY_SAMPLE_COUNT becomes visible when monitoring interval is increased