### PR TITLE
RX - Added programmable RX channel defaults on RX lost

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -403,6 +403,10 @@ static void resetConf(void)
     masterConfig.rxConfig.rx_min_usec = 885;          // any of first 4 channels below this value will trigger rx loss detection
     masterConfig.rxConfig.rx_max_usec = 2115;         // any of first 4 channels above this value will trigger rx loss detection
 
+    for (i = 0; i < MAX_SUPPORTED_RC_CHANNEL_COUNT-4; i++) {
+        masterConfig.rxConfig.rx_fail_usec_steps[i] = CHANNEL_VALUE_TO_RXFAIL_STEP(masterConfig.rxConfig.midrc);
+    }
+
     masterConfig.rxConfig.rssi_channel = 0;
     masterConfig.rxConfig.rssi_scale = RSSI_SCALE_DEFAULT;
     masterConfig.rxConfig.rssi_ppm_invert = 0;

--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -227,6 +227,10 @@ static const char * const boardIdentifier = TARGET_BOARD_IDENTIFIER;
 
 #define MSP_FAILSAFE_CONFIG             75 //out message         Returns FC Fail-Safe settings
 #define MSP_SET_FAILSAFE_CONFIG         76 //in message          Sets FC Fail-Safe settings
+
+#define MSP_RXFAIL_CONFIG               77 //out message         Returns RXFAIL settings
+#define MSP_SET_RXFAIL_CONFIG           78 //in message          Sets RXFAIL settings
+
 //
 // Baseflight MSP commands (if enabled they exist in Cleanflight)
 //
@@ -1159,6 +1163,13 @@ static bool processOutCommand(uint8_t cmdMSP)
         serialize16(masterConfig.failsafeConfig.failsafe_throttle);
         break;
 
+    case MSP_RXFAIL_CONFIG:
+        headSerialReply(2 * (rxRuntimeConfig.channelCount-4));
+        for (i = 4; i < rxRuntimeConfig.channelCount; i++) {
+            serialize16(RXFAIL_STEP_TO_CHANNEL_VALUE(masterConfig.rxConfig.rx_fail_usec_steps[i-4]));
+        }
+        break;
+
     case MSP_RSSI_CONFIG:
         headSerialReply(1);
         serialize8(masterConfig.rxConfig.rssi_channel);
@@ -1582,6 +1593,18 @@ static bool processInCommand(void)
         masterConfig.failsafeConfig.failsafe_delay = read8();
         masterConfig.failsafeConfig.failsafe_off_delay = read8();
         masterConfig.failsafeConfig.failsafe_throttle = read16();
+        break;
+
+    case MSP_SET_RXFAIL_CONFIG:
+        {
+            uint8_t channelCount = currentPort->dataSize / sizeof(uint16_t);
+            if (channelCount > MAX_SUPPORTED_RC_CHANNEL_COUNT-4) {
+                headSerialError(0);
+            } else {
+                for (i = 4; i < channelCount; i++)
+                    masterConfig.rxConfig.rx_fail_usec_steps[i-4] = CHANNEL_VALUE_TO_RXFAIL_STEP(read16());
+            }
+        }
         break;
 
     case MSP_SET_RSSI_CONFIG:

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -27,6 +27,10 @@
 #define PWM_PULSE_MIN   750       // minimum PWM pulse width which is considered valid
 #define PWM_PULSE_MAX   2250      // maximum PWM pulse width which is considered valid
 
+#define RXFAIL_STEP_TO_CHANNEL_VALUE(step) (PWM_PULSE_MIN + 25 * step)
+#define CHANNEL_VALUE_TO_RXFAIL_STEP(channelValue) ((constrain(channelValue, PWM_PULSE_MIN, PWM_PULSE_MAX) - PWM_PULSE_MIN) / 25)
+#define MAX_RXFAIL_RANGE_STEP ((PWM_PULSE_MAX - PWM_PULSE_MIN) / 25)
+
 #define DEFAULT_SERVO_MIN 1000
 #define DEFAULT_SERVO_MIDDLE 1500
 #define DEFAULT_SERVO_MAX 2000
@@ -90,6 +94,7 @@ typedef struct rxConfig_s {
 
     uint16_t rx_min_usec;
     uint16_t rx_max_usec;
+    uint8_t rx_fail_usec_steps[MAX_SUPPORTED_RC_CHANNEL_COUNT-4];
 
 } rxConfig_t;
 


### PR DESCRIPTION
~~With this PR users can set an individual value for each RX channel, that will be used in case of an RX lost. I added a CLI command `rxfail` to set these values. Mapping for channels is taking into account, so when channel 0 is set to 1000, this value will be used for A in default mapping and for T in JR map.~~

~~I did not yet added MSP commands.~~

EDIT:
The intention of this PR is to cover (RX faisafe state) safety independent of failsafe handling.
In other words: What does the flight controller do when you forget to switch your transmitter on or a wire comes loose, has radio interference etc. (even when failsafe handling is disabled).

Please see the commit message(s) for latest implementation details.