### PR TITLE
more robust ci server / curl integration

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,12 +1,23 @@
 #!/bin/bash
+
 REVISION=$(git rev-parse --short HEAD)
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 REVISION=$(git rev-parse --short HEAD)
 LAST_COMMIT_DATE=$(git log -1 --date=short --format="%cd")
 TARGET_FILE=obj/cleanflight_${TARGET}
-REPONAME=${TRAVIS_REPO_SLUG:=$USER/undefined}
+$TRAVIS_REPO_SLUG=${TRAVIS_REPO_SLUG:=$USER/undefined}
 BUILDNAME=${BUILDNAME:=travis}
+TRAVIS_BUILD_NUMBER=${TRAVIS_BUILD_NUMBER:=undefined}
 
+CURLBASEOPTS="--retry 10
+	--retry-delay 10
+	--retry-max-time 120
+	--form \"revision=${REVISION}\"
+	--form \"branch=${BRANCH}\"
+	--form \"last_commit_date=${LAST_COMMIT_DATE}\"
+	--form \"travis_build_number=${TRAVIS_BUILD_NUMBER}\"
+	--form \"github_repo=${TRAVIS_REPO_SLUG}\"
+	--form \"build_name=${BUILDNAME}\""
 
 # A hacky way of running the unit tests at the same time as the normal builds.
 if [ $RUNTESTS ] ; then
@@ -29,29 +40,13 @@ elif [ $PUBLISHDOCS ] ; then
 
 		./build_docs.sh
 
-		curl -k \
-			--form "manual=@docs/Manual.pdf" \
-			--form "revision=${REVISION}" \
-			--form "branch=${BRANCH}" \
-			--form "last_commit_date=${LAST_COMMIT_DATE}" \
-			--form "travis_build_number=${TRAVIS_BUILD_NUMBER}" \
-			--form "github_repo=${REPONAME}" \
-			--form "build_name=${BUILDNAME}" \
-			${PUBLISH_URL}
+		curl -k ${CURLBASEOPTS} --form "manual=@docs/Manual.pdf" ${PUBLISH_URL} || true
 	fi
 
 elif [ $PUBLISHMETA ] ; then
 	if [ $PUBLISH_URL ] ; then
 		RECENT_COMMITS=$(git shortlog -n25)
-		curl -k \
-			--form "recent_commits=${RECENT_COMMITS}" \
-			--form "revision=${REVISION}" \
-			--form "branch=${BRANCH}" \
-			--form "last_commit_date=${LAST_COMMIT_DATE}" \
-			--form "travis_build_number=${TRAVIS_BUILD_NUMBER}" \
-			--form "github_repo=${REPONAME}" \
-			--form "build_name=${BUILDNAME}" \
-			${PUBLISH_URL}
+		curl -k ${CURLBASEOPTS} --form "recent_commits=${RECENT_COMMITS}" ${PUBLISH_URL} || true
 	fi
 
 else
@@ -66,15 +61,8 @@ else
 			exit 1
 		fi
 
-		curl -k \
-			--form "file=@${TARGET_FILE}" \
-			--form "revision=${REVISION}" \
-			--form "branch=${BRANCH}" \
-			--form "last_commit_date=${LAST_COMMIT_DATE}" \
-			--form "travis_build_number=${TRAVIS_BUILD_NUMBER}" \
-			--form "github_repo=${REPONAME}" \
-			--form "build_name=${BUILDNAME}" \
-			${PUBLISH_URL}
+		curl -k ${CURLBASEOPTS} --form "file=@${TARGET_FILE}" ${PUBLISH_URL} || true
+		exit 0;
 	else
 		make -j2
 	fi

--- a/.travis.sh
+++ b/.travis.sh
@@ -5,7 +5,7 @@ BRANCH=$(git rev-parse --abbrev-ref HEAD)
 REVISION=$(git rev-parse --short HEAD)
 LAST_COMMIT_DATE=$(git log -1 --date=short --format="%cd")
 TARGET_FILE=obj/cleanflight_${TARGET}
-$TRAVIS_REPO_SLUG=${TRAVIS_REPO_SLUG:=$USER/undefined}
+TRAVIS_REPO_SLUG=${TRAVIS_REPO_SLUG:=$USER/undefined}
 BUILDNAME=${BUILDNAME:=travis}
 TRAVIS_BUILD_NUMBER=${TRAVIS_BUILD_NUMBER:=undefined}
 


### PR DESCRIPTION
* cleaned up curl parameter handling
* added a maximum of 10 retries for publishing builds to the CI server
* limited retries to 2 minutes of total time
* do not show the build as broken if curl eventually fails to upload the build artifacts. 