### PR TITLE
Test for no EOC connection allowing external I2C baro on acro boards

### DIFF
--- a/src/main/drivers/barometer_bmp085.h
+++ b/src/main/drivers/barometer_bmp085.h
@@ -27,3 +27,6 @@ typedef struct bmp085Config_s {
 
 bool bmp085Detect(const bmp085Config_t *config, baro_t *baro);
 void bmp085Disable(const bmp085Config_t *config);
+#if defined(BARO_EOC_GPIO)
+bool bmp085TestEOCConnected(const bmp085Config_t *config);
+#endif


### PR DESCRIPTION
with some baro code and comments cleanup.
Fixes issue #1017 
