### PR TITLE
Luxfloat Optimisation and new defaults

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -175,15 +175,15 @@ static void resetPidProfile(pidProfile_t *pidProfile)
     pidProfile->pterm_cut_hz = 0;
     pidProfile->gyro_cut_hz = 0;
 
-    pidProfile->P_f[ROLL] = 2.5f;     // new PID with preliminary defaults test carefully
-    pidProfile->I_f[ROLL] = 0.6f;
-    pidProfile->D_f[ROLL] = 0.06f;
-    pidProfile->P_f[PITCH] = 2.5f;
-    pidProfile->I_f[PITCH] = 0.6f;
-    pidProfile->D_f[PITCH] = 0.06f;
-    pidProfile->P_f[YAW] = 8.0f;
-    pidProfile->I_f[YAW] = 0.5f;
-    pidProfile->D_f[YAW] = 0.05f;
+    pidProfile->P_f[ROLL] = 1.5f;     // new PID with preliminary defaults test carefully
+    pidProfile->I_f[ROLL] = 0.4f;
+    pidProfile->D_f[ROLL] = 0.03f;
+    pidProfile->P_f[PITCH] = 1.5f;
+    pidProfile->I_f[PITCH] = 0.4f;
+    pidProfile->D_f[PITCH] = 0.03f;
+    pidProfile->P_f[YAW] = 2.5f;
+    pidProfile->I_f[YAW] = 1.0f;
+    pidProfile->D_f[YAW] = 0.00f;
     pidProfile->A_level = 5.0f;
     pidProfile->H_level = 3.0f;
     pidProfile->H_sensitivity = 75;


### PR DESCRIPTION
Luxfloat PID controller was a nice concept, but very hard to tune and not as locked in as some others. After a lot of playing with different PID controllers I figured out what is good and what not.
Well this is how it should be! delta calculation was not optimal.
Please give some feedback

Updated:
- New defaults
- New delta calculation (RateError instead of GyroError)
- Removed TPA for Integral (not needed)

Flight with this PR and RC smoothing:
https://www.youtube.com/watch?v=1_SiBKD7R7M

NAZE
https://dl.dropboxusercontent.com/u/31537757/cleanflight/cleanflight_NAZE.hex

SRF3
https://dl.dropboxusercontent.com/u/31537757/cleanflight/cleanflight_SPRACINGF3.hex

CC3D:
https://dl.dropboxusercontent.com/u/31537757/cleanflight/cleanflight_CC3D.hex
https://dl.dropboxusercontent.com/u/31537757/cleanflight/cleanflight_CC3D.bin