### PR TITLE
Bug Fix: Stop motors in 3D mode

### DIFF
--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -534,7 +534,7 @@ void writeAllMotors(int16_t mc)
 
 void stopMotors(void)
 {
-    writeAllMotors(escAndServoConfig->mincommand);
+    writeAllMotors(feature(FEATURE_3D) ? flight3DConfig->neutral3d : escAndServoConfig->mincommand);
 
     delay(50); // give the timers and ESCs a chance to react.
 }


### PR DESCRIPTION
Fixed a bug: in 3D mode to stop the motors, send neutral3d value to the ESCs instead of mincommand.

This was causing the motors to go full negative for a short time everytime I left the CLI mode tab in the Configurator GUI.