### PR TITLE
various: optimise RAM and flash usage

### DIFF
--- a/lib/main/CMSIS/CM3/DeviceSupport/ST/STM32F10x/system_stm32f10x.c
+++ b/lib/main/CMSIS/CM3/DeviceSupport/ST/STM32F10x/system_stm32f10x.c
@@ -5,7 +5,7 @@
 
 uint32_t SystemCoreClock = SYSCLK_FREQ_72MHz;   /*!< System Clock Frequency (Core Clock) */
 
-__I uint8_t AHBPrescTable[16] = { 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 6, 7, 8, 9 };
+static const uint8_t AHBPrescTable[16] = { 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 6, 7, 8, 9 };
 
 uint32_t hse_value = 8000000;
 

--- a/lib/main/STM32F10x_StdPeriph_Driver/src/stm32f10x_rcc.c
+++ b/lib/main/STM32F10x_StdPeriph_Driver/src/stm32f10x_rcc.c
@@ -190,8 +190,8 @@
   * @{
   */ 
 
-static __I uint8_t APBAHBPrescTable[16] = {0, 0, 0, 0, 1, 2, 3, 4, 1, 2, 3, 4, 6, 7, 8, 9};
-static __I uint8_t ADCPrescTable[4] = {2, 4, 6, 8};
+static const uint8_t APBAHBPrescTable[16] = {0, 0, 0, 0, 1, 2, 3, 4, 1, 2, 3, 4, 6, 7, 8, 9};
+static const uint8_t ADCPrescTable[4] = {2, 4, 6, 8};
 extern uint32_t hse_value;
 
 /**

--- a/src/main/io/display.c
+++ b/src/main/io/display.c
@@ -83,7 +83,7 @@ static char lineBuffer[SCREEN_CHARACTER_COLUMN_COUNT + 1];
 #define HALF_SCREEN_CHARACTER_COLUMN_COUNT (SCREEN_CHARACTER_COLUMN_COUNT / 2)
 #define IS_SCREEN_CHARACTER_COLUMN_COUNT_ODD (SCREEN_CHARACTER_COLUMN_COUNT & 1)
 
-const char* pageTitles[] = {
+static const char* const pageTitles[] = {
     "CLEANFLIGHT",
     "ARMED",
     "BATTERY",

--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -396,38 +396,22 @@ static mspPort_t mspPorts[MAX_MSP_PORT_COUNT];
 
 static mspPort_t *currentPort;
 
-static void serialize32(uint32_t a)
-{
-    static uint8_t t;
-    t = a;
-    serialWrite(mspSerialPort, t);
-    currentPort->checksum ^= t;
-    t = a >> 8;
-    serialWrite(mspSerialPort, t);
-    currentPort->checksum ^= t;
-    t = a >> 16;
-    serialWrite(mspSerialPort, t);
-    currentPort->checksum ^= t;
-    t = a >> 24;
-    serialWrite(mspSerialPort, t);
-    currentPort->checksum ^= t;
-}
-
-static void serialize16(int16_t a)
-{
-    static uint8_t t;
-    t = a;
-    serialWrite(mspSerialPort, t);
-    currentPort->checksum ^= t;
-    t = a >> 8 & 0xff;
-    serialWrite(mspSerialPort, t);
-    currentPort->checksum ^= t;
-}
-
 static void serialize8(uint8_t a)
 {
     serialWrite(mspSerialPort, a);
     currentPort->checksum ^= a;
+}
+
+static void serialize16(uint16_t a)
+{
+    serialize8((uint8_t)(a >> 0));
+    serialize8((uint8_t)(a >> 8));
+}
+
+static void serialize32(uint32_t a)
+{
+    serialize16((uint16_t)(a >> 0));
+    serialize16((uint16_t)(a >> 16));
 }
 
 static uint8_t read8(void)

--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -140,12 +140,12 @@ void useRcControlsConfig(modeActivationCondition_t *modeActivationConditions, es
 #define BASEFLIGHT_IDENTIFIER "BAFL";
 
 #define FLIGHT_CONTROLLER_IDENTIFIER_LENGTH 4
-static const char *flightControllerIdentifier = CLEANFLIGHT_IDENTIFIER; // 4 UPPER CASE alpha numeric characters that identify the flight controller.
+static const char * const flightControllerIdentifier = CLEANFLIGHT_IDENTIFIER; // 4 UPPER CASE alpha numeric characters that identify the flight controller.
 
 #define FLIGHT_CONTROLLER_VERSION_LENGTH    3
 #define FLIGHT_CONTROLLER_VERSION_MASK      0xFFF
 
-const char *boardIdentifier = TARGET_BOARD_IDENTIFIER;
+static const char * const boardIdentifier = TARGET_BOARD_IDENTIFIER;
 #define BOARD_IDENTIFIER_LENGTH             4 // 4 UPPER CASE alpha numeric characters that identify the board being used.
 #define BOARD_HARDWARE_REVISION_LENGTH      2
 

--- a/src/main/version.c
+++ b/src/main/version.c
@@ -15,7 +15,7 @@
  * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-char *targetName = __TARGET__;
-char *shortGitRevision = __REVISION__;
-char *buildDate = __DATE__;
-char *buildTime = __TIME__;
+const char * const targetName = __TARGET__;
+const char * const shortGitRevision = __REVISION__;
+const char * const buildDate = __DATE__;
+const char * const buildTime = __TIME__;

--- a/src/main/version.h
+++ b/src/main/version.h
@@ -25,13 +25,13 @@
 
 #define MW_VERSION              231
 
-extern char* targetName;
+extern const char* const targetName;
 
 #define GIT_SHORT_REVISION_LENGTH   7 // lower case hexadecimal digits.
-extern char* shortGitRevision;
+extern const char* const shortGitRevision;
 
 #define BUILD_DATE_LENGTH 11
-extern char* buildDate;  // "MMM DD YYYY" MMM = Jan/Feb/...
+extern const char* const buildDate;  // "MMM DD YYYY" MMM = Jan/Feb/...
 
 #define BUILD_TIME_LENGTH 8
-extern char* buildTime;  // "HH:MM:SS"
+extern const char* const buildTime;  // "HH:MM:SS"


### PR DESCRIPTION
This patch moves more constant data out of RAM and into flash, and re-works the MSP serialisers to save code space.

Saves about 180 bytes of flash and ~300 bytes of RAM.