### PR TITLE
Travis/CI Updates: retry failed HTTP requests, Updated GCC to 4.9-2015q2

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -10,7 +10,7 @@ BUILDNAME=${BUILDNAME:=travis}
 TRAVIS_BUILD_NUMBER=${TRAVIS_BUILD_NUMBER:=undefined}
 
 CURLBASEOPTS=(
-	"--retry-delay" "10"
+	"--retry" "10"
 	"--retry-max-time" "120"
 	"--form" "revision=${REVISION}"
 	"--form" "branch=${BRANCH}"

--- a/.travis.sh
+++ b/.travis.sh
@@ -9,9 +9,11 @@ TRAVIS_REPO_SLUG=${TRAVIS_REPO_SLUG:=$USER/undefined}
 BUILDNAME=${BUILDNAME:=travis}
 TRAVIS_BUILD_NUMBER=${TRAVIS_BUILD_NUMBER:=undefined}
 
-CURLBASEOPTS=(
+CURL_BASEOPTS=(
 	"--retry" "10"
-	"--retry-max-time" "120"
+	"--retry-max-time" "120" )
+
+CURL_PUB_BASEOPTS=(
 	"--form" "revision=${REVISION}"
 	"--form" "branch=${BRANCH}"
 	"--form" "travis_build_number=${TRAVIS_BUILD_NUMBER}"
@@ -30,7 +32,7 @@ elif [ $PUBLISHDOCS ] ; then
 		sudo apt-get install zlib1g-dev libssl-dev wkhtmltopdf libxml2-dev libxslt-dev #ruby-rvm
 
 		# Patch Gimli to fix underscores_inside_words
-		curl -L https://github.com/walle/gimli/archive/v0.5.9.tar.gz | tar zxf -
+		curl -L "${CURL_BASEOPTS[@]}" https://github.com/walle/gimli/archive/v0.5.9.tar.gz | tar zxf -
 
 		sed -i 's/).render(/, :no_intra_emphasis => true).render(/' gimli-0.5.9/ext/github_markup.rb
 
@@ -40,13 +42,13 @@ elif [ $PUBLISHDOCS ] ; then
 
 		./build_docs.sh
 
-		curl -k "${CURLBASEOPTS[@]}" --form "manual=@docs/Manual.pdf" ${PUBLISH_URL} || true
+		curl -k "${CURL_BASEOPTS[@]}" "${CURL_PUB_BASEOPTS[@]}" --form "manual=@docs/Manual.pdf" ${PUBLISH_URL} || true
 	fi
 
 elif [ $PUBLISHMETA ] ; then
 	if [ $PUBLISH_URL ] ; then
 		RECENT_COMMITS=$(git shortlog -n25)
-		curl -k "${CURLBASEOPTS[@]}" --form "recent_commits=${RECENT_COMMITS}" ${PUBLISH_URL} || true
+		curl -k "${CURL_BASEOPTS[@]}" "${CURL_PUB_BASEOPTS[@]}" --form "recent_commits=${RECENT_COMMITS}" ${PUBLISH_URL} || true
 	fi
 
 else
@@ -61,7 +63,7 @@ else
 			exit 1
 		fi
 
-		curl -k "${CURLBASEOPTS[@]}" --form "file=@${TARGET_FILE}" ${PUBLISH_URL} || true
+		curl -k "${CURL_BASEOPTS[@]}" "${CURL_PUB_BASEOPTS[@]}" --form "file=@${TARGET_FILE}" ${PUBLISH_URL} || true
 		exit 0;
 	else
 		make -j2

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,11 @@ compiler: clang
 
 before_install:
   - sudo apt-get update
-  - curl --retry 10 --retry-max-time 120 -L "https://launchpad.net/gcc-arm-embedded/4.8/4.8-2014-q3-update/+download/gcc-arm-none-eabi-4_8-2014q3-20140805-linux.tar.bz2" > gcc-arm-none-eabi-4_8-2014q3-20140805-linux.tar.bz2
+  - curl --retry 10 --retry-max-time 120 -L "https://launchpad.net/gcc-arm-embedded/4.9/4.9-2015-q2-update/+download/gcc-arm-none-eabi-4_9-2015q2-20150609-linux.tar.bz2" | tar xfj -
 
 install:
   - sudo apt-get install build-essential git libc6-i386
-  - tar -xf gcc-arm-none-eabi-4_8-2014q3-20140805-linux.tar.bz2
-  - export PATH=$PATH:$PWD/gcc-arm-none-eabi-4_8-2014q3/bin
+  - export PATH=$PATH:$PWD/gcc-arm-none-eabi-4_9-2015q2/bin
 
 before_script: arm-none-eabi-gcc --version
 script: ./.travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,13 @@ compiler: clang
 
 before_install:
   - sudo apt-get update
-  - wget "https://launchpad.net/gcc-arm-embedded/4.8/4.8-2014-q3-update/+download/gcc-arm-none-eabi-4_8-2014q3-20140805-linux.tar.bz2"
+  - curl --retry 10 --retry-max-time 120 -L "https://launchpad.net/gcc-arm-embedded/4.8/4.8-2014-q3-update/+download/gcc-arm-none-eabi-4_8-2014q3-20140805-linux.tar.bz2" > gcc-arm-none-eabi-4_8-2014q3-20140805-linux.tar.bz2
 
-install: 
+install:
   - sudo apt-get install build-essential git libc6-i386
   - tar -xf gcc-arm-none-eabi-4_8-2014q3-20140805-linux.tar.bz2
   - export PATH=$PATH:$PWD/gcc-arm-none-eabi-4_8-2014q3/bin
-   
+
 before_script: arm-none-eabi-gcc --version
 script: ./.travis.sh
 

--- a/docs/development/Travis.md
+++ b/docs/development/Travis.md
@@ -1,6 +1,6 @@
 #Travis
 
-Cleanflight provides Travis build and config files in the repository root. 
+Cleanflight provides Travis build and config files in the repository root.
 
 ## Pushing builds to a remote server
 
@@ -8,3 +8,4 @@ Cleanflight provides Travis build and config files in the repository root.
 ```PUBLISH_URL``` environment variable. If set, the build script will use the cURL binary and simulate
 a file upload post to the configured server.
 
+Pleas check the ```notifications``` section in the ```.travis.yml``` file and adjust the irc notifications if you plan on using Travis on your Cleanflight fork


### PR DESCRIPTION
* cleaned up curl parameter handling
* added a maximum of 10 retries for publishing builds to the CI server and fetching toolchains
* limited retries to 2 minutes of total time
* do not show the build as broken if curl eventually fails to upload the build artifacts.
* updated GCC 4.8 -> 4.9