### PR TITLE
Corrected default mixer values for octo flat X

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -546,52 +546,52 @@ static void resetConf(void)
     currentControlRateProfile->rates[FD_YAW] = 100;
     parseRcChannels("TAER1234", &masterConfig.rxConfig);
 
-    //  { 1.0f, -0.5f,  1.0f, -1.0f },          // REAR_R
+    //  { 1.0f, -0.414178f,  1.0f, -1.0f },          // REAR_R
     masterConfig.customMixer[0].throttle = 1.0f;
-    masterConfig.customMixer[0].roll = -0.5f;
+    masterConfig.customMixer[0].roll = -0.414178f;
     masterConfig.customMixer[0].pitch = 1.0f;
     masterConfig.customMixer[0].yaw = -1.0f;
 
-    //  { 1.0f, -0.5f, -1.0f,  1.0f },          // FRONT_R
+    //  { 1.0f, -0.414178f, -1.0f,  1.0f },          // FRONT_R
     masterConfig.customMixer[1].throttle = 1.0f;
-    masterConfig.customMixer[1].roll = -0.5f;
+    masterConfig.customMixer[1].roll = -0.414178f;
     masterConfig.customMixer[1].pitch = -1.0f;
     masterConfig.customMixer[1].yaw = 1.0f;
 
-    //  { 1.0f,  0.5f,  1.0f,  1.0f },          // REAR_L
+    //  { 1.0f,  0.414178f,  1.0f,  1.0f },          // REAR_L
     masterConfig.customMixer[2].throttle = 1.0f;
-    masterConfig.customMixer[2].roll = 0.5f;
+    masterConfig.customMixer[2].roll = 0.414178f;
     masterConfig.customMixer[2].pitch = 1.0f;
     masterConfig.customMixer[2].yaw = 1.0f;
 
-    //  { 1.0f,  0.5f, -1.0f, -1.0f },          // FRONT_L
+    //  { 1.0f,  0.414178f, -1.0f, -1.0f },          // FRONT_L
     masterConfig.customMixer[3].throttle = 1.0f;
-    masterConfig.customMixer[3].roll = 0.5f;
+    masterConfig.customMixer[3].roll = 0.414178f;
     masterConfig.customMixer[3].pitch = -1.0f;
     masterConfig.customMixer[3].yaw = -1.0f;
 
-    //  { 1.0f, -1.0f, -0.5f, -1.0f },          // MIDFRONT_R
+    //  { 1.0f, -1.0f, -0.414178f, -1.0f },          // MIDFRONT_R
     masterConfig.customMixer[4].throttle = 1.0f;
     masterConfig.customMixer[4].roll = -1.0f;
-    masterConfig.customMixer[4].pitch = -0.5f;
+    masterConfig.customMixer[4].pitch = -0.414178f;
     masterConfig.customMixer[4].yaw = -1.0f;
 
-    //  { 1.0f,  1.0f, -0.5f,  1.0f },          // MIDFRONT_L
+    //  { 1.0f,  1.0f, -0.414178f,  1.0f },          // MIDFRONT_L
     masterConfig.customMixer[5].throttle = 1.0f;
     masterConfig.customMixer[5].roll = 1.0f;
-    masterConfig.customMixer[5].pitch = -0.5f;
+    masterConfig.customMixer[5].pitch = -0.414178f;
     masterConfig.customMixer[5].yaw = 1.0f;
 
-    //  { 1.0f, -1.0f,  0.5f,  1.0f },          // MIDREAR_R
+    //  { 1.0f, -1.0f,  0.414178f,  1.0f },          // MIDREAR_R
     masterConfig.customMixer[6].throttle = 1.0f;
     masterConfig.customMixer[6].roll = -1.0f;
-    masterConfig.customMixer[6].pitch = 0.5f;
+    masterConfig.customMixer[6].pitch = 0.414178f;
     masterConfig.customMixer[6].yaw = 1.0f;
 
-    //  { 1.0f,  1.0f,  0.5f, -1.0f },          // MIDREAR_L
+    //  { 1.0f,  1.0f,  0.414178f, -1.0f },          // MIDREAR_L
     masterConfig.customMixer[7].throttle = 1.0f;
     masterConfig.customMixer[7].roll = 1.0f;
-    masterConfig.customMixer[7].pitch = 0.5f;
+    masterConfig.customMixer[7].pitch = 0.414178f;
     masterConfig.customMixer[7].yaw = -1.0f;
 #endif
 

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -193,14 +193,14 @@ static const motorMixer_t mixerOctoFlatP[] = {
 };
 
 static const motorMixer_t mixerOctoFlatX[] = {
-    { 1.0f,  1.0f, -0.5f,  1.0f },          // MIDFRONT_L
-    { 1.0f, -0.5f, -1.0f,  1.0f },          // FRONT_R
-    { 1.0f, -1.0f,  0.5f,  1.0f },          // MIDREAR_R
-    { 1.0f,  0.5f,  1.0f,  1.0f },          // REAR_L
-    { 1.0f,  0.5f, -1.0f, -1.0f },          // FRONT_L
-    { 1.0f, -1.0f, -0.5f, -1.0f },          // MIDFRONT_R
-    { 1.0f, -0.5f,  1.0f, -1.0f },          // REAR_R
-    { 1.0f,  1.0f,  0.5f, -1.0f },          // MIDREAR_L
+    { 1.0f,  1.0f, -0.414178f,  1.0f },      // MIDFRONT_L
+    { 1.0f, -0.414178f, -1.0f,  1.0f },      // FRONT_R
+    { 1.0f, -1.0f,  0.414178f,  1.0f },      // MIDREAR_R
+    { 1.0f,  0.414178f,  1.0f,  1.0f },      // REAR_L
+    { 1.0f,  0.414178f, -1.0f, -1.0f },      // FRONT_L
+    { 1.0f, -1.0f, -0.414178f, -1.0f },      // MIDFRONT_R
+    { 1.0f, -0.414178f,  1.0f, -1.0f },      // REAR_R
+    { 1.0f,  1.0f,  0.414178f, -1.0f },      // MIDREAR_L
 };
 
 static const motorMixer_t mixerVtail4[] = {


### PR DESCRIPTION
(Sorry, still learning the ways of Github. Let me do this again.)
Assuming motors are arranged in the typical format of equidistant around a circle, the mixer values for octo flat X seem to have been incorrect since MultiWii. Before and after:
![selection_025](https://cloud.githubusercontent.com/assets/2474537/8540417/9b3f4730-24c0-11e5-9734-782db2e5b2b6.png)