### PR TITLE
Added fast acos/atan2 functions. Added unittests for fast trigonometry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -645,6 +645,7 @@ LDFLAGS		 = -lm \
 		   -static \
 		   -Wl,-gc-sections,-Map,$(TARGET_MAP) \
 		   -Wl,-L$(LINKER_DIR) \
+           -Wl,--cref \
 		   -T$(LD_SCRIPT)
 
 ###############################################################################

--- a/src/main/common/maths.c
+++ b/src/main/common/maths.c
@@ -21,12 +21,15 @@
 #include "axis.h"
 #include "maths.h"
 
+#if defined(FAST_TRIGONOMETRY) || defined(EVEN_FASTER_TRIGONOMETRY)
+#if defined(EVEN_FASTER_TRIGONOMETRY)
+
 // http://lolengine.net/blog/2011/12/21/better-function-approximations
 // Chebyshev http://stackoverflow.com/questions/345085/how-do-trigonometric-functions-work/345117#345117
 // Thanks for ledvinap for making such accuracy possible! See: https://github.com/cleanflight/cleanflight/issues/940#issuecomment-110323384
 // https://github.com/Crashpilot1000/HarakiriWebstore1/blob/master/src/mw.c#L1235
-#if defined(FAST_TRIGONOMETRY) || defined(EVEN_FASTER_TRIGONOMETRY)
-#if defined(EVEN_FASTER_TRIGONOMETRY)
+// sin_approx maximum absolute error = 2.305023e-06
+// cos_approx maximum absolute error = 2.857298e-06
 #define sinPolyCoef3 -1.666568107e-1f
 #define sinPolyCoef5  8.312366210e-3f
 #define sinPolyCoef7 -1.849218155e-4f
@@ -37,7 +40,6 @@
 #define sinPolyCoef7 -1.980661520e-4f                                          // Double: -1.980661520135080504411629636078917643846e-4
 #define sinPolyCoef9  2.600054768e-6f                                          // Double:  2.600054767890361277123254766503271638682e-6
 #endif
-
 float sin_approx(float x)
 {
     int32_t xint = x;
@@ -53,6 +55,47 @@ float sin_approx(float x)
 float cos_approx(float x)
 {
     return sin_approx(x + (0.5f * M_PIf));
+}
+
+// Initial implementation by Crashpilot1000 (https://github.com/Crashpilot1000/HarakiriWebstore1/blob/396715f73c6fcf859e0db0f34e12fe44bace6483/src/mw.c#L1292)
+// Polynomial coefficients by Andor (http://www.dsprelated.com/showthread/comp.dsp/21872-1.php) optimized by Ledvinap to save one multiplication
+// Max absolute error 0,000027 degree
+// atan2_approx maximum absolute error = 7.152557e-07 rads (4.098114e-05 degree)
+float atan2_approx(float y, float x)
+{
+    #define atanPolyCoef1  3.14551665884836e-07f
+    #define atanPolyCoef2  0.99997356613987f
+    #define atanPolyCoef3  0.14744007058297684f
+    #define atanPolyCoef4  0.3099814292351353f
+    #define atanPolyCoef5  0.05030176425872175f
+    #define atanPolyCoef6  0.1471039133652469f
+    #define atanPolyCoef7  0.6444640676891548f
+
+    float res, absX, absY;
+    absX = fabsf(x);
+    absY = fabsf(y);
+    res  = MAX(absX, absY);
+    if (res) res = MIN(absX, absY) / res;
+    else res = 0.0f;
+    res = -((((atanPolyCoef5 * res - atanPolyCoef4) * res - atanPolyCoef3) * res - atanPolyCoef2) * res - atanPolyCoef1) / ((atanPolyCoef7 * res + atanPolyCoef6) * res + 1.0f);
+    if (absY > absX) res = (M_PIf / 2.0f) - res;
+    if (x < 0) res = M_PIf - res;
+    if (y < 0) res = -res;
+    return res;
+}
+
+// http://http.developer.nvidia.com/Cg/acos.html
+// Handbook of Mathematical Functions
+// M. Abramowitz and I.A. Stegun, Ed.
+// acos_approx maximum absolute error = 6.760856e-05 rads (3.873685e-03 degree)
+float acos_approx(float x)
+{
+    float xa = fabsf(x);
+    float result = sqrtf(1.0f - xa) * (1.5707288f + xa * (-0.2121144f + xa * (0.0742610f + (-0.0187293f * xa))));
+    if (x < 0.0f)
+        return M_PIf - result;
+    else
+        return result;
 }
 #endif
 

--- a/src/main/common/maths.h
+++ b/src/main/common/maths.h
@@ -88,12 +88,18 @@ int32_t quickMedianFilter5(int32_t * v);
 int32_t quickMedianFilter7(int32_t * v);
 int32_t quickMedianFilter9(int32_t * v);
 
-#if defined(FAST_TRIGONOMETRY) || defined(EVEN_FASTER_TRIGONOMETRY)
+#if defined(FAST_MATH) || defined(VERY_FAST_MATH)
 float sin_approx(float x);
 float cos_approx(float x);
+float atan2_approx(float y, float x);
+float acos_approx(float x);
+#define tan_approx(x)       (sin_approx(x) / cos_approx(x))
 #else
 #define sin_approx(x)   sinf(x)
 #define cos_approx(x)   cosf(x)
+#define atan2_approx(y,x)   atan2f(y,x)
+#define acos_approx(x)      acosf(x)
+#define tan_approx(x)       tanf(x)
 #endif
 
 void arraySubInt32(int32_t *dest, int32_t *array1, int32_t *array2, int count);

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -339,9 +339,9 @@ static void imuMahonyAHRSupdate(float dt, float gx, float gy, float gz,
 STATIC_UNIT_TESTED void imuUpdateEulerAngles(void)
 {
     /* Compute pitch/roll angles */
-    attitude.values.roll = lrintf(atan2f(rMat[2][1], rMat[2][2]) * (1800.0f / M_PIf));
-    attitude.values.pitch = lrintf(((0.5f * M_PIf) - acosf(-rMat[2][0])) * (1800.0f / M_PIf));
-    attitude.values.yaw = lrintf((-atan2f(rMat[1][0], rMat[0][0]) * (1800.0f / M_PIf) + magneticDeclination));
+    attitude.values.roll = lrintf(atan2_approx(rMat[2][1], rMat[2][2]) * (1800.0f / M_PIf));
+    attitude.values.pitch = lrintf(((0.5f * M_PIf) - acos_approx(-rMat[2][0])) * (1800.0f / M_PIf));
+    attitude.values.yaw = lrintf((-atan2_approx(rMat[1][0], rMat[0][0]) * (1800.0f / M_PIf) + magneticDeclination));
 
     if (attitude.values.yaw < 0)
         attitude.values.yaw += 3600;
@@ -452,7 +452,7 @@ int16_t calculateThrottleAngleCorrection(uint8_t throttle_correction_value)
     if (rMat[2][2] <= 0.015f) {
         return 0;
     }
-    int angle = lrintf(acosf(rMat[2][2]) * throttleAngleScale);
+    int angle = lrintf(acos_approx(rMat[2][2]) * throttleAngleScale);
     if (angle > 900)
         angle = 900;
     return lrintf(throttle_correction_value * sin_approx(angle / (900.0f * M_PIf / 2.0f)));

--- a/src/main/flight/lowpass.c
+++ b/src/main/flight/lowpass.c
@@ -20,6 +20,7 @@
 #include <stdlib.h>
 #include <math.h>
 
+#include "common/maths.h"
 #include "flight/lowpass.h"
 
 //#define DEBUG_LOWPASS
@@ -31,7 +32,7 @@ void generateLowpassCoeffs2(int16_t freq, lowpass_t *filter)
 
     // generates coefficients for a 2nd-order butterworth low-pass filter
     float freqf = (float)freq*0.001f;
-    float omega = tanf((float)M_PI*freqf/2.0f);
+    float omega = tan_approx((float)M_PI*freqf/2.0f);
     float scaling = 1.0f / (omega*omega + 1.4142136f*omega + 1.0f);
 
 

--- a/src/main/flight/navigation.c
+++ b/src/main/flight/navigation.c
@@ -461,7 +461,7 @@ static void GPS_distance_cm_bearing(int32_t *currentLat1, int32_t *currentLon1, 
     float dLon = (float)(*destinationLon2 - *currentLon1) * GPS_scaleLonDown;
     *dist = sqrtf(sq(dLat) + sq(dLon)) * DISTANCE_BETWEEN_TWO_LONGITUDE_POINTS_AT_EQUATOR_IN_HUNDREDS_OF_KILOMETERS;
 
-    *bearing = 9000.0f + atan2f(-dLat, dLon) * TAN_89_99_DEGREES;      // Convert the output radians to 100xdeg
+    *bearing = 9000.0f + atan2_approx(-dLat, dLon) * TAN_89_99_DEGREES;      // Convert the output radians to 100xdeg
     if (*bearing < 0)
         *bearing += 36000;
 }

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -360,6 +360,7 @@ $(OBJECT_DIR)/lowpass_unittest.o : \
 $(OBJECT_DIR)/lowpass_unittest : \
 	$(OBJECT_DIR)/flight/lowpass.o \
 	$(OBJECT_DIR)/lowpass_unittest.o \
+    $(OBJECT_DIR)/common/maths.o \
 	$(OBJECT_DIR)/gtest_main.a
 
 	$(CXX) $(CXX_FLAGS) $^ -o $(OBJECT_DIR)/$@

--- a/src/test/unit/flight_imu_unittest.cc
+++ b/src/test/unit/flight_imu_unittest.cc
@@ -17,6 +17,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <math.h>
 
 #include <limits.h>
 
@@ -61,14 +62,14 @@ void imuComputeQuaternionFromRPY(int16_t initialRoll, int16_t initialPitch, int1
     if (initialPitch > 1800) initialPitch -= 3600;
     if (initialYaw > 1800) initialYaw -= 3600;
 
-    float cosRoll = cos_approx(DECIDEGREES_TO_RADIANS(initialRoll) * 0.5f);
-    float sinRoll = sin_approx(DECIDEGREES_TO_RADIANS(initialRoll) * 0.5f);
+    float cosRoll = cosf(DECIDEGREES_TO_RADIANS(initialRoll) * 0.5f);
+    float sinRoll = sinf(DECIDEGREES_TO_RADIANS(initialRoll) * 0.5f);
 
-    float cosPitch = cos_approx(DECIDEGREES_TO_RADIANS(initialPitch) * 0.5f);
-    float sinPitch = sin_approx(DECIDEGREES_TO_RADIANS(initialPitch) * 0.5f);
+    float cosPitch = cosf(DECIDEGREES_TO_RADIANS(initialPitch) * 0.5f);
+    float sinPitch = sinf(DECIDEGREES_TO_RADIANS(initialPitch) * 0.5f);
 
-    float cosYaw = cos_approx(DECIDEGREES_TO_RADIANS(-initialYaw) * 0.5f);
-    float sinYaw = sin_approx(DECIDEGREES_TO_RADIANS(-initialYaw) * 0.5f);
+    float cosYaw = cosf(DECIDEGREES_TO_RADIANS(-initialYaw) * 0.5f);
+    float sinYaw = sinf(DECIDEGREES_TO_RADIANS(-initialYaw) * 0.5f);
 
     q0 = cosRoll * cosPitch * cosYaw + sinRoll * sinPitch * sinYaw;
     q1 = sinRoll * cosPitch * cosYaw - cosRoll * sinPitch * sinYaw;

--- a/src/test/unit/maths_unittest.cc
+++ b/src/test/unit/maths_unittest.cc
@@ -20,6 +20,8 @@
 
 #include <limits.h>
 
+#include <math.h>
+
 #define BARO
 
 extern "C" {
@@ -145,3 +147,52 @@ TEST(MathsUnittest, TestRotateVectorAroundAxis)
 
     expectVectorsAreEqual(&vector, &expected_result);
 }
+
+#if defined(FAST_MATH) || defined(VERY_FAST_MATH)
+TEST(MathsUnittest, TestFastTrigonometrySinCos)
+{
+    double sinError = 0;
+    for (float x = -10 * M_PI; x < 10 * M_PI; x += M_PI / 300) {
+        double approxResult = sin_approx(x);
+        double libmResult = sinf(x);
+        sinError = MAX(sinError, fabs(approxResult - libmResult));
+    }
+    printf("sin_approx maximum absolute error = %e\n", sinError);
+    EXPECT_LE(sinError, 3e-6);
+
+    double cosError = 0;
+    for (float x = -10 * M_PI; x < 10 * M_PI; x += M_PI / 300) {
+        double approxResult = cos_approx(x);
+        double libmResult = cosf(x);
+        cosError = MAX(cosError, fabs(approxResult - libmResult));
+    }
+    printf("cos_approx maximum absolute error = %e\n", cosError);
+    EXPECT_LE(cosError, 3e-6);
+}
+
+TEST(MathsUnittest, TestFastTrigonometryATan2)
+{
+    double error = 0;
+    for (float x = -1.0f; x < 1.0f; x += 0.01) {
+        for (float y = -1.0f; x < 1.0f; x += 0.001) {
+            double approxResult = atan2_approx(y, x);
+            double libmResult = atan2f(y, x);
+            error = MAX(error, fabs(approxResult - libmResult));
+        }
+    }
+    printf("atan2_approx maximum absolute error = %e rads (%e degree)\n", error, error / M_PI * 180.0f);
+    EXPECT_LE(error, 1e-6);
+}
+
+TEST(MathsUnittest, TestFastTrigonometryACos)
+{
+    double error = 0;
+    for (float x = -1.0f; x < 1.0f; x += 0.001) {
+        double approxResult = acos_approx(x);
+        double libmResult = acos(x);
+        error = MAX(error, fabs(approxResult - libmResult));
+    }
+    printf("acos_approx maximum absolute error = %e rads (%e degree)\n", error, error / M_PI * 180.0f);
+    EXPECT_LE(error, 1e-4);
+}
+#endif


### PR DESCRIPTION
This is a continuation of #1092. 
Now cleanflight does not use any libm trigonometry functions. atan2f is ported over from  here: http://www.dspguru.com/dsp/tricks/fixed-point-atan2-with-self-normalization (also available here https://gist.github.com/volkansalma/2972237).
acosf is taken from Handbook of Mathematical Functions by M. Abramowitz and I.A. Stegun (reference implementation available here http://http.developer.nvidia.com/Cg/acos.html)

Code footprint is 1480 byte smaller:

master branch @ 52fe86e66db4e5f3d51422782b781d2b65db0182
   text    data     bss     dec     hex filename
 119732     364   12860  132956   2075c ./obj/main/cleanflight_CC3D.elf

fast-trig-improvements @ f3b571179dd639b1a047bad2e8b2f03f991db5a1
   text    data     bss     dec     hex filename
 118252     364   12856  131472   20190 ./obj/main/cleanflight_CC3D.elf

looptime=800 is now possible in rate mode and PIDC1 on CC3D