### PR TITLE
Same lpf behaviour MPU6000 and MPU6050

### DIFF
--- a/src/main/drivers/accgyro_spi_mpu6000.c
+++ b/src/main/drivers/accgyro_spi_mpu6000.c
@@ -275,33 +275,18 @@ bool mpu6000SpiGyroDetect(gyro_t *gyro, uint16_t lpf)
     int16_t data[3];
 
     // default lpf is 42Hz
-    switch (lpf) {
-        case 256:
-            mpuLowPassFilter = BITS_DLPF_CFG_256HZ;
-            break;
-        case 188:
-            mpuLowPassFilter = BITS_DLPF_CFG_188HZ;
-            break;
-        case 98:
-            mpuLowPassFilter = BITS_DLPF_CFG_98HZ;
-            break;
-        default:
-        case 42:
-            mpuLowPassFilter = BITS_DLPF_CFG_42HZ;
-            break;
-        case 20:
-            mpuLowPassFilter = BITS_DLPF_CFG_20HZ;
-            break;
-        case 10:
-            mpuLowPassFilter = BITS_DLPF_CFG_10HZ;
-            break;
-        case 5:
-            mpuLowPassFilter = BITS_DLPF_CFG_5HZ;
-            break;
-        case 0:
-            mpuLowPassFilter = BITS_DLPF_CFG_2100HZ_NOLPF;
-            break;
-    }
+    if (lpf >= 188)
+        mpuLowPassFilter = BITS_DLPF_CFG_188HZ;
+    else if (lpf >= 98)
+        mpuLowPassFilter = BITS_DLPF_CFG_98HZ;
+    else if (lpf >= 42)
+        mpuLowPassFilter = BITS_DLPF_CFG_42HZ;
+    else if (lpf >= 20)
+        mpuLowPassFilter = BITS_DLPF_CFG_20HZ;
+    else if (lpf >= 10)
+        mpuLowPassFilter = BITS_DLPF_CFG_10HZ;
+    else
+        mpuLowPassFilter = BITS_DLPF_CFG_5HZ;
 
     spiSetDivisor(MPU6000_SPI_INSTANCE, SPI_0_5625MHZ_CLOCK_DIVIDER);
 


### PR DESCRIPTION
I have no CC3D to test, but it's not trivial.

I noticed different behaviour from some users with CC3D than some users with naze32 during my filtering tests. It's best to make those equal?