### PR TITLE
Support for 128Mbit SPI flash

### DIFF
--- a/docs/Blackbox.md
+++ b/docs/Blackbox.md
@@ -146,6 +146,8 @@ These chips are also supported:
 * Micron/ST M25P16 - 16 Mbit
 * Micron N25Q064 - 64 Mbit
 * Winbond W25Q64 - 64 Mbit
+* Micron N25Q0128 - 128 Mbit
+* Winbond W25Q128 - 128 Mbit
 
 ## Enabling the Blackbox (CLI)
 In the [Cleanflight Configurator][] , enter the CLI tab. Enable the Blackbox feature by typing in `feature BLACKBOX` and

--- a/src/main/drivers/flash.h
+++ b/src/main/drivers/flash.h
@@ -20,7 +20,7 @@
 #include <stdint.h>
 
 typedef struct flashGeometry_t {
-    uint8_t sectors; // Count of the number of erasable blocks on the device
+    uint16_t sectors; // Count of the number of erasable blocks on the device
 
     uint16_t pagesPerSector;
     uint16_t pageSize; // In bytes

--- a/src/main/drivers/flash_m25p16.c
+++ b/src/main/drivers/flash_m25p16.c
@@ -42,6 +42,8 @@
 #define JEDEC_ID_MICRON_M25P16         0x202015
 #define JEDEC_ID_MICRON_N25Q064        0x20BA17
 #define JEDEC_ID_WINBOND_W25Q64        0xEF4017
+#define JEDEC_ID_MICRON_N25Q128        0x20ba18
+#define JEDEC_ID_WINBOND_W25Q128       0xEF4018
 
 #define DISABLE_M25P16       GPIO_SetBits(M25P16_CS_GPIO,   M25P16_CS_PIN)
 #define ENABLE_M25P16        GPIO_ResetBits(M25P16_CS_GPIO, M25P16_CS_PIN)
@@ -157,6 +159,12 @@ static bool m25p16_readIdentification()
         case JEDEC_ID_MICRON_N25Q064:
         case JEDEC_ID_WINBOND_W25Q64:
             geometry.sectors = 128;
+            geometry.pagesPerSector = 256;
+            geometry.pageSize = 256;
+        break;
+        case JEDEC_ID_MICRON_N25Q128:
+        case JEDEC_ID_WINBOND_W25Q128:
+            geometry.sectors = 256;
             geometry.pagesPerSector = 256;
             geometry.pageSize = 256;
         break;


### PR DESCRIPTION
Support for the following SPI Flash Memorys:
                   
* Micron N25Q0128 - 128 Mbit (not tested but should also work)
* Winbond W25Q128 - 128 Mbit (tested)
