### PR TITLE
Added experimental PID controller 6 "Bruce Lee"

### DIFF
--- a/docs/PID tuning.md
+++ b/docs/PID tuning.md
@@ -159,15 +159,6 @@ The PID controller is flight tested and running well with the default PID settin
 
 Yaw authority is also quite good.
 
-### PID controller 6, "BruceLee"
-
-PID Controller 6 is an experimental PID controller, which is same as PID1 for P and I, but with different D gain filtering. D term is the most sensitive tuning
-parameter when it comes to vibrations and PT1 element is implemented, which acts as a low pass filter to make the Dterm less sensitive to vibrations.
-Therefore this PID controller allows it easily to run less gyro_lpf filtering from MPU6050 to get less delay to the PID controller and better tuning for Acro flights.
-
-Angle and Horizon mode work the same way as on the PID1, but in this case default gains should be better as different scaling is used.
-TPA is also supported.
-
 
 ## RC rate, Pitch and Roll Rates (P/R rate before they were separated), and Yaw rate
 

--- a/docs/PID tuning.md
+++ b/docs/PID tuning.md
@@ -159,6 +159,15 @@ The PID controller is flight tested and running well with the default PID settin
 
 Yaw authority is also quite good.
 
+### PID controller 6, "BruceLee"
+
+PID Controller 6 is an experimental PID controller, which is same as PID1 for P and I, but with different D gain filtering. D term is the most sensitive tuning
+parameter when it comes to vibrations and PT1 element is implemented, which acts as a low pass filter to make the Dterm less sensitive to vibrations.
+Therefore this PID controller allows it easily to run less gyro_lpf filtering from MPU6050 to get less delay to the PID controller and better tuning for Acro flights.
+
+Angle and Horizon mode work the same way as on the PID1, but in this case default gains should be better as different scaling is used.
+TPA is also supported.
+
 
 ## RC rate, Pitch and Roll Rates (P/R rate before they were separated), and Yaw rate
 

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#define F_CUT 17.0f                         // Used for PT1 element in pid6
 #define GYRO_I_MAX 256                      // Gyro I limiter
 #define RCconstPI   0.159154943092f         // 0.5f / M_PI;
 #define MAIN_CUT_HZ 12.0f                   // (default 12Hz, Range 1-50Hz)

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -409,7 +409,7 @@ const clivalue_t valueTable[] = {
     { "mag_hardware",               VAR_UINT8  | MASTER_VALUE,  &masterConfig.mag_hardware, 0, MAG_MAX },
     { "mag_declination",            VAR_INT16  | PROFILE_VALUE, &masterConfig.profile[0].mag_declination, -18000, 18000 },
 
-    { "pid_controller",             VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.pidController, 0, 5 },
+    { "pid_controller",             VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.pidController, 0, 6 },
 
     { "p_pitch",                    VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.P8[PITCH], 0, 200 },
     { "i_pitch",                    VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.I8[PITCH], 0, 200 },


### PR DESCRIPTION
PID Controller 6 is an experimental PID controller, which is same as
PID1 for P and I, but with different D gain filtering. D term is the
most sensitive tuning parameter when it comes to vibrations and therefore PT1 element is implemented, which acts as a low pass filter to make the Dterm less sensitive to
vibrations. Also more floating point math added where needed.
Therefore this PID controller allows it easily to run less gyro_lpf
filtering from MPU6050 to get less delay to the PID controller and
better tuning for Acro flights.

Hover with same PID's on PID1 and PID6 with gyro_lpf=256:

PID1
![pid1](https://cloud.githubusercontent.com/assets/10757508/8070049/dbef0c3e-0efe-11e5-929c-27cd21b196f2.png)


PID6:
![pid6](https://cloud.githubusercontent.com/assets/10757508/8070059/f151a500-0efe-11e5-97d3-087fff61cc42.png)
