### PR TITLE
Experimental Butterworth Filter for Dterm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,6 +229,7 @@ COMMON_SRC	 = build_config.c \
 		   flight/imu.c \
 		   flight/mixer.c \
 		   flight/lowpass.c \
+		   flight/butterworth.c \
 		   drivers/bus_i2c_soft.c \
 		   drivers/serial.c \
 		   drivers/sound_beeper.c \

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -171,6 +171,7 @@ static void resetPidProfile(pidProfile_t *pidProfile)
     pidProfile->D8[PIDVEL] = 1;
 
     pidProfile->yaw_p_limit = YAW_P_LIMIT_MAX;
+    pidProfile->dterm_filtering = 0;
 
     pidProfile->P_f[ROLL] = 2.5f;     // new PID with preliminary defaults test carefully
     pidProfile->I_f[ROLL] = 0.6f;

--- a/src/main/flight/butterworth.c
+++ b/src/main/flight/butterworth.c
@@ -1,0 +1,51 @@
+/*
+ * butterworth.c
+
+ *
+ *  Created on: 17 jun. 2015
+ *      Author: borisb
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <math.h>
+
+#include "flight/butterworth.h"
+
+
+#define BB0 15191
+#define BB1 30381
+#define BB2 15191
+#define BFACTOR (4096*1024)
+
+#define BA0 4096
+#define BA1 7466
+#define BA2 -3429
+#define AFACTOR BA0
+
+int16_t ButterWs[9]={0,0,0,0,0,0,0,0,0};
+
+int16_t Butter(int16_t *w, int16_t NewValue)
+{
+    int32_t Acc;
+
+    Acc = NewValue*BA0;
+    Acc += (BA1 * w[1]);
+    Acc += (BA2 * w[2]);
+    w[0] = (int16_t) (Acc/AFACTOR);
+    Acc = (BB0 * w[0]);
+    Acc += (BB1 * w[1]);
+    Acc += (BB2 * w[2]);
+    w[2] = w[1];
+    w[1] = w[0];
+    return (int16_t)(Acc/BFACTOR);
+}
+
+
+
+int16_t Butterworth(int axis, int16_t delta) {
+	int16_t NewDelta;
+
+    NewDelta = Butter(&(ButterWs[3*axis]), delta);
+    return NewDelta;
+}

--- a/src/main/flight/butterworth.h
+++ b/src/main/flight/butterworth.h
@@ -1,0 +1,8 @@
+/*
+ * butterworth.h
+ *
+ *  Created on: 17 jun. 2015
+ *      Author: borisb
+ */
+
+int16_t Butterworth(int axis, int16_t delta);

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -55,6 +55,7 @@ typedef struct pidProfile_s {
     float H_level;
     uint8_t H_sensitivity;
     uint16_t yaw_p_limit;                   // set P term limit (fixed value was 300)
+    uint8_t dterm_filtering;
 } pidProfile_t;
 
 #define DEGREES_TO_DECIDEGREES(angle) (angle * 10)

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -448,6 +448,7 @@ const clivalue_t valueTable[] = {
     { "d_vel",                      VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.D8[PIDVEL], 0, 200 },
 
     { "yaw_p_limit",                VAR_UINT16 | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.yaw_p_limit, YAW_P_LIMIT_MIN, YAW_P_LIMIT_MAX },
+	{ "dterm_filtering",            VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.dterm_filtering, 0, 1 },
 
 #ifdef BLACKBOX
     { "blackbox_rate_num",          VAR_UINT8  | MASTER_VALUE,  &masterConfig.blackbox_rate_num, 1, 32 },


### PR DESCRIPTION
Hi guys,

In my search for good Dterm filtering I would like to test this one as well.

So far my results seem great on integer based pid controllers. If someone can help get it right in luxfloat it would be great. Perhaps there should be seperate floating point function for it.

![butterworth](https://cloud.githubusercontent.com/assets/10757508/8221204/b2112a74-155b-11e5-855c-27717b6fda7c.jpg)


Implemented in:
PID0-PID4

On luxfloat I just did a quick implementation and don't trust it now, but on PID0,1,3,4 works fine.

I didn't do anything on harakiri as that one has it's own filter.

To enable:
set dterm_filtering = 1
set gyro_lpf = 188 (256 doesn't really work actually on naze32 boards)

Test hex/binary:

