### PR TITLE
Sensors - Detect BMP085 before MS5611

### DIFF
--- a/src/main/sensors/initialisation.c
+++ b/src/main/sensors/initialisation.c
@@ -435,7 +435,16 @@ static void detectBaro()
 
     switch (baroHardware) {
         case BARO_DEFAULT:
-            ; // fallthough
+            ; // fallthrough
+
+        case BARO_BMP085: // Always test before MS5611 as some BMP180's can pass MS5611 CRC test
+#ifdef USE_BARO_BMP085
+            if (bmp085Detect(bmp085Config, &baro)) {
+                baroHardware = BARO_BMP085;
+                break;
+            }
+#endif
+            ; // fallthrough
 
         case BARO_MS5611:
 #ifdef USE_BARO_MS5611
@@ -444,14 +453,8 @@ static void detectBaro()
                 break;
             }
 #endif
-            ; // fallthough
-        case BARO_BMP085:
-#ifdef USE_BARO_BMP085
-            if (bmp085Detect(bmp085Config, &baro)) {
-                baroHardware = BARO_BMP085;
-                break;
-            }
-#endif
+            ; // fallthrough
+
         case BARO_NONE:
             baroHardware = BARO_NONE;
             break;


### PR DESCRIPTION
The current code tests for an MS5611 baro and then a BMP085 baro.   
The test for an MS5611 relies on a 4 bit CRC which, on occasion, the BMP180 will pass (the BMP180 is a drop in replacement for the BMP085).  So the FC thinks it has an MS5611 connected.
This PR tests for a BMP085 (BMP180) before testing for an MS5611.

Another approach would be to test for an MS5611 first, and if the CRC is correct, check an undocumented address = 0x00.  That may work today but is a risky approach and could cause issues in the future.  Plus, it's extra code.