### PR TITLE
Butterworth Dterm filter testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,6 +229,7 @@ COMMON_SRC	 = build_config.c \
 		   flight/imu.c \
 		   flight/mixer.c \
 		   flight/lowpass.c \
+		   flight/butterworth.c \
 		   drivers/bus_i2c_soft.c \
 		   drivers/serial.c \
 		   drivers/sound_beeper.c \

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -171,6 +171,7 @@ static void resetPidProfile(pidProfile_t *pidProfile)
     pidProfile->D8[PIDVEL] = 1;
 
     pidProfile->yaw_p_limit = YAW_P_LIMIT_MAX;
+    pidProfile->dterm_filtering = 0;
 
     pidProfile->P_f[ROLL] = 2.5f;     // new PID with preliminary defaults test carefully
     pidProfile->I_f[ROLL] = 0.6f;

--- a/src/main/drivers/accgyro_mpu6050.c
+++ b/src/main/drivers/accgyro_mpu6050.c
@@ -372,9 +372,9 @@ bool mpu6050GyroDetect(const mpu6050Config_t *configToUse, gyro_t *gyro, uint16_
     // 16.4 dps/lsb scalefactor
     gyro->scale = 1.0f / 16.4f;
 
-    if (lpf >= 188)
-        mpuLowPassFilter = INV_FILTER_188HZ;
-    else if (lpf >= 98)
+    if (lpf == 256)            // diasable LPF if requested
+        mpuLowPassFilter = INV_FILTER_256HZ_NOLPF2;
+    else if (lpf >= 188)
         mpuLowPassFilter = INV_FILTER_98HZ;
     else if (lpf >= 42)
         mpuLowPassFilter = INV_FILTER_42HZ;
@@ -424,6 +424,10 @@ static void mpu6050GyroInit(void)
     i2cWrite(MPU6050_ADDRESS, MPU_RA_SMPLRT_DIV, 0x00); //SMPLRT_DIV    -- SMPLRT_DIV = 0  Sample Rate = Gyroscope Output Rate / (1 + SMPLRT_DIV)
     i2cWrite(MPU6050_ADDRESS, MPU_RA_PWR_MGMT_1, 0x03); //PWR_MGMT_1    -- SLEEP 0; CYCLE 0; TEMP_DIS 0; CLKSEL 3 (PLL with Z Gyro reference)
     delay(15); //PLL Settling time when changing CLKSEL is max 10ms.  Use 15ms to be sure 
+    if(mpuLowPassFilter == INV_FILTER_256HZ_NOLPF2)          // keep 1khz sampling frequency if internal filter is disabled
+        i2cWrite(MPU6050_ADDRESS, MPU_RA_SMPLRT_DIV, 0x07);  //SMPLRT_DIV    -- SMPLRT_DIV = 7  Sample Rate = Gyroscope Output Rate / (1 + SMPLRT_DIV)
+    else
+        i2cWrite(MPU6050_ADDRESS, MPU_RA_SMPLRT_DIV, 0x00);
     i2cWrite(MPU6050_ADDRESS, MPU_RA_CONFIG, mpuLowPassFilter); //CONFIG        -- EXT_SYNC_SET 0 (disable input pin for data sync) ; default DLPF_CFG = 0 => ACC bandwidth = 260Hz  GYRO bandwidth = 256Hz)
     i2cWrite(MPU6050_ADDRESS, MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3);   //GYRO_CONFIG   -- FS_SEL = 3: Full scale set to 2000 deg/sec
 

--- a/src/main/drivers/accgyro_mpu6050.c
+++ b/src/main/drivers/accgyro_mpu6050.c
@@ -372,9 +372,9 @@ bool mpu6050GyroDetect(const mpu6050Config_t *configToUse, gyro_t *gyro, uint16_
     // 16.4 dps/lsb scalefactor
     gyro->scale = 1.0f / 16.4f;
 
-    if (lpf == 256)            // diasable LPF if requested
-        mpuLowPassFilter = INV_FILTER_256HZ_NOLPF2;
-    else if (lpf >= 188)
+    if (lpf >= 188)
+        mpuLowPassFilter = INV_FILTER_188HZ;
+    else if (lpf >= 98)
         mpuLowPassFilter = INV_FILTER_98HZ;
     else if (lpf >= 42)
         mpuLowPassFilter = INV_FILTER_42HZ;
@@ -424,10 +424,6 @@ static void mpu6050GyroInit(void)
     i2cWrite(MPU6050_ADDRESS, MPU_RA_SMPLRT_DIV, 0x00); //SMPLRT_DIV    -- SMPLRT_DIV = 0  Sample Rate = Gyroscope Output Rate / (1 + SMPLRT_DIV)
     i2cWrite(MPU6050_ADDRESS, MPU_RA_PWR_MGMT_1, 0x03); //PWR_MGMT_1    -- SLEEP 0; CYCLE 0; TEMP_DIS 0; CLKSEL 3 (PLL with Z Gyro reference)
     delay(15); //PLL Settling time when changing CLKSEL is max 10ms.  Use 15ms to be sure 
-    if(mpuLowPassFilter == INV_FILTER_256HZ_NOLPF2)          // keep 1khz sampling frequency if internal filter is disabled
-        i2cWrite(MPU6050_ADDRESS, MPU_RA_SMPLRT_DIV, 0x07);  //SMPLRT_DIV    -- SMPLRT_DIV = 7  Sample Rate = Gyroscope Output Rate / (1 + SMPLRT_DIV)
-    else
-        i2cWrite(MPU6050_ADDRESS, MPU_RA_SMPLRT_DIV, 0x00);
     i2cWrite(MPU6050_ADDRESS, MPU_RA_CONFIG, mpuLowPassFilter); //CONFIG        -- EXT_SYNC_SET 0 (disable input pin for data sync) ; default DLPF_CFG = 0 => ACC bandwidth = 260Hz  GYRO bandwidth = 256Hz)
     i2cWrite(MPU6050_ADDRESS, MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3);   //GYRO_CONFIG   -- FS_SEL = 3: Full scale set to 2000 deg/sec
 

--- a/src/main/flight/butterworth.c
+++ b/src/main/flight/butterworth.c
@@ -1,0 +1,51 @@
+/*
+ * butterworth.c
+
+ *
+ *  Created on: 17 jun. 2015
+ *      Author: borisb
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <math.h>
+
+#include "flight/butterworth.h"
+
+
+#define BB0 15191
+#define BB1 30381
+#define BB2 15191
+#define BFACTOR (4096*1024)
+
+#define BA0 4096
+#define BA1 7466
+#define BA2 -3429
+#define AFACTOR BA0
+
+int16_t ButterWs[9]={0,0,0,0,0,0,0,0,0};
+
+int16_t Butter(int16_t *w, int16_t NewValue)
+{
+    int32_t Acc;
+
+    Acc = NewValue*BA0;
+    Acc += (BA1 * w[1]);
+    Acc += (BA2 * w[2]);
+    w[0] = (int16_t) (Acc/AFACTOR);
+    Acc = (BB0 * w[0]);
+    Acc += (BB1 * w[1]);
+    Acc += (BB2 * w[2]);
+    w[2] = w[1];
+    w[1] = w[0];
+    return (int16_t)(Acc/BFACTOR);
+}
+
+
+
+int16_t Butterworth(int axis, int16_t delta) {
+	int16_t NewDelta;
+
+    NewDelta = Butter(&(ButterWs[3*axis]), delta);
+    return NewDelta;
+}

--- a/src/main/flight/butterworth.h
+++ b/src/main/flight/butterworth.h
@@ -1,0 +1,8 @@
+/*
+ * butterworth.h
+ *
+ *  Created on: 17 jun. 2015
+ *      Author: borisb
+ */
+
+int16_t Butterworth(int axis, int16_t delta);

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -93,34 +93,6 @@ void pidResetErrorGyro(void)
 
 const angle_index_t rcAliasToAngleIndexMap[] = { AI_ROLL, AI_PITCH };
 
-#define BB0 15191
-#define BB1 30381
-#define BB2 15191
-#define BFACTOR (4096*1024)
-
-#define BA0 4096
-#define BA1 7466
-#define BA2 -3429
-#define AFACTOR BA0
-
-int16_t ButterWs[9]={0,0,0,0,0,0,0,0,0};
-
-int16_t Butter(int16_t *w, int16_t NewValue)
-{
-    int32_t Acc;
-
-    Acc = NewValue*BA0;
-    Acc += (BA1 * w[1]);
-    Acc += (BA2 * w[2]);
-    w[0] = (int16_t) (Acc/AFACTOR);
-    Acc = (BB0 * w[0]);
-    Acc += (BB1 * w[1]);
-    Acc += (BB2 * w[2]);
-    w[2] = w[1];
-    w[1] = w[0];
-    return (int16_t)(Acc/BFACTOR);
-}
-
 #ifdef AUTOTUNE
 bool shouldAutotune(void)
 {
@@ -335,6 +307,7 @@ static void pidMultiWii23(pidProfile_t *pidProfile, controlRateConfig_t *control
     int32_t rc, error, errorAngle;
     int32_t PTerm, ITerm, PTermACC, ITermACC, DTerm;
     static int16_t lastGyro[2] = { 0, 0 };
+    static int32_t delta1[2] = { 0, 0 }, delta2[2] = { 0, 0 };
     int32_t delta;
 
     if (FLIGHT_MODE(HORIZON_MODE)) {
@@ -390,8 +363,11 @@ static void pidMultiWii23(pidProfile_t *pidProfile, controlRateConfig_t *control
 
         delta = (gyroADC[axis] - lastGyro[axis]) / 4;   // 16 bits is ok here, the dif between 2 consecutive gyro reads is limited to 800
         lastGyro[axis] = gyroADC[axis];
+        DTerm = delta1[axis] + delta2[axis] + delta;
+        delta2[axis] = delta1[axis];
+        delta1[axis] = delta;
 
-        DTerm=(Butter(&(ButterWs[3*axis]), delta) * (dynD8[axis] * 2) * PIDweight[axis] / 100)>>5;
+        DTerm = ((int32_t)DTerm * dynD8[axis]) >> 5;   // 32 bits is needed for calculation
 
         axisPID[axis] = PTerm + ITerm - DTerm;
 
@@ -672,8 +648,8 @@ static void pidRewrite(pidProfile_t *pidProfile, controlRateConfig_t *controlRat
 
     int32_t errorAngle;
     int axis;
-    int32_t delta;
-   //static int32_t delta1[3], delta2[3];
+    int32_t delta, deltaSum;
+    static int32_t delta1[3], delta2[3];
     int32_t PTerm, ITerm, DTerm;
     static int32_t lastError[3] = { 0, 0, 0 };
     int32_t AngleRateTmp, RateError;
@@ -763,8 +739,11 @@ static void pidRewrite(pidProfile_t *pidProfile, controlRateConfig_t *controlRat
         // Correct difference by cycle time. Cycle time is jittery (can be different 2 times), so calculated difference
         // would be scaled by different dt each time. Division by dT fixes that.
         delta = (delta * ((uint16_t) 0xFFFF / (cycleTime >> 4))) >> 6;
-
-        DTerm=(Butter(&(ButterWs[3*axis]), delta) * (pidProfile->D8[axis] * 2) * PIDweight[axis] / 100)>>8;
+        // add moving average here to reduce noise
+        deltaSum = delta1[axis] + delta2[axis] + delta;
+        delta2[axis] = delta1[axis];
+        delta1[axis] = delta;
+        DTerm = (deltaSum * pidProfile->D8[axis] * PIDweight[axis] / 100) >> 8;
 
         // -----calculate total PID output
         axisPID[axis] = PTerm + ITerm + DTerm;

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -55,6 +55,7 @@ typedef struct pidProfile_s {
     float H_level;
     uint8_t H_sensitivity;
     uint16_t yaw_p_limit;                   // set P term limit (fixed value was 300)
+    uint8_t dterm_filtering;
 } pidProfile_t;
 
 #define DEGREES_TO_DECIDEGREES(angle) (angle * 10)

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -448,6 +448,7 @@ const clivalue_t valueTable[] = {
     { "d_vel",                      VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.D8[PIDVEL], 0, 200 },
 
     { "yaw_p_limit",                VAR_UINT16 | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.yaw_p_limit, YAW_P_LIMIT_MIN, YAW_P_LIMIT_MAX },
+	{ "dterm_filtering",            VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.dterm_filtering, 0, 1 },
 
 #ifdef BLACKBOX
     { "blackbox_rate_num",          VAR_UINT8  | MASTER_VALUE,  &masterConfig.blackbox_rate_num, 1, 32 },


### PR DESCRIPTION
Hi guys,

In my search for good Dterm filtering I would like to test this one as well.

So far my results seem great on integer based pid controllers. If someone can help get it right in luxfloat it would be great. Perhaps there should be seperate floating point function for it.

![butterworth](https://cloud.githubusercontent.com/assets/10757508/8221204/b2112a74-155b-11e5-855c-27717b6fda7c.jpg)


Implemented in:
PID0-PID4

On luxfloat I just did a quick implementation and don't trust it now, but on PID0,1,3,4 works fine.

I didn't do anything on harakiri as that one has it's own filter.

To enable:
set dterm_filtering = 1
set gyro_lpf = 188 (256 doesn't really work actually on naze32 boards)

Test hex/binary:

CC3D:
https://dl.dropboxusercontent.com/u/31537757/cleanflight/butterworth/cleanflight_CC3D.bin

Naze32:
https://dl.dropboxusercontent.com/u/31537757/cleanflight/butterworth/cleanflight_NAZE.hex