### PR TITLE
Telemetry_Switch TELEMETRY_BOX conditional logic incorrect

### DIFF
--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -622,7 +622,7 @@ void mspInit(serialConfig_t *serialConfig)
 
     activeBoxIds[activeBoxIdCount++] = BOXOSD;
 
-    if (feature(FEATURE_TELEMETRY && masterConfig.telemetryConfig.telemetry_switch))
+    if (feature(FEATURE_TELEMETRY) && masterConfig.telemetryConfig.telemetry_switch)
         activeBoxIds[activeBoxIdCount++] = BOXTELEMETRY;
 
 #ifdef AUTOTUNE


### PR DESCRIPTION
TELEMETRY_BOX mode is not available in the GUI following setting telemetry_switch=1 with feature TELEMETRY enabled.  

This is a simple correction to the brace location to restore the intended logic and make TELEMETRY mode available in the GUI if telemetry_switch is set to 1.
