### PR TITLE
Remove dependency on global variable and pass it in instead

### DIFF
--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -462,7 +462,7 @@ void executePeriodicTasks(void)
 #ifdef MAG
     case UPDATE_COMPASS_TASK:
         if (sensors(SENSOR_MAG)) {
-            updateCompass(&masterConfig.magZero);
+	  updateCompass(&masterConfig.magZero, currentTime);
         }
         break;
 #endif

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -41,8 +41,6 @@
 
 mag_t mag;                   // mag access functions
 
-extern uint32_t currentTime; // FIXME dependency on global variable, pass it in instead.
-
 int16_t magADC[XYZ_AXIS_COUNT];
 sensor_align_e magAlign = 0;
 #ifdef MAG
@@ -59,7 +57,7 @@ void compassInit(void)
 
 #define COMPASS_UPDATE_FREQUENCY_10HZ (1000 * 100)
 
-void updateCompass(flightDynamicsTrims_t *magZero)
+void updateCompass(flightDynamicsTrims_t *magZero, const uint32_t currentTime)
 {
     static uint32_t nextUpdateAt, tCal = 0;
     static flightDynamicsTrims_t magZeroTempMin;

--- a/src/main/sensors/compass.h
+++ b/src/main/sensors/compass.h
@@ -29,7 +29,7 @@ typedef enum {
 
 #ifdef MAG
 void compassInit(void);
-void updateCompass(flightDynamicsTrims_t *magZero);
+void updateCompass(flightDynamicsTrims_t *magZero, const uint32_t currentTime);
 #endif
 
 extern int16_t magADC[XYZ_AXIS_COUNT];


### PR DESCRIPTION
This removes the  global variable currentTime from compass and it is passed in.

This is a small change while I was looking through the code and learning the code base