### PR TITLE
Update failsafe to be triggered by a range of values on channels

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -401,8 +401,11 @@ static void resetConf(void)
     masterConfig.rxConfig.midrc = 1500;
     masterConfig.rxConfig.mincheck = 1100;
     masterConfig.rxConfig.maxcheck = 1900;
-    masterConfig.rxConfig.rx_min_usec = 985;          // any of first 4 channels below this value will trigger rx loss detection
-    masterConfig.rxConfig.rx_max_usec = 2115;         // any of first 4 channels above this value will trigger rx loss detection
+    masterConfig.rxConfig.rx_min_usec = PWM_PULSE_MIN;          // only used for constraining now
+    masterConfig.rxConfig.rx_max_usec = PWM_PULSE_MAX;          // only used for constraining now
+    masterConfig.rxConfig.failsafe_channel_mask = 0x0F;         // default to all stick channels
+    masterConfig.rxConfig.fs_min_usec = 0;                      //     if all channels in channel mask are between
+    masterConfig.rxConfig.fs_max_usec = 935;                    //     fs_min_usec and fs_max_usec, trigger failsafe
 
     masterConfig.rxConfig.rssi_channel = 0;
     masterConfig.rxConfig.rssi_scale = RSSI_SCALE_DEFAULT;

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -384,6 +384,9 @@ const clivalue_t valueTable[] = {
     { "failsafe_delay",             VAR_UINT8  | MASTER_VALUE,  &masterConfig.failsafeConfig.failsafe_delay, 0, 200 },
     { "failsafe_off_delay",         VAR_UINT8  | MASTER_VALUE,  &masterConfig.failsafeConfig.failsafe_off_delay, 0, 200 },
     { "failsafe_throttle",          VAR_UINT16 | MASTER_VALUE,  &masterConfig.failsafeConfig.failsafe_throttle, PWM_RANGE_MIN, PWM_RANGE_MAX },
+    { "failsafe_channel_mask",      VAR_UINT8  | MASTER_VALUE,  &masterConfig.rxConfig.failsafe_channel_mask, 0, 0xFF },
+    { "failsafe_min",               VAR_UINT16 | MASTER_VALUE,  &masterConfig.rxConfig.fs_min_usec, PWM_PULSE_MIN, PWM_PULSE_MAX },
+    { "failsafe_max",               VAR_UINT16 | MASTER_VALUE,  &masterConfig.rxConfig.fs_max_usec, PWM_PULSE_MIN, PWM_PULSE_MAX },
 
     { "rx_min_usec",                VAR_UINT16 | MASTER_VALUE,  &masterConfig.rxConfig.rx_min_usec, PWM_PULSE_MIN, PWM_PULSE_MAX },
     { "rx_max_usec",                VAR_UINT16 | MASTER_VALUE,  &masterConfig.rxConfig.rx_max_usec, PWM_PULSE_MIN, PWM_PULSE_MAX },

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -89,6 +89,10 @@ typedef struct rxConfig_s {
     uint16_t rx_min_usec;
     uint16_t rx_max_usec;
 
+    uint8_t  failsafe_channel_mask;
+    uint16_t fs_min_usec;
+    uint16_t fs_max_usec;
+
 } rxConfig_t;
 
 #define REMAPPABLE_CHANNEL_COUNT (sizeof(((rxConfig_t *)0)->rcmap) / sizeof(((rxConfig_t *)0)->rcmap[0]))


### PR DESCRIPTION
Update failsafe to be triggered by a range of values on channels that match a mask.

Fix range constraints on inputs.