### PR TITLE
Add logging of the inflight adjustment events to the blackbox.

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1013,13 +1013,13 @@ void blackboxLogEvent(FlightLogEvent event, flightLogEventData_t *data)
             blackboxWriteS16(data->autotuneTargets.secondPeakAngle);
         break;
         case FLIGHT_LOG_EVENT_INFLIGHT_ADJUSTMENT:
-        	 if (data->inflightAdjustment.floatFlag) {
-            	 blackboxWrite(data->inflightAdjustment.adjustmentFunction + FLIGHT_LOG_EVENT_INFLIGHT_ADJUSTMENT_FUNCTION_FLOAT_VALUE_FLAG);
-        		 blackboxWriteFloat(data->inflightAdjustment.newFloatValue);
-        	 } else {
-            	 blackboxWrite(data->inflightAdjustment.adjustmentFunction);
-        		 blackboxWriteU32(data->inflightAdjustment.newValue);
-        	 }
+            if (data->inflightAdjustment.floatFlag) {
+                blackboxWrite(data->inflightAdjustment.adjustmentFunction + FLIGHT_LOG_EVENT_INFLIGHT_ADJUSTMENT_FUNCTION_FLOAT_VALUE_FLAG);
+                blackboxWriteFloat(data->inflightAdjustment.newFloatValue);
+            } else {
+                blackboxWrite(data->inflightAdjustment.adjustmentFunction);
+                blackboxWriteSignedVB(data->inflightAdjustment.newValue);
+            }
         break;
         case FLIGHT_LOG_EVENT_LOG_END:
             blackboxPrint("End of log");

--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1012,6 +1012,15 @@ void blackboxLogEvent(FlightLogEvent event, flightLogEventData_t *data)
             blackboxWriteS16(data->autotuneTargets.firstPeakAngle);
             blackboxWriteS16(data->autotuneTargets.secondPeakAngle);
         break;
+        case FLIGHT_LOG_EVENT_INFLIGHT_ADJUSTMENT:
+        	 if (data->inflightAdjustment.floatFlag) {
+            	 blackboxWrite(data->inflightAdjustment.adjustmentFunction + FLIGHT_LOG_EVENT_INFLIGHT_ADJUSTMENT_FUNCTION_FLOAT_VALUE_FLAG);
+        		 blackboxWriteFloat(data->inflightAdjustment.newFloatValue);
+        	 } else {
+            	 blackboxWrite(data->inflightAdjustment.adjustmentFunction);
+        		 blackboxWriteU32(data->inflightAdjustment.newValue);
+        	 }
+        break;
         case FLIGHT_LOG_EVENT_LOG_END:
             blackboxPrint("End of log");
             blackboxWrite(0);

--- a/src/main/blackbox/blackbox_fielddefs.h
+++ b/src/main/blackbox/blackbox_fielddefs.h
@@ -138,10 +138,10 @@ typedef struct flightLogEvent_autotuneTargets_t {
 } flightLogEvent_autotuneTargets_t;
 
 typedef struct flightLogEvent_inflightAdjustment_t {
-	uint8_t adjustmentFunction;
-	bool floatFlag;
-	int32_t newValue;
-	float newFloatValue;
+    uint8_t adjustmentFunction;
+    bool floatFlag;
+    int32_t newValue;
+    float newFloatValue;
 } flightLogEvent_inflightAdjustment_t;
 
 typedef union flightLogEventData_t

--- a/src/main/blackbox/blackbox_fielddefs.h
+++ b/src/main/blackbox/blackbox_fielddefs.h
@@ -103,6 +103,7 @@ typedef enum FlightLogEvent {
     FLIGHT_LOG_EVENT_AUTOTUNE_CYCLE_START = 10,
     FLIGHT_LOG_EVENT_AUTOTUNE_CYCLE_RESULT = 11,
     FLIGHT_LOG_EVENT_AUTOTUNE_TARGETS = 12,
+    FLIGHT_LOG_EVENT_INFLIGHT_ADJUSTMENT = 13,
     FLIGHT_LOG_EVENT_LOG_END = 255
 } FlightLogEvent;
 
@@ -121,6 +122,7 @@ typedef struct flightLogEvent_autotuneCycleStart_t {
 
 #define FLIGHT_LOG_EVENT_AUTOTUNE_FLAG_OVERSHOT 1
 #define FLIGHT_LOG_EVENT_AUTOTUNE_FLAG_TIMEDOUT 2
+#define FLIGHT_LOG_EVENT_INFLIGHT_ADJUSTMENT_FUNCTION_FLOAT_VALUE_FLAG 128
 
 typedef struct flightLogEvent_autotuneCycleResult_t {
     uint8_t flags;
@@ -135,12 +137,20 @@ typedef struct flightLogEvent_autotuneTargets_t {
     uint16_t firstPeakAngle, secondPeakAngle;
 } flightLogEvent_autotuneTargets_t;
 
+typedef struct flightLogEvent_inflightAdjustment_t {
+	uint8_t adjustmentFunction;
+	bool floatFlag;
+	int32_t newValue;
+	float newFloatValue;
+} flightLogEvent_inflightAdjustment_t;
+
 typedef union flightLogEventData_t
 {
     flightLogEvent_syncBeep_t syncBeep;
     flightLogEvent_autotuneCycleStart_t autotuneCycleStart;
     flightLogEvent_autotuneCycleResult_t autotuneCycleResult;
     flightLogEvent_autotuneTargets_t autotuneTargets;
+    flightLogEvent_inflightAdjustment_t inflightAdjustment;
 } flightLogEventData_t;
 
 typedef struct flightLogEvent_t

--- a/src/main/blackbox/blackbox_io.c
+++ b/src/main/blackbox/blackbox_io.c
@@ -407,6 +407,22 @@ void blackboxWriteTag8_8SVB(int32_t *values, int valueCount)
     }
 }
 
+/** Write unsigned integer **/
+void blackboxWriteU32(int32_t value)
+{
+    blackboxWrite(value & 0xFF);
+    blackboxWrite((value >> 8) & 0xFF);
+    blackboxWrite((value >> 16) & 0xFF);
+    blackboxWrite((value >> 24) & 0xFF);
+}
+
+/** Write float value in the integer form **/
+void blackboxWriteFloat(float value)
+{
+    blackboxWriteU32(castFloatBytesToInt(value));
+}
+
+
 /**
  * If there is data waiting to be written to the blackbox device, attempt to write (a portion of) that now.
  * 

--- a/src/main/blackbox/blackbox_io.c
+++ b/src/main/blackbox/blackbox_io.c
@@ -422,7 +422,6 @@ void blackboxWriteFloat(float value)
     blackboxWriteU32(castFloatBytesToInt(value));
 }
 
-
 /**
  * If there is data waiting to be written to the blackbox device, attempt to write (a portion of) that now.
  * 

--- a/src/main/blackbox/blackbox_io.h
+++ b/src/main/blackbox/blackbox_io.h
@@ -45,6 +45,8 @@ void blackboxWriteS16(int16_t value);
 void blackboxWriteTag2_3S32(int32_t *values);
 void blackboxWriteTag8_4S16(int32_t *values);
 void blackboxWriteTag8_8SVB(int32_t *values, int valueCount);
+void blackboxWriteU32(int32_t value);
+void blackboxWriteFloat(float value);
 
 bool blackboxDeviceFlush(void);
 bool blackboxDeviceOpen(void);

--- a/src/main/io/rc_controls.c
+++ b/src/main/io/rc_controls.c
@@ -68,27 +68,30 @@ int16_t rcCommand[4];           // interval [1000;2000] for THROTTLE and [-500;+
 
 uint32_t rcModeActivationMask; // one bit per mode defined in boxId_e
 
+
+void blackboxLogInflightAdjustmentEvent(adjustmentFunction_e adjustmentFunction, int32_t newValue) {
 #ifdef BLACKBOX
-void blackboxLogInflightAdjustmentEvent(adjustmentFunction_e adjustmentFunction, uint32_t newValue) {
-	if (feature(FEATURE_BLACKBOX)) {
-		flightLogEvent_inflightAdjustment_t eventData;
-		eventData.adjustmentFunction = adjustmentFunction;
-		eventData.newValue = newValue;
-		eventData.floatFlag = false;
-		blackboxLogEvent(FLIGHT_LOG_EVENT_INFLIGHT_ADJUSTMENT, (flightLogEventData_t*)&eventData);
-	}
+    if (feature(FEATURE_BLACKBOX)) {
+        flightLogEvent_inflightAdjustment_t eventData;
+        eventData.adjustmentFunction = adjustmentFunction;
+        eventData.newValue = newValue;
+        eventData.floatFlag = false;
+        blackboxLogEvent(FLIGHT_LOG_EVENT_INFLIGHT_ADJUSTMENT, (flightLogEventData_t*)&eventData);
+    }
+#endif
 }
 
 void blackboxLogInflightAdjustmentEventFloat(adjustmentFunction_e adjustmentFunction, float newFloatValue) {
-	if (feature(FEATURE_BLACKBOX)) {
-		flightLogEvent_inflightAdjustment_t eventData;
-		eventData.adjustmentFunction = adjustmentFunction;
-		eventData.newFloatValue = newFloatValue;
-		eventData.floatFlag = true;
-		blackboxLogEvent(FLIGHT_LOG_EVENT_INFLIGHT_ADJUSTMENT, (flightLogEventData_t*)&eventData);
-	}
-}
+#ifdef BLACKBOX
+    if (feature(FEATURE_BLACKBOX)) {
+        flightLogEvent_inflightAdjustment_t eventData;
+        eventData.adjustmentFunction = adjustmentFunction;
+        eventData.newFloatValue = newFloatValue;
+        eventData.floatFlag = true;
+        blackboxLogEvent(FLIGHT_LOG_EVENT_INFLIGHT_ADJUSTMENT, (flightLogEventData_t*)&eventData);
+    }
 #endif
+}
 
 bool isUsingSticksForArming(void)
 {
@@ -110,8 +113,6 @@ throttleStatus_e calculateThrottleStatus(rxConfig_t *rxConfig, uint16_t deadband
 
     return THROTTLE_HIGH;
 }
-
-
 
 void processRcStickPositions(rxConfig_t *rxConfig, throttleStatus_e throttleStatus, bool retarded_arm, bool disarm_kill_switch)
 {
@@ -469,33 +470,25 @@ void applyStepAdjustment(controlRateConfig_t *controlRateConfig, uint8_t adjustm
             newValue = constrain((int)controlRateConfig->rcRate8 + delta, 0, 250); // FIXME magic numbers repeated in serial_cli.c
             controlRateConfig->rcRate8 = newValue;
             generatePitchRollCurve(controlRateConfig);
-#ifdef BLACKBOX
             blackboxLogInflightAdjustmentEvent(ADJUSTMENT_RC_RATE, newValue);
-#endif
         break;
         case ADJUSTMENT_RC_EXPO:
             newValue = constrain((int)controlRateConfig->rcExpo8 + delta, 0, 100); // FIXME magic numbers repeated in serial_cli.c
             controlRateConfig->rcExpo8 = newValue;
             generatePitchRollCurve(controlRateConfig);
-#ifdef BLACKBOX
             blackboxLogInflightAdjustmentEvent(ADJUSTMENT_RC_EXPO, newValue);
-#endif
         break;
         case ADJUSTMENT_THROTTLE_EXPO:
             newValue = constrain((int)controlRateConfig->thrExpo8 + delta, 0, 100); // FIXME magic numbers repeated in serial_cli.c
             controlRateConfig->thrExpo8 = newValue;
             generateThrottleCurve(controlRateConfig, escAndServoConfig);
-#ifdef BLACKBOX
             blackboxLogInflightAdjustmentEvent(ADJUSTMENT_THROTTLE_EXPO, newValue);
-#endif
     	break;
         case ADJUSTMENT_PITCH_ROLL_RATE:
         case ADJUSTMENT_PITCH_RATE:
             newValue = constrain((int)controlRateConfig->rates[FD_PITCH] + delta, 0, CONTROL_RATE_CONFIG_ROLL_PITCH_RATE_MAX);
             controlRateConfig->rates[FD_PITCH] = newValue;
-#ifdef BLACKBOX
             blackboxLogInflightAdjustmentEvent(ADJUSTMENT_PITCH_RATE, newValue);
-#endif
             if (adjustmentFunction == ADJUSTMENT_PITCH_RATE) {
                 break;
             }
@@ -503,31 +496,23 @@ void applyStepAdjustment(controlRateConfig_t *controlRateConfig, uint8_t adjustm
         case ADJUSTMENT_ROLL_RATE:
             newValue = constrain((int)controlRateConfig->rates[FD_ROLL] + delta, 0, CONTROL_RATE_CONFIG_ROLL_PITCH_RATE_MAX);
             controlRateConfig->rates[FD_ROLL] = newValue;
-#ifdef BLACKBOX
             blackboxLogInflightAdjustmentEvent(ADJUSTMENT_ROLL_RATE, newValue);
-#endif
             break;
         case ADJUSTMENT_YAW_RATE:
             newValue = constrain((int)controlRateConfig->rates[FD_YAW] + delta, 0, CONTROL_RATE_CONFIG_YAW_RATE_MAX);
             controlRateConfig->rates[FD_YAW] = newValue;
-#ifdef BLACKBOX
             blackboxLogInflightAdjustmentEvent(ADJUSTMENT_YAW_RATE, newValue);
-#endif
-    		break;
+            break;
         case ADJUSTMENT_PITCH_ROLL_P:
         case ADJUSTMENT_PITCH_P:
             if (IS_PID_CONTROLLER_FP_BASED(pidProfile->pidController)) {
                 newFloatValue = constrainf(pidProfile->P_f[PIDPITCH] + (float)(delta / 10.0f), 0, 100); // FIXME magic numbers repeated in serial_cli.c
                 pidProfile->P_f[PIDPITCH] = newFloatValue;
-#ifdef BLACKBOX
                 blackboxLogInflightAdjustmentEventFloat(ADJUSTMENT_PITCH_P, newFloatValue);
-#endif
             } else {
                 newValue = constrain((int)pidProfile->P8[PIDPITCH] + delta, 0, 200); // FIXME magic numbers repeated in serial_cli.c
                 pidProfile->P8[PIDPITCH] = newValue;
-#ifdef BLACKBOX
                 blackboxLogInflightAdjustmentEvent(ADJUSTMENT_PITCH_P, newValue);
-#endif
             }
             if (adjustmentFunction == ADJUSTMENT_PITCH_P) {
                 break;
@@ -537,15 +522,11 @@ void applyStepAdjustment(controlRateConfig_t *controlRateConfig, uint8_t adjustm
             if (IS_PID_CONTROLLER_FP_BASED(pidProfile->pidController)) {
                 newFloatValue = constrainf(pidProfile->P_f[PIDROLL] + (float)(delta / 10.0f), 0, 100); // FIXME magic numbers repeated in serial_cli.c
                 pidProfile->P_f[PIDROLL] = newFloatValue;
-#ifdef BLACKBOX
                 blackboxLogInflightAdjustmentEventFloat(ADJUSTMENT_ROLL_P, newFloatValue);
-#endif
             } else {
                 newValue = constrain((int)pidProfile->P8[PIDROLL] + delta, 0, 200); // FIXME magic numbers repeated in serial_cli.c
                 pidProfile->P8[PIDROLL] = newValue;
-#ifdef BLACKBOX
                 blackboxLogInflightAdjustmentEvent(ADJUSTMENT_ROLL_P, newValue);
-#endif
             }
             break;
         case ADJUSTMENT_PITCH_ROLL_I:
@@ -553,15 +534,11 @@ void applyStepAdjustment(controlRateConfig_t *controlRateConfig, uint8_t adjustm
             if (IS_PID_CONTROLLER_FP_BASED(pidProfile->pidController)) {
                 newFloatValue = constrainf(pidProfile->I_f[PIDPITCH] + (float)(delta / 100.0f), 0, 100); // FIXME magic numbers repeated in serial_cli.c
                 pidProfile->I_f[PIDPITCH] = newFloatValue;
-#ifdef BLACKBOX
                 blackboxLogInflightAdjustmentEventFloat(ADJUSTMENT_PITCH_I, newFloatValue);
-#endif
             } else {
                 newValue = constrain((int)pidProfile->I8[PIDPITCH] + delta, 0, 200); // FIXME magic numbers repeated in serial_cli.c
                 pidProfile->I8[PIDPITCH] = newValue;
-#ifdef BLACKBOX
                 blackboxLogInflightAdjustmentEvent(ADJUSTMENT_PITCH_I, newValue);
-#endif
             }
             if (adjustmentFunction == ADJUSTMENT_PITCH_I) {
                 break;
@@ -571,15 +548,11 @@ void applyStepAdjustment(controlRateConfig_t *controlRateConfig, uint8_t adjustm
             if (IS_PID_CONTROLLER_FP_BASED(pidProfile->pidController)) {
                 newFloatValue = constrainf(pidProfile->I_f[PIDROLL] + (float)(delta / 100.0f), 0, 100); // FIXME magic numbers repeated in serial_cli.c
                 pidProfile->I_f[PIDROLL] = newFloatValue;
-#ifdef BLACKBOX
                 blackboxLogInflightAdjustmentEventFloat(ADJUSTMENT_ROLL_I, newFloatValue);
-#endif
             } else {
                 newValue = constrain((int)pidProfile->I8[PIDROLL] + delta, 0, 200); // FIXME magic numbers repeated in serial_cli.c
                 pidProfile->I8[PIDROLL] = newValue;
-#ifdef BLACKBOX
                 blackboxLogInflightAdjustmentEvent(ADJUSTMENT_ROLL_I, newValue);
-#endif
             }
             break;
         case ADJUSTMENT_PITCH_ROLL_D:
@@ -587,15 +560,11 @@ void applyStepAdjustment(controlRateConfig_t *controlRateConfig, uint8_t adjustm
             if (IS_PID_CONTROLLER_FP_BASED(pidProfile->pidController)) {
                 newFloatValue = constrainf(pidProfile->D_f[PIDPITCH] + (float)(delta / 1000.0f), 0, 100); // FIXME magic numbers repeated in serial_cli.c
                 pidProfile->D_f[PIDPITCH] = newFloatValue;
-#ifdef BLACKBOX
                 blackboxLogInflightAdjustmentEventFloat(ADJUSTMENT_PITCH_D, newFloatValue);
-#endif
             } else {
                 newValue = constrain((int)pidProfile->D8[PIDPITCH] + delta, 0, 200); // FIXME magic numbers repeated in serial_cli.c
                 pidProfile->D8[PIDPITCH] = newValue;
-#ifdef BLACKBOX
-    blackboxLogInflightAdjustmentEvent(ADJUSTMENT_PITCH_D, newValue);
-#endif
+                blackboxLogInflightAdjustmentEvent(ADJUSTMENT_PITCH_D, newValue);
             }
             if (adjustmentFunction == ADJUSTMENT_PITCH_D) {
                 break;
@@ -605,60 +574,44 @@ void applyStepAdjustment(controlRateConfig_t *controlRateConfig, uint8_t adjustm
             if (IS_PID_CONTROLLER_FP_BASED(pidProfile->pidController)) {
                 newFloatValue = constrainf(pidProfile->D_f[PIDROLL] + (float)(delta / 1000.0f), 0, 100); // FIXME magic numbers repeated in serial_cli.c
                 pidProfile->D_f[PIDROLL] = newFloatValue;
-#ifdef BLACKBOX
                 blackboxLogInflightAdjustmentEventFloat(ADJUSTMENT_ROLL_D, newFloatValue);
-#endif
             } else {
                 newValue = constrain((int)pidProfile->D8[PIDROLL] + delta, 0, 200); // FIXME magic numbers repeated in serial_cli.c
                 pidProfile->D8[PIDROLL] = newValue;
-#ifdef BLACKBOX
                 blackboxLogInflightAdjustmentEvent(ADJUSTMENT_ROLL_D, newValue);
-#endif
             }
             break;
         case ADJUSTMENT_YAW_P:
             if (IS_PID_CONTROLLER_FP_BASED(pidProfile->pidController)) {
                 newFloatValue = constrainf(pidProfile->P_f[PIDYAW] + (float)(delta / 10.0f), 0, 100); // FIXME magic numbers repeated in serial_cli.c
                 pidProfile->P_f[PIDYAW] = newFloatValue;
-#ifdef BLACKBOX
                 blackboxLogInflightAdjustmentEventFloat(ADJUSTMENT_YAW_P, newFloatValue);
-#endif
             } else {
                 newValue = constrain((int)pidProfile->P8[PIDYAW] + delta, 0, 200); // FIXME magic numbers repeated in serial_cli.c
                 pidProfile->P8[PIDYAW] = newValue;
-#ifdef BLACKBOX
                 blackboxLogInflightAdjustmentEvent(ADJUSTMENT_YAW_P, newValue);
-#endif
             }
             break;
         case ADJUSTMENT_YAW_I:
             if (IS_PID_CONTROLLER_FP_BASED(pidProfile->pidController)) {
                 newFloatValue = constrainf(pidProfile->I_f[PIDYAW] + (float)(delta / 100.0f), 0, 100); // FIXME magic numbers repeated in serial_cli.c
                 pidProfile->I_f[PIDYAW] = newFloatValue;
-#ifdef BLACKBOX
                 blackboxLogInflightAdjustmentEventFloat(ADJUSTMENT_YAW_I, newFloatValue);
-#endif
             } else {
                 newValue = constrain((int)pidProfile->I8[PIDYAW] + delta, 0, 200); // FIXME magic numbers repeated in serial_cli.c
                 pidProfile->I8[PIDYAW] = newValue;
-#ifdef BLACKBOX
                 blackboxLogInflightAdjustmentEvent(ADJUSTMENT_YAW_I, newValue);
-#endif
             }
             break;
         case ADJUSTMENT_YAW_D:
             if (IS_PID_CONTROLLER_FP_BASED(pidProfile->pidController)) {
                 newFloatValue = constrainf(pidProfile->D_f[PIDYAW] + (float)(delta / 1000.0f), 0, 100); // FIXME magic numbers repeated in serial_cli.c
                 pidProfile->D_f[PIDYAW] = newFloatValue;
-#ifdef BLACKBOX
                 blackboxLogInflightAdjustmentEventFloat(ADJUSTMENT_YAW_D, newFloatValue);
-#endif
             } else {
                 newValue = constrain((int)pidProfile->D8[PIDYAW] + delta, 0, 200); // FIXME magic numbers repeated in serial_cli.c
                 pidProfile->D8[PIDYAW] = newValue;
-#ifdef BLACKBOX
                 blackboxLogInflightAdjustmentEvent(ADJUSTMENT_YAW_D, newValue);
-#endif
             }
             break;
         default:
@@ -676,9 +629,7 @@ void applySelectAdjustment(uint8_t adjustmentFunction, uint8_t position)
         case ADJUSTMENT_RATE_PROFILE:
             if (getCurrentControlRateProfile() != position) {
                 changeControlRateProfile(position);
-#ifdef BLACKBOX
                 blackboxLogInflightAdjustmentEvent(ADJUSTMENT_RATE_PROFILE, position);
-#endif
                 applied = true;
             }
             break;

--- a/src/main/io/rc_controls.c
+++ b/src/main/io/rc_controls.c
@@ -483,7 +483,7 @@ void applyStepAdjustment(controlRateConfig_t *controlRateConfig, uint8_t adjustm
             controlRateConfig->thrExpo8 = newValue;
             generateThrottleCurve(controlRateConfig, escAndServoConfig);
             blackboxLogInflightAdjustmentEvent(ADJUSTMENT_THROTTLE_EXPO, newValue);
-    	break;
+        break;
         case ADJUSTMENT_PITCH_ROLL_RATE:
         case ADJUSTMENT_PITCH_RATE:
             newValue = constrain((int)controlRateConfig->rates[FD_PITCH] + delta, 0, CONTROL_RATE_CONFIG_ROLL_PITCH_RATE_MAX);

--- a/src/main/io/rc_controls.c
+++ b/src/main/io/rc_controls.c
@@ -520,7 +520,7 @@ void applyStepAdjustment(controlRateConfig_t *controlRateConfig, uint8_t adjustm
                 newFloatValue = constrainf(pidProfile->P_f[PIDPITCH] + (float)(delta / 10.0f), 0, 100); // FIXME magic numbers repeated in serial_cli.c
                 pidProfile->P_f[PIDPITCH] = newFloatValue;
 #ifdef BLACKBOX
-    			blackboxLogInflightAdjustmentEventFloat(ADJUSTMENT_PITCH_P, newFloatValue);
+                blackboxLogInflightAdjustmentEventFloat(ADJUSTMENT_PITCH_P, newFloatValue);
 #endif
             } else {
                 newValue = constrain((int)pidProfile->P8[PIDPITCH] + delta, 0, 200); // FIXME magic numbers repeated in serial_cli.c
@@ -538,7 +538,7 @@ void applyStepAdjustment(controlRateConfig_t *controlRateConfig, uint8_t adjustm
                 newFloatValue = constrainf(pidProfile->P_f[PIDROLL] + (float)(delta / 10.0f), 0, 100); // FIXME magic numbers repeated in serial_cli.c
                 pidProfile->P_f[PIDROLL] = newFloatValue;
 #ifdef BLACKBOX
-    			blackboxLogInflightAdjustmentEventFloat(ADJUSTMENT_ROLL_P, newFloatValue);
+                blackboxLogInflightAdjustmentEventFloat(ADJUSTMENT_ROLL_P, newFloatValue);
 #endif
             } else {
                 newValue = constrain((int)pidProfile->P8[PIDROLL] + delta, 0, 200); // FIXME magic numbers repeated in serial_cli.c
@@ -554,7 +554,7 @@ void applyStepAdjustment(controlRateConfig_t *controlRateConfig, uint8_t adjustm
                 newFloatValue = constrainf(pidProfile->I_f[PIDPITCH] + (float)(delta / 100.0f), 0, 100); // FIXME magic numbers repeated in serial_cli.c
                 pidProfile->I_f[PIDPITCH] = newFloatValue;
 #ifdef BLACKBOX
-    			blackboxLogInflightAdjustmentEventFloat(ADJUSTMENT_PITCH_I, newFloatValue);
+                blackboxLogInflightAdjustmentEventFloat(ADJUSTMENT_PITCH_I, newFloatValue);
 #endif
             } else {
                 newValue = constrain((int)pidProfile->I8[PIDPITCH] + delta, 0, 200); // FIXME magic numbers repeated in serial_cli.c
@@ -572,7 +572,7 @@ void applyStepAdjustment(controlRateConfig_t *controlRateConfig, uint8_t adjustm
                 newFloatValue = constrainf(pidProfile->I_f[PIDROLL] + (float)(delta / 100.0f), 0, 100); // FIXME magic numbers repeated in serial_cli.c
                 pidProfile->I_f[PIDROLL] = newFloatValue;
 #ifdef BLACKBOX
-    			blackboxLogInflightAdjustmentEventFloat(ADJUSTMENT_ROLL_I, newFloatValue);
+                blackboxLogInflightAdjustmentEventFloat(ADJUSTMENT_ROLL_I, newFloatValue);
 #endif
             } else {
                 newValue = constrain((int)pidProfile->I8[PIDROLL] + delta, 0, 200); // FIXME magic numbers repeated in serial_cli.c
@@ -588,7 +588,7 @@ void applyStepAdjustment(controlRateConfig_t *controlRateConfig, uint8_t adjustm
                 newFloatValue = constrainf(pidProfile->D_f[PIDPITCH] + (float)(delta / 1000.0f), 0, 100); // FIXME magic numbers repeated in serial_cli.c
                 pidProfile->D_f[PIDPITCH] = newFloatValue;
 #ifdef BLACKBOX
-    			blackboxLogInflightAdjustmentEventFloat(ADJUSTMENT_PITCH_D, newFloatValue);
+                blackboxLogInflightAdjustmentEventFloat(ADJUSTMENT_PITCH_D, newFloatValue);
 #endif
             } else {
                 newValue = constrain((int)pidProfile->D8[PIDPITCH] + delta, 0, 200); // FIXME magic numbers repeated in serial_cli.c
@@ -606,7 +606,7 @@ void applyStepAdjustment(controlRateConfig_t *controlRateConfig, uint8_t adjustm
                 newFloatValue = constrainf(pidProfile->D_f[PIDROLL] + (float)(delta / 1000.0f), 0, 100); // FIXME magic numbers repeated in serial_cli.c
                 pidProfile->D_f[PIDROLL] = newFloatValue;
 #ifdef BLACKBOX
-    			blackboxLogInflightAdjustmentEventFloat(ADJUSTMENT_ROLL_D, newFloatValue);
+                blackboxLogInflightAdjustmentEventFloat(ADJUSTMENT_ROLL_D, newFloatValue);
 #endif
             } else {
                 newValue = constrain((int)pidProfile->D8[PIDROLL] + delta, 0, 200); // FIXME magic numbers repeated in serial_cli.c
@@ -621,7 +621,7 @@ void applyStepAdjustment(controlRateConfig_t *controlRateConfig, uint8_t adjustm
                 newFloatValue = constrainf(pidProfile->P_f[PIDYAW] + (float)(delta / 10.0f), 0, 100); // FIXME magic numbers repeated in serial_cli.c
                 pidProfile->P_f[PIDYAW] = newFloatValue;
 #ifdef BLACKBOX
-    			blackboxLogInflightAdjustmentEventFloat(ADJUSTMENT_YAW_P, newFloatValue);
+                blackboxLogInflightAdjustmentEventFloat(ADJUSTMENT_YAW_P, newFloatValue);
 #endif
             } else {
                 newValue = constrain((int)pidProfile->P8[PIDYAW] + delta, 0, 200); // FIXME magic numbers repeated in serial_cli.c
@@ -636,7 +636,7 @@ void applyStepAdjustment(controlRateConfig_t *controlRateConfig, uint8_t adjustm
                 newFloatValue = constrainf(pidProfile->I_f[PIDYAW] + (float)(delta / 100.0f), 0, 100); // FIXME magic numbers repeated in serial_cli.c
                 pidProfile->I_f[PIDYAW] = newFloatValue;
 #ifdef BLACKBOX
-    			blackboxLogInflightAdjustmentEventFloat(ADJUSTMENT_YAW_I, newFloatValue);
+                blackboxLogInflightAdjustmentEventFloat(ADJUSTMENT_YAW_I, newFloatValue);
 #endif
             } else {
                 newValue = constrain((int)pidProfile->I8[PIDYAW] + delta, 0, 200); // FIXME magic numbers repeated in serial_cli.c
@@ -651,7 +651,7 @@ void applyStepAdjustment(controlRateConfig_t *controlRateConfig, uint8_t adjustm
                 newFloatValue = constrainf(pidProfile->D_f[PIDYAW] + (float)(delta / 1000.0f), 0, 100); // FIXME magic numbers repeated in serial_cli.c
                 pidProfile->D_f[PIDYAW] = newFloatValue;
 #ifdef BLACKBOX
-    			blackboxLogInflightAdjustmentEventFloat(ADJUSTMENT_YAW_D, newFloatValue);
+                blackboxLogInflightAdjustmentEventFloat(ADJUSTMENT_YAW_D, newFloatValue);
 #endif
             } else {
                 newValue = constrain((int)pidProfile->D8[PIDYAW] + delta, 0, 200); // FIXME magic numbers repeated in serial_cli.c

--- a/src/main/io/rc_controls.c
+++ b/src/main/io/rc_controls.c
@@ -53,6 +53,8 @@
 #include "flight/navigation.h"
 #include "flight/failsafe.h"
 
+#include "blackbox/blackbox.h"
+
 #include "mw.h"
 
 
@@ -66,6 +68,27 @@ int16_t rcCommand[4];           // interval [1000;2000] for THROTTLE and [-500;+
 
 uint32_t rcModeActivationMask; // one bit per mode defined in boxId_e
 
+#ifdef BLACKBOX
+void blackboxLogInflightAdjustmentEvent(adjustmentFunction_e adjustmentFunction, uint32_t newValue) {
+	if (feature(FEATURE_BLACKBOX)) {
+		flightLogEvent_inflightAdjustment_t eventData;
+		eventData.adjustmentFunction = adjustmentFunction;
+		eventData.newValue = newValue;
+		eventData.floatFlag = false;
+		blackboxLogEvent(FLIGHT_LOG_EVENT_INFLIGHT_ADJUSTMENT, (flightLogEventData_t*)&eventData);
+	}
+}
+
+void blackboxLogInflightAdjustmentEventFloat(adjustmentFunction_e adjustmentFunction, float newFloatValue) {
+	if (feature(FEATURE_BLACKBOX)) {
+		flightLogEvent_inflightAdjustment_t eventData;
+		eventData.adjustmentFunction = adjustmentFunction;
+		eventData.newFloatValue = newFloatValue;
+		eventData.floatFlag = true;
+		blackboxLogEvent(FLIGHT_LOG_EVENT_INFLIGHT_ADJUSTMENT, (flightLogEventData_t*)&eventData);
+	}
+}
+#endif
 
 bool isUsingSticksForArming(void)
 {
@@ -443,44 +466,68 @@ void applyStepAdjustment(controlRateConfig_t *controlRateConfig, uint8_t adjustm
     }
     switch(adjustmentFunction) {
         case ADJUSTMENT_RC_RATE:
-            newValue = (int)controlRateConfig->rcRate8 + delta;
-            controlRateConfig->rcRate8 = constrain(newValue, 0, 250); // FIXME magic numbers repeated in serial_cli.c
+            newValue = constrain((int)controlRateConfig->rcRate8 + delta, 0, 250); // FIXME magic numbers repeated in serial_cli.c
+            controlRateConfig->rcRate8 = newValue;
             generatePitchRollCurve(controlRateConfig);
+#ifdef BLACKBOX
+            blackboxLogInflightAdjustmentEvent(ADJUSTMENT_RC_RATE, newValue);
+#endif
         break;
         case ADJUSTMENT_RC_EXPO:
-            newValue = (int)controlRateConfig->rcExpo8 + delta;
-            controlRateConfig->rcExpo8 = constrain(newValue, 0, 100); // FIXME magic numbers repeated in serial_cli.c
+            newValue = constrain((int)controlRateConfig->rcExpo8 + delta, 0, 100); // FIXME magic numbers repeated in serial_cli.c
+            controlRateConfig->rcExpo8 = newValue;
             generatePitchRollCurve(controlRateConfig);
-            break;
+#ifdef BLACKBOX
+            blackboxLogInflightAdjustmentEvent(ADJUSTMENT_RC_EXPO, newValue);
+#endif
+        break;
         case ADJUSTMENT_THROTTLE_EXPO:
-            newValue = (int)controlRateConfig->thrExpo8 + delta;
-            controlRateConfig->thrExpo8 = constrain(newValue, 0, 100); // FIXME magic numbers repeated in serial_cli.c
+            newValue = constrain((int)controlRateConfig->thrExpo8 + delta, 0, 100); // FIXME magic numbers repeated in serial_cli.c
+            controlRateConfig->thrExpo8 = newValue;
             generateThrottleCurve(controlRateConfig, escAndServoConfig);
-            break;
+#ifdef BLACKBOX
+            blackboxLogInflightAdjustmentEvent(ADJUSTMENT_THROTTLE_EXPO, newValue);
+#endif
+    	break;
         case ADJUSTMENT_PITCH_ROLL_RATE:
         case ADJUSTMENT_PITCH_RATE:
-            newValue = (int)controlRateConfig->rates[FD_PITCH] + delta;
-            controlRateConfig->rates[FD_PITCH] = constrain(newValue, 0, CONTROL_RATE_CONFIG_ROLL_PITCH_RATE_MAX);
+            newValue = constrain((int)controlRateConfig->rates[FD_PITCH] + delta, 0, CONTROL_RATE_CONFIG_ROLL_PITCH_RATE_MAX);
+            controlRateConfig->rates[FD_PITCH] = newValue;
+#ifdef BLACKBOX
+            blackboxLogInflightAdjustmentEvent(ADJUSTMENT_PITCH_RATE, newValue);
+#endif
             if (adjustmentFunction == ADJUSTMENT_PITCH_RATE) {
                 break;
             }
             // follow though for combined ADJUSTMENT_PITCH_ROLL_RATE
         case ADJUSTMENT_ROLL_RATE:
-            newValue = (int)controlRateConfig->rates[FD_ROLL] + delta;
-            controlRateConfig->rates[FD_ROLL] = constrain(newValue, 0, CONTROL_RATE_CONFIG_ROLL_PITCH_RATE_MAX);
+            newValue = constrain((int)controlRateConfig->rates[FD_ROLL] + delta, 0, CONTROL_RATE_CONFIG_ROLL_PITCH_RATE_MAX);
+            controlRateConfig->rates[FD_ROLL] = newValue;
+#ifdef BLACKBOX
+            blackboxLogInflightAdjustmentEvent(ADJUSTMENT_ROLL_RATE, newValue);
+#endif
             break;
         case ADJUSTMENT_YAW_RATE:
-            newValue = (int)controlRateConfig->rates[FD_YAW] + delta;
-            controlRateConfig->rates[FD_YAW] = constrain(newValue, 0, CONTROL_RATE_CONFIG_YAW_RATE_MAX);
-            break;
+            newValue = constrain((int)controlRateConfig->rates[FD_YAW] + delta, 0, CONTROL_RATE_CONFIG_YAW_RATE_MAX);
+            controlRateConfig->rates[FD_YAW] = newValue;
+#ifdef BLACKBOX
+            blackboxLogInflightAdjustmentEvent(ADJUSTMENT_YAW_RATE, newValue);
+#endif
+    		break;
         case ADJUSTMENT_PITCH_ROLL_P:
         case ADJUSTMENT_PITCH_P:
             if (IS_PID_CONTROLLER_FP_BASED(pidProfile->pidController)) {
-                newFloatValue = pidProfile->P_f[PIDPITCH] + (float)(delta / 10.0f);
-                pidProfile->P_f[PIDPITCH] = constrainf(newFloatValue, 0, 100); // FIXME magic numbers repeated in serial_cli.c
+                newFloatValue = constrainf(pidProfile->P_f[PIDPITCH] + (float)(delta / 10.0f), 0, 100); // FIXME magic numbers repeated in serial_cli.c
+                pidProfile->P_f[PIDPITCH] = newFloatValue;
+#ifdef BLACKBOX
+    			blackboxLogInflightAdjustmentEventFloat(ADJUSTMENT_PITCH_P, newFloatValue);
+#endif
             } else {
-                newValue = (int)pidProfile->P8[PIDPITCH] + delta;
-                pidProfile->P8[PIDPITCH] = constrain(newValue, 0, 200); // FIXME magic numbers repeated in serial_cli.c
+                newValue = constrain((int)pidProfile->P8[PIDPITCH] + delta, 0, 200); // FIXME magic numbers repeated in serial_cli.c
+                pidProfile->P8[PIDPITCH] = newValue;
+#ifdef BLACKBOX
+                blackboxLogInflightAdjustmentEvent(ADJUSTMENT_PITCH_P, newValue);
+#endif
             }
             if (adjustmentFunction == ADJUSTMENT_PITCH_P) {
                 break;
@@ -488,21 +535,33 @@ void applyStepAdjustment(controlRateConfig_t *controlRateConfig, uint8_t adjustm
             // follow though for combined ADJUSTMENT_PITCH_ROLL_P
         case ADJUSTMENT_ROLL_P:
             if (IS_PID_CONTROLLER_FP_BASED(pidProfile->pidController)) {
-                newFloatValue = pidProfile->P_f[PIDROLL] + (float)(delta / 10.0f);
-                pidProfile->P_f[PIDROLL] = constrainf(newFloatValue, 0, 100); // FIXME magic numbers repeated in serial_cli.c
+                newFloatValue = constrainf(pidProfile->P_f[PIDROLL] + (float)(delta / 10.0f), 0, 100); // FIXME magic numbers repeated in serial_cli.c
+                pidProfile->P_f[PIDROLL] = newFloatValue;
+#ifdef BLACKBOX
+    			blackboxLogInflightAdjustmentEventFloat(ADJUSTMENT_ROLL_P, newFloatValue);
+#endif
             } else {
-                newValue = (int)pidProfile->P8[PIDROLL] + delta;
-                pidProfile->P8[PIDROLL] = constrain(newValue, 0, 200); // FIXME magic numbers repeated in serial_cli.c
+                newValue = constrain((int)pidProfile->P8[PIDROLL] + delta, 0, 200); // FIXME magic numbers repeated in serial_cli.c
+                pidProfile->P8[PIDROLL] = newValue;
+#ifdef BLACKBOX
+                blackboxLogInflightAdjustmentEvent(ADJUSTMENT_ROLL_P, newValue);
+#endif
             }
             break;
         case ADJUSTMENT_PITCH_ROLL_I:
         case ADJUSTMENT_PITCH_I:
             if (IS_PID_CONTROLLER_FP_BASED(pidProfile->pidController)) {
-                newFloatValue = pidProfile->I_f[PIDPITCH] + (float)(delta / 100.0f);
-                pidProfile->I_f[PIDPITCH] = constrainf(newFloatValue, 0, 100); // FIXME magic numbers repeated in serial_cli.c
+                newFloatValue = constrainf(pidProfile->I_f[PIDPITCH] + (float)(delta / 100.0f), 0, 100); // FIXME magic numbers repeated in serial_cli.c
+                pidProfile->I_f[PIDPITCH] = newFloatValue;
+#ifdef BLACKBOX
+    			blackboxLogInflightAdjustmentEventFloat(ADJUSTMENT_PITCH_I, newFloatValue);
+#endif
             } else {
-                newValue = (int)pidProfile->I8[PIDPITCH] + delta;
-                pidProfile->I8[PIDPITCH] = constrain(newValue, 0, 200); // FIXME magic numbers repeated in serial_cli.c
+                newValue = constrain((int)pidProfile->I8[PIDPITCH] + delta, 0, 200); // FIXME magic numbers repeated in serial_cli.c
+                pidProfile->I8[PIDPITCH] = newValue;
+#ifdef BLACKBOX
+                blackboxLogInflightAdjustmentEvent(ADJUSTMENT_PITCH_I, newValue);
+#endif
             }
             if (adjustmentFunction == ADJUSTMENT_PITCH_I) {
                 break;
@@ -510,21 +569,33 @@ void applyStepAdjustment(controlRateConfig_t *controlRateConfig, uint8_t adjustm
             // follow though for combined ADJUSTMENT_PITCH_ROLL_I
         case ADJUSTMENT_ROLL_I:
             if (IS_PID_CONTROLLER_FP_BASED(pidProfile->pidController)) {
-                newFloatValue = pidProfile->I_f[PIDROLL] + (float)(delta / 100.0f);
-                pidProfile->I_f[PIDROLL] = constrainf(newFloatValue, 0, 100); // FIXME magic numbers repeated in serial_cli.c
+                newFloatValue = constrainf(pidProfile->I_f[PIDROLL] + (float)(delta / 100.0f), 0, 100); // FIXME magic numbers repeated in serial_cli.c
+                pidProfile->I_f[PIDROLL] = newFloatValue;
+#ifdef BLACKBOX
+    			blackboxLogInflightAdjustmentEventFloat(ADJUSTMENT_ROLL_I, newFloatValue);
+#endif
             } else {
-                newValue = (int)pidProfile->I8[PIDROLL] + delta;
-                pidProfile->I8[PIDROLL] = constrain(newValue, 0, 200); // FIXME magic numbers repeated in serial_cli.c
+                newValue = constrain((int)pidProfile->I8[PIDROLL] + delta, 0, 200); // FIXME magic numbers repeated in serial_cli.c
+                pidProfile->I8[PIDROLL] = newValue;
+#ifdef BLACKBOX
+                blackboxLogInflightAdjustmentEvent(ADJUSTMENT_ROLL_I, newValue);
+#endif
             }
             break;
         case ADJUSTMENT_PITCH_ROLL_D:
         case ADJUSTMENT_PITCH_D:
             if (IS_PID_CONTROLLER_FP_BASED(pidProfile->pidController)) {
-                newFloatValue = pidProfile->D_f[PIDPITCH] + (float)(delta / 1000.0f);
-                pidProfile->D_f[PIDPITCH] = constrainf(newFloatValue, 0, 100); // FIXME magic numbers repeated in serial_cli.c
+                newFloatValue = constrainf(pidProfile->D_f[PIDPITCH] + (float)(delta / 1000.0f), 0, 100); // FIXME magic numbers repeated in serial_cli.c
+                pidProfile->D_f[PIDPITCH] = newFloatValue;
+#ifdef BLACKBOX
+    			blackboxLogInflightAdjustmentEventFloat(ADJUSTMENT_PITCH_D, newFloatValue);
+#endif
             } else {
-                newValue = (int)pidProfile->D8[PIDPITCH] + delta;
-                pidProfile->D8[PIDPITCH] = constrain(newValue, 0, 200); // FIXME magic numbers repeated in serial_cli.c
+                newValue = constrain((int)pidProfile->D8[PIDPITCH] + delta, 0, 200); // FIXME magic numbers repeated in serial_cli.c
+                pidProfile->D8[PIDPITCH] = newValue;
+#ifdef BLACKBOX
+    blackboxLogInflightAdjustmentEvent(ADJUSTMENT_PITCH_D, newValue);
+#endif
             }
             if (adjustmentFunction == ADJUSTMENT_PITCH_D) {
                 break;
@@ -532,38 +603,62 @@ void applyStepAdjustment(controlRateConfig_t *controlRateConfig, uint8_t adjustm
             // follow though for combined ADJUSTMENT_PITCH_ROLL_D
         case ADJUSTMENT_ROLL_D:
             if (IS_PID_CONTROLLER_FP_BASED(pidProfile->pidController)) {
-                newFloatValue = pidProfile->D_f[PIDROLL] + (float)(delta / 1000.0f);
-                pidProfile->D_f[PIDROLL] = constrainf(newFloatValue, 0, 100); // FIXME magic numbers repeated in serial_cli.c
+                newFloatValue = constrainf(pidProfile->D_f[PIDROLL] + (float)(delta / 1000.0f), 0, 100); // FIXME magic numbers repeated in serial_cli.c
+                pidProfile->D_f[PIDROLL] = newFloatValue;
+#ifdef BLACKBOX
+    			blackboxLogInflightAdjustmentEventFloat(ADJUSTMENT_ROLL_D, newFloatValue);
+#endif
             } else {
-                newValue = (int)pidProfile->D8[PIDROLL] + delta;
-                pidProfile->D8[PIDROLL] = constrain(newValue, 0, 200); // FIXME magic numbers repeated in serial_cli.c
+                newValue = constrain((int)pidProfile->D8[PIDROLL] + delta, 0, 200); // FIXME magic numbers repeated in serial_cli.c
+                pidProfile->D8[PIDROLL] = newValue;
+#ifdef BLACKBOX
+                blackboxLogInflightAdjustmentEvent(ADJUSTMENT_ROLL_D, newValue);
+#endif
             }
             break;
         case ADJUSTMENT_YAW_P:
             if (IS_PID_CONTROLLER_FP_BASED(pidProfile->pidController)) {
-                newFloatValue = pidProfile->P_f[PIDYAW] + (float)(delta / 10.0f);
-                pidProfile->P_f[PIDYAW] = constrainf(newFloatValue, 0, 100); // FIXME magic numbers repeated in serial_cli.c
+                newFloatValue = constrainf(pidProfile->P_f[PIDYAW] + (float)(delta / 10.0f), 0, 100); // FIXME magic numbers repeated in serial_cli.c
+                pidProfile->P_f[PIDYAW] = newFloatValue;
+#ifdef BLACKBOX
+    			blackboxLogInflightAdjustmentEventFloat(ADJUSTMENT_YAW_P, newFloatValue);
+#endif
             } else {
-                newValue = (int)pidProfile->P8[PIDYAW] + delta;
-                pidProfile->P8[PIDYAW] = constrain(newValue, 0, 200); // FIXME magic numbers repeated in serial_cli.c
+                newValue = constrain((int)pidProfile->P8[PIDYAW] + delta, 0, 200); // FIXME magic numbers repeated in serial_cli.c
+                pidProfile->P8[PIDYAW] = newValue;
+#ifdef BLACKBOX
+                blackboxLogInflightAdjustmentEvent(ADJUSTMENT_YAW_P, newValue);
+#endif
             }
             break;
         case ADJUSTMENT_YAW_I:
             if (IS_PID_CONTROLLER_FP_BASED(pidProfile->pidController)) {
-                newFloatValue = pidProfile->I_f[PIDYAW] + (float)(delta / 100.0f);
-                pidProfile->I_f[PIDYAW] = constrainf(newFloatValue, 0, 100); // FIXME magic numbers repeated in serial_cli.c
+                newFloatValue = constrainf(pidProfile->I_f[PIDYAW] + (float)(delta / 100.0f), 0, 100); // FIXME magic numbers repeated in serial_cli.c
+                pidProfile->I_f[PIDYAW] = newFloatValue;
+#ifdef BLACKBOX
+    			blackboxLogInflightAdjustmentEventFloat(ADJUSTMENT_YAW_I, newFloatValue);
+#endif
             } else {
-                newValue = (int)pidProfile->I8[PIDYAW] + delta;
-                pidProfile->I8[PIDYAW] = constrain(newValue, 0, 200); // FIXME magic numbers repeated in serial_cli.c
+                newValue = constrain((int)pidProfile->I8[PIDYAW] + delta, 0, 200); // FIXME magic numbers repeated in serial_cli.c
+                pidProfile->I8[PIDYAW] = newValue;
+#ifdef BLACKBOX
+                blackboxLogInflightAdjustmentEvent(ADJUSTMENT_YAW_I, newValue);
+#endif
             }
             break;
         case ADJUSTMENT_YAW_D:
             if (IS_PID_CONTROLLER_FP_BASED(pidProfile->pidController)) {
-                newFloatValue = pidProfile->D_f[PIDYAW] + (float)(delta / 1000.0f);
-                pidProfile->D_f[PIDYAW] = constrainf(newFloatValue, 0, 100); // FIXME magic numbers repeated in serial_cli.c
+                newFloatValue = constrainf(pidProfile->D_f[PIDYAW] + (float)(delta / 1000.0f), 0, 100); // FIXME magic numbers repeated in serial_cli.c
+                pidProfile->D_f[PIDYAW] = newFloatValue;
+#ifdef BLACKBOX
+    			blackboxLogInflightAdjustmentEventFloat(ADJUSTMENT_YAW_D, newFloatValue);
+#endif
             } else {
-                newValue = (int)pidProfile->D8[PIDYAW] + delta;
-                pidProfile->D8[PIDYAW] = constrain(newValue, 0, 200); // FIXME magic numbers repeated in serial_cli.c
+                newValue = constrain((int)pidProfile->D8[PIDYAW] + delta, 0, 200); // FIXME magic numbers repeated in serial_cli.c
+                pidProfile->D8[PIDYAW] = newValue;
+#ifdef BLACKBOX
+                blackboxLogInflightAdjustmentEvent(ADJUSTMENT_YAW_D, newValue);
+#endif
             }
             break;
         default:
@@ -581,6 +676,9 @@ void applySelectAdjustment(uint8_t adjustmentFunction, uint8_t position)
         case ADJUSTMENT_RATE_PROFILE:
             if (getCurrentControlRateProfile() != position) {
                 changeControlRateProfile(position);
+#ifdef BLACKBOX
+                blackboxLogInflightAdjustmentEvent(ADJUSTMENT_RATE_PROFILE, position);
+#endif
                 applied = true;
             }
             break;


### PR DESCRIPTION
I've added logging of the inflight adjustments as blackbox events. 

In the blackbox viewer (its separate PR) it will look like:

![blackbox_inflight_adjustment](https://cloud.githubusercontent.com/assets/2101514/8272102/d56d4740-1836-11e5-8b5a-1e8270c432ba.png)

For example, constantly increasing Roll P ends up in some... Oscillations ;)

![screen shot 2015-06-21 at 17 15 46](https://cloud.githubusercontent.com/assets/2101514/8272180/468b0528-1839-11e5-8302-94ecd4e8a641.png)

Please let me know what you think. 

PS Its my first PR :)