### PR TITLE
Fixes for channel forwarding functionality

### DIFF
--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -449,11 +449,13 @@ static void updateGimbalServos(uint8_t firstServoIndex)
 void writeServos(void)
 {
     uint8_t servoIndex = 0;
+    uint8_t fwdAuxServoIdx = 0;
 
     switch (currentMixerMode) {
         case MIXER_BI:
             pwmWriteServo(servoIndex++, servo[SERVO_BIPLANE_LEFT]);
             pwmWriteServo(servoIndex++, servo[SERVO_BIPLANE_RIGHT]);
+            fwdAuxServoIdx = 2;
             break;
 
         case MIXER_TRI:
@@ -467,28 +469,33 @@ void writeServos(void)
                 else
                     pwmWriteServo(servoIndex++, 0); // kill servo signal completely.
             }
+            fwdAuxServoIdx = 2;
             break;
 
         case MIXER_FLYING_WING:
             pwmWriteServo(servoIndex++, servo[SERVO_FLAPPERON_1]);
             pwmWriteServo(servoIndex++, servo[SERVO_FLAPPERON_2]);
+            fwdAuxServoIdx = 4;
             break;
 
         case MIXER_DUALCOPTER:
             pwmWriteServo(servoIndex++, servo[SERVO_DUALCOPTER_LEFT]);
             pwmWriteServo(servoIndex++, servo[SERVO_DUALCOPTER_RIGHT]);
+            fwdAuxServoIdx = 2;
             break;
 
         case MIXER_AIRPLANE:
             for (int i = SERVO_PLANE_INDEX_MIN; i <= SERVO_PLANE_INDEX_MAX; i++) {
                 pwmWriteServo(servoIndex++, servo[i]);
             }
+            fwdAuxServoIdx = 4;
             break;
 
         case MIXER_SINGLECOPTER:
             for (int i = SERVO_SINGLECOPTER_INDEX_MIN; i <= SERVO_SINGLECOPTER_INDEX_MAX; i++) {
                 pwmWriteServo(servoIndex++, servo[i]);
             }
+            fwdAuxServoIdx = 2;
             break;
 
         default:
@@ -499,11 +506,13 @@ void writeServos(void)
     if (feature(FEATURE_SERVO_TILT)) {
         updateGimbalServos(servoIndex);
         servoIndex += 2;
+        if (fwdAuxServoIdx == 0)            // if not explicitly set above
+            fwdAuxServoIdx = servoIndex;    //  then set value (to 2)
     }
 
     // forward AUX to remaining servo outputs (not constrained)
     if (gimbalConfig->gimbal_flags & GIMBAL_FORWARDAUX) {
-        forwardAuxChannelsToServos(servoIndex);
+        forwardAuxChannelsToServos(fwdAuxServoIdx);
         servoIndex += MAX_AUX_CHANNEL_COUNT;
     }
 }


### PR DESCRIPTION
Fixes for gimbal_flags=4 functionality for Tricopter, Bicopter, Dualcopter, FlyingWing, Airplane and Singlecopter mixes.

Changes in the current master (889b14d, 0608601) broke the gimbal_flags=4 functionality for these mixes that where working in the "Version 1.9.0 2015-05-31 release":  Tricopter, Bicopter (when SERVO_TILT=true), Dualcopter (when SERVO_TILT=true), FlyingWing (when SERVO_TILT=false) and Airplane (when SERVO_TILT=false).  For Singlecopter mix, gimbal_flags=4 functionality wasn't working in the "Version 1.9.0 2015-05-31 release."

For all mixes the functionality should now work as expected (when RX_PPM/RX_SERIAL and gimbal_flags=4, AUX1..4 RC inputs forwarded to PWM5..8 pins).  The improvements in the current master to SERVO_TILT should still be there (i.e., one channel of SERVO_TILT active with Tricopter mix on Naze32.)

What was needed was to feed the right 'firstServoIndex' value to the 'forwardAuxChannelsToServos()' function for each mix.  (Note that this was not fixed by 0608601.)  There may be a better way to determine this value, but the servo mapping across all the various mixes and boards gets rather convoluted.

--ET