### PR TITLE
Remove failsafe_trottle setting from AlienWii32 defaults

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -535,7 +535,6 @@ static void resetConf(void)
     currentProfile->pidProfile.P8[PITCH] = 36;
     masterConfig.failsafeConfig.failsafe_delay = 2;
     masterConfig.failsafeConfig.failsafe_off_delay = 0;
-    masterConfig.failsafeConfig.failsafe_throttle = 1000;
     currentControlRateProfile->rcRate8 = 130;
     currentControlRateProfile->rates[FD_PITCH] = 20;
     currentControlRateProfile->rates[FD_ROLL] = 20;


### PR DESCRIPTION
New Cleanflight default is now the same.