### PR TITLE
Hardware - Add support for legacy I2C-NAV-GPS board

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,6 +234,7 @@ COMMON_SRC	 = build_config.c \
 		   drivers/serial.c \
 		   drivers/sound_beeper.c \
 		   drivers/system.c \
+           drivers/gps_i2cnav.c \
 		   io/beeper.c \
 		   io/rc_controls.c \
 		   io/rc_curves.c \

--- a/docs/Navigation.md
+++ b/docs/Navigation.md
@@ -1,0 +1,28 @@
+# Navigation
+
+Navigation system in Cleanflight is responsible for assisting the pilot allowing altitude and position hold, return-to-home and waypoint flight.
+
+## Altitude hold
+
+Altitude hold requires a valid source of altitude - barometer or sonar. The best source is chosen automatically
+
+PIDs to tune: ALT & VEL
+PID meaning:
+    ALT - translates altitude error to desired climb rate, only P-term is used, I and D has no meaning
+    VEL - translated climb rate error to throttle adjustment, full PID is used
+
+## Throttle tilt compensation
+
+TODO
+
+## Position hold
+
+Position hold required GPS and compass sensors. Flight modes that require a compass (POSHOLD, RTH) are locked until compass is properly calibrated
+
+PIDs to tune: POS, POSR, NAVR
+PID meaning:
+    POS - translated position error to desired velocity, uses P & I terms
+    POSR - translates velocity error to pitch/roll adjustment when in POSHOLD mode, is a full PID-regulator
+    NAVR - translates velocity error to pitch/roll adjustment when in RTH/WP mode, is a full PID-regulator
+
+## Wind compensation

--- a/src/main/drivers/gps.h
+++ b/src/main/drivers/gps.h
@@ -1,0 +1,36 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+typedef struct gpsDataGeneric_s {
+    struct {
+        unsigned gpsOk : 1;     // gps read successful
+        unsigned newData : 1;   // new gps data available (lat/lon/alt)
+        unsigned fix3D : 1;     // gps fix status
+    } flags;
+    int32_t latitude;
+    int32_t longitude;
+    uint8_t numSat;
+    uint16_t altitude;
+    uint16_t speed;
+    uint16_t ground_course;
+    uint16_t hdop;
+} gpsDataGeneric_t;
+
+typedef void (*gpsReadFuncPtr)(gpsDataGeneric_t * gpsMsg);                       // baro start operation
+

--- a/src/main/drivers/gps_i2cnav.c
+++ b/src/main/drivers/gps_i2cnav.c
@@ -1,0 +1,91 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <platform.h>
+
+#include "build_config.h"
+
+#include "gps.h"
+#include "gps_i2cnav.h"
+
+#include "gpio.h"
+#include "system.h"
+#include "bus_i2c.h"
+
+#define I2C_GPS_ADDRESS               0x20 //7 bits       
+
+#define I2C_GPS_STATUS_00             00    //(Read only)
+  #define I2C_GPS_STATUS_NEW_DATA       0x01  // New data is available (after every GGA frame)
+  #define I2C_GPS_STATUS_2DFIX          0x02  // 2dfix achieved
+  #define I2C_GPS_STATUS_3DFIX          0x04  // 3dfix achieved
+  #define I2C_GPS_STATUS_NUMSATS        0xF0  // Number of sats in view
+#define I2C_GPS_REG_VERSION           03   // Version of the I2C_NAV SW uint8_t
+#define I2C_GPS_LOCATION              07    // current location 8 byte (lat, lon) int32_t
+#define I2C_GPS_GROUND_SPEED          31    // GPS ground speed in m/s*100 (uint16_t)      (Read Only)
+#define I2C_GPS_ALTITUDE              33    // GPS altitude in meters (uint16_t)           (Read Only)
+#define I2C_GPS_GROUND_COURSE         35    // GPS ground course (uint16_t)
+#define I2C_GPS_TIME                  39    // UTC Time from GPS in hhmmss.sss * 100 (uint32_t)(unneccesary precision) (Read Only)
+
+bool i2cnavGPSModuleDetect(void)
+{
+    bool ack;
+    uint8_t i2cGpsStatus;
+    
+    ack = i2cRead(I2C_GPS_ADDRESS, I2C_GPS_STATUS_00, 1, &i2cGpsStatus); /* status register */ 
+    
+    if (ack) 
+        return true;
+    
+    return false;
+}
+
+void i2cnavGPSModuleRead(gpsDataGeneric_t * gpsMsg)
+{
+    bool ack;
+    uint8_t i2cGpsStatus;
+    
+    gpsMsg->flags.newData = 0;
+    gpsMsg->flags.fix3D = 0;
+    gpsMsg->flags.gpsOk = 0;
+    
+    ack = i2cRead(I2C_GPS_ADDRESS, I2C_GPS_STATUS_00, 1, &i2cGpsStatus); /* status register */ 
+
+    if (!ack)
+        return;
+
+    gpsMsg->flags.gpsOk = 1;
+    gpsMsg->numSat = i2cGpsStatus >> 4;
+
+    if (i2cGpsStatus & I2C_GPS_STATUS_3DFIX) {
+        gpsMsg->flags.fix3D = 1;
+        
+        if (i2cGpsStatus & I2C_GPS_STATUS_NEW_DATA) {   
+            i2cRead(I2C_GPS_ADDRESS, I2C_GPS_LOCATION,      4, (uint8_t*)&gpsMsg->latitude);
+            i2cRead(I2C_GPS_ADDRESS, I2C_GPS_LOCATION + 4,  4, (uint8_t*)&gpsMsg->longitude);
+            i2cRead(I2C_GPS_ADDRESS, I2C_GPS_GROUND_SPEED,  2, (uint8_t*)&gpsMsg->speed);
+            i2cRead(I2C_GPS_ADDRESS, I2C_GPS_GROUND_COURSE, 2, (uint8_t*)&gpsMsg->ground_course);
+            i2cRead(I2C_GPS_ADDRESS, I2C_GPS_ALTITUDE,      2, (uint8_t*)&gpsMsg->altitude);
+            
+            gpsMsg->hdop = 0;
+            
+            gpsMsg->flags.newData = 1;
+        }
+    }
+}

--- a/src/main/drivers/gps_i2cnav.h
+++ b/src/main/drivers/gps_i2cnav.h
@@ -1,0 +1,23 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "gps.h"
+
+bool i2cnavGPSModuleDetect(void);
+void i2cnavGPSModuleRead(gpsDataGeneric_t * gpsMsg);

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -35,6 +35,10 @@
 #include "drivers/serial_uart.h"
 #include "drivers/gpio.h"
 #include "drivers/light_led.h"
+#include "drivers/sensor.h"
+
+#include "drivers/gps.h"
+#include "drivers/gps_i2cnav.h"
 
 #include "sensors/sensors.h"
 
@@ -191,7 +195,7 @@ static void shiftPacketLog(void)
     }
 }
 
-static void gpsNewData(uint16_t c);
+static void gpsNewDataSerial(uint16_t c);
 static bool gpsNewFrameNMEA(char c);
 static bool gpsNewFrameUBLOX(uint8_t data);
 
@@ -203,10 +207,11 @@ static void gpsSetState(gpsState_e state)
     gpsData.messageState = GPS_MESSAGE_STATE_IDLE;
 }
 
+bool gpsDetectI2C(void);
+
 void gpsInit(serialConfig_t *initialSerialConfig, gpsConfig_t *initialGpsConfig)
 {
     serialConfig = initialSerialConfig;
-
 
     gpsData.baudrateIndex = 0;
     gpsData.errors = 0;
@@ -216,35 +221,57 @@ void gpsInit(serialConfig_t *initialSerialConfig, gpsConfig_t *initialGpsConfig)
 
     gpsConfig = initialGpsConfig;
 
+    // Clear satellites in view information, if we use I2C driver this is not used
+    GPS_numCh = 0;
+    for (int i = 0; i < GPS_SV_MAXSATS; i++){
+        GPS_svinfo_chn[i] = 0;
+        GPS_svinfo_svid[i] = 0;
+        GPS_svinfo_quality[i] = 0;
+        GPS_svinfo_cno[i] = 0;
+    }
+
     // init gpsData structure. if we're not actually enabled, don't bother doing anything else
     gpsSetState(GPS_UNKNOWN);
 
     gpsData.lastMessage = millis();
 
-    serialPortConfig_t *gpsPortConfig = findSerialPortConfig(FUNCTION_GPS);
-    if (!gpsPortConfig) {
-        featureClear(FEATURE_GPS);
-        return;
-    }
+    if (gpsConfig->provider == GPS_NMEA || gpsConfig->provider == GPS_UBLOX) {
+        serialPortConfig_t *gpsPortConfig = findSerialPortConfig(FUNCTION_GPS);
+        if (!gpsPortConfig) {
+            // No port configured for SERIAL GPS - automatically fallback to I2C GPS if it is present
+            if (gpsDetectI2C()) {
+                gpsConfig->provider = GPS_I2C;
+            }
+            else {
+                featureClear(FEATURE_GPS);
+                return;
+            }
+        }
+        else {
+            while (gpsInitData[gpsData.baudrateIndex].baudrateIndex != gpsPortConfig->gps_baudrateIndex) {
+                gpsData.baudrateIndex++;
+                if (gpsData.baudrateIndex >= GPS_INIT_DATA_ENTRY_COUNT) {
+                    gpsData.baudrateIndex = DEFAULT_BAUD_RATE_INDEX;
+                    break;
+                }
+            }
 
-    while (gpsInitData[gpsData.baudrateIndex].baudrateIndex != gpsPortConfig->gps_baudrateIndex) {
-        gpsData.baudrateIndex++;
-        if (gpsData.baudrateIndex >= GPS_INIT_DATA_ENTRY_COUNT) {
-            gpsData.baudrateIndex = DEFAULT_BAUD_RATE_INDEX;
-            break;
+            portMode_t mode = MODE_RXTX;
+            // only RX is needed for NMEA-style GPS
+            if (gpsConfig->provider == GPS_NMEA)
+                mode &= ~MODE_TX;
+
+            // no callback - buffer will be consumed in gpsThread()
+            gpsPort = openSerialPort(gpsPortConfig->identifier, FUNCTION_GPS, NULL, gpsInitData[gpsData.baudrateIndex].baudrateIndex, mode, SERIAL_NOT_INVERTED);
+            if (!gpsPort) {
+                featureClear(FEATURE_GPS);
+                return;
+            }
         }
     }
 
-    portMode_t mode = MODE_RXTX;
-    // only RX is needed for NMEA-style GPS
-    if (gpsConfig->provider == GPS_NMEA)
-        mode &= ~MODE_TX;
-
-    // no callback - buffer will be consumed in gpsThread()
-    gpsPort = openSerialPort(gpsPortConfig->identifier, FUNCTION_GPS, NULL, gpsInitData[gpsData.baudrateIndex].baudrateIndex, mode, SERIAL_NOT_INVERTED);
-    if (!gpsPort) {
-        featureClear(FEATURE_GPS);
-        return;
+    if (gpsConfig->provider == GPS_I2C) {
+        // Nothing to do yet
     }
 
     // signal GPS "thread" to initialize when it gets to it
@@ -270,7 +297,6 @@ void gpsInitUblox(void)
     // Wait until GPS transmit buffer is empty
     if (!isSerialTransmitBufferEmpty(gpsPort))
         return;
-
 
     switch (gpsData.state) {
         case GPS_INITIALIZING:
@@ -343,6 +369,95 @@ void gpsInitUblox(void)
     }
 }
 
+#define GPS_I2C_POLL_RATE_HZ    20  // Poll I2C GPS at this rate
+static gpsReadFuncPtr gpsReadNewDataI2CDriver = NULL;
+
+bool gpsDetectI2C(void)
+{
+    // Older Atmega328p based I2C NAV boards (also PARIS I2C NAV module)
+    if (i2cnavGPSModuleDetect()) {
+        gpsReadNewDataI2CDriver = &i2cnavGPSModuleRead;
+        return true;
+    }
+
+    gpsReadNewDataI2CDriver  = NULL;
+    return false;
+}
+
+void gpsInitI2C(void)
+{
+    switch(gpsData.state) {
+        case GPS_INITIALIZING:
+        case GPS_CHANGE_BAUD:
+        case GPS_CONFIGURE:
+            if (gpsDetectI2C()) {
+                gpsSetState(GPS_RECEIVING_DATA);
+            }
+            else {
+                gpsSetState(GPS_INITIALIZING);
+            }
+            break;
+    }
+}
+
+void gpsReadNewDataI2C(void)
+{
+    static gpsDataGeneric_t gpsMsg;
+
+    // Check for poll rate timeout
+    if ((millis() - gpsData.lastMessage) < (1000 / GPS_I2C_POLL_RATE_HZ)) 
+        return;
+
+    // Query driver for new data
+    if (gpsReadNewDataI2CDriver) {
+        gpsReadNewDataI2CDriver(&gpsMsg);
+
+        if (gpsMsg.flags.gpsOk) {
+            // Fix data
+            if (gpsMsg.flags.fix3D)
+                ENABLE_STATE(GPS_FIX);
+            else
+                DISABLE_STATE(GPS_FIX);
+
+            // sat count
+            GPS_numSat = gpsMsg.numSat;
+
+            // Other data
+            if (gpsMsg.flags.newData) {
+                if (gpsMsg.flags.fix3D) {
+                    GPS_hdop = gpsMsg.hdop;
+                    GPS_altitude = gpsMsg.altitude;
+                    GPS_speed = gpsMsg.speed;
+                    GPS_ground_course = gpsMsg.ground_course;
+                    GPS_coord[LAT] = gpsMsg.latitude;
+                    GPS_coord[LON] = gpsMsg.longitude;
+                }
+                else {
+                }
+
+                GPS_packetCount++;
+
+                if (GPS_update == 1)
+                    GPS_update = 0;
+                else
+                    GPS_update = 1;
+
+                onGpsNewData();
+
+                // new data received and parsed, we're in business
+                gpsData.lastLastMessage = gpsData.lastMessage;
+                gpsData.lastMessage = millis();
+            }
+
+            sensorsSet(SENSOR_GPS);
+        }
+    }
+    else {
+        sensorsClear(SENSOR_GPS);
+        gpsSetState(GPS_LOST_COMMUNICATION);
+    }
+}
+
 void gpsInitHardware(void)
 {
     switch (gpsConfig->provider) {
@@ -353,16 +468,30 @@ void gpsInitHardware(void)
         case GPS_UBLOX:
             gpsInitUblox();
             break;
+
+        case GPS_I2C:
+            gpsInitI2C();
+            break;
+    }
+}
+
+void gpsReadNewData(void)
+{
+    if (gpsConfig->provider == GPS_NMEA || gpsConfig->provider == GPS_UBLOX) {
+        if (gpsPort) {
+            while (serialTotalBytesWaiting(gpsPort))
+                gpsNewDataSerial(serialRead(gpsPort));
+        }
+    }
+    else if (gpsConfig->provider == GPS_I2C) {
+        gpsReadNewDataI2C();
     }
 }
 
 void gpsThread(void)
 {
     // read out available GPS bytes
-    if (gpsPort) {
-        while (serialTotalBytesWaiting(gpsPort))
-            gpsNewData(serialRead(gpsPort));
-    }
+    gpsReadNewData();
 
     switch (gpsData.state) {
         case GPS_UNKNOWN:
@@ -376,11 +505,13 @@ void gpsThread(void)
 
         case GPS_LOST_COMMUNICATION:
             gpsData.timeouts++;
-            if (gpsConfig->autoBaud) {
-                // try another rate
+
+            // try another rate for serial GPS
+            if ((gpsConfig->provider == GPS_NMEA || gpsConfig->provider == GPS_UBLOX) && gpsConfig->autoBaud) {
                 gpsData.baudrateIndex++;
                 gpsData.baudrateIndex %= GPS_INIT_ENTRIES;
             }
+
             gpsData.lastMessage = millis();
             // TODO - move some / all of these into gpsData
             GPS_numSat = 0;
@@ -399,9 +530,9 @@ void gpsThread(void)
     }
 }
 
-static void gpsNewData(uint16_t c)
+static void gpsNewDataSerial(uint16_t c)
 {
-    if (!gpsNewFrame(c)) {
+    if (!gpsNewFrameFromSerial(c)) {
         return;
     }
 
@@ -422,13 +553,15 @@ static void gpsNewData(uint16_t c)
     onGpsNewData();
 }
 
-bool gpsNewFrame(uint8_t c)
+bool gpsNewFrameFromSerial(uint8_t c)
 {
     switch (gpsConfig->provider) {
         case GPS_NMEA:          // NMEA
             return gpsNewFrameNMEA(c);
         case GPS_UBLOX:         // UBX binary
             return gpsNewFrameUBLOX(c);
+        case GPS_I2C:           // Shouldn't happen
+            return false;
     }
 
     return false;
@@ -1039,7 +1172,7 @@ void gpsEnablePassthrough(serialPort_t *gpsPassthroughPort)
         if (serialTotalBytesWaiting(gpsPort)) {
             LED0_ON;
             c = serialRead(gpsPort);
-            gpsNewData(c);
+            gpsNewDataSerial(c);
             serialWrite(gpsPassthroughPort, c);
             LED0_OFF;
         }

--- a/src/main/io/gps.h
+++ b/src/main/io/gps.h
@@ -24,10 +24,11 @@
 
 typedef enum {
     GPS_NMEA = 0,
-    GPS_UBLOX
+    GPS_UBLOX,
+    GPS_I2C
 } gpsProvider_e;
 
-#define GPS_PROVIDER_MAX GPS_UBLOX
+#define GPS_PROVIDER_MAX GPS_I2C
 
 typedef enum {
     SBAS_AUTO = 0,
@@ -119,5 +120,5 @@ extern uint8_t GPS_svinfo_cno[16];         // Carrier to Noise Ratio (Signal Str
 
 
 void gpsThread(void);
-bool gpsNewFrame(uint8_t c);
+bool gpsNewFrameFromSerial(uint8_t c);
 void updateGpsIndicator(uint32_t currentTime);

--- a/src/main/sensors/sensors.h
+++ b/src/main/sensors/sensors.h
@@ -50,7 +50,6 @@ typedef enum {
     SENSOR_MAG = 1 << 3,
     SENSOR_SONAR = 1 << 4,
     SENSOR_GPS = 1 << 5,
-    SENSOR_GPSMAG = 1 << 6,
 } sensors_e;
 
 typedef enum {


### PR DESCRIPTION
There are alot if I2C-NAV-GPS board left from MultiWii era, there are even modules with GPS receiver, magnetometer and an Atmega328 MCU running I2CNAV code (i.e. PARIS Sirius I2C NAV GPS). This PR is related to #363 and implements support for these boards, allowing them to be connected to NAZE/CC3D or other flight controller via I2C.
I2C GPS is automatically detected when enabling `feature GPS`, but not selecting a serial port for GPS. I2C GPS can be explicitly selected by setting `gps_provider` to 2.