### PR TITLE
Fix for division by zero in MSP_RAW_IMU scaling

### DIFF
--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -813,10 +813,10 @@ static bool processOutCommand(uint8_t cmdMSP)
     case MSP_RAW_IMU:
         headSerialReply(18);
         // Hack scale due to choice of units for sensor data in multiwii
-        uint8_t scale = acc_1G > 1024 ? 8 : 0;
+        uint8_t scaleShift = acc_1G > 1024 ? 3 /* i.e. div by 8 */ : 0;
 
         for (i = 0; i < 3; i++)
-            serialize16(accSmooth[i] / scale);
+            serialize16(accSmooth[i] >> scaleShift);
         for (i = 0; i < 3; i++)
             serialize16(gyroADC[i]);
         for (i = 0; i < 3; i++)


### PR DESCRIPTION
Fix for the change in 26e950b43385f539cc3a26cac294f69d70af6d33