### PR TITLE
Fix Blackbox header truncation by using new serial Tx buffer freespace API

### DIFF
--- a/src/main/blackbox/blackbox_io.h
+++ b/src/main/blackbox/blackbox_io.h
@@ -32,7 +32,11 @@ typedef enum BlackboxDevice {
     BLACKBOX_DEVICE_END
 } BlackboxDevice;
 
-extern uint8_t blackboxWriteChunkSize;
+typedef enum {
+    BLACKBOX_RESERVE_SUCCESS,
+    BLACKBOX_RESERVE_TEMPORARY_FAILURE,
+    BLACKBOX_RESERVE_PERMANENT_FAILURE
+} blackboxBufferReserveStatus_e;
 
 void blackboxWrite(uint8_t value);
 
@@ -51,3 +55,5 @@ bool blackboxDeviceOpen(void);
 void blackboxDeviceClose(void);
 
 bool isBlackboxDeviceFull(void);
+
+blackboxBufferReserveStatus_e blackboxDeviceReserveBufferSpace(uint32_t bytes);

--- a/src/main/drivers/serial.c
+++ b/src/main/drivers/serial.c
@@ -40,9 +40,14 @@ void serialWrite(serialPort_t *instance, uint8_t ch)
     instance->vTable->serialWrite(instance, ch);
 }
 
-uint8_t serialTotalBytesWaiting(serialPort_t *instance)
+uint8_t serialRxBytesWaiting(serialPort_t *instance)
 {
-    return instance->vTable->serialTotalBytesWaiting(instance);
+    return instance->vTable->serialTotalRxWaiting(instance);
+}
+
+uint8_t serialTxBytesFree(serialPort_t *instance)
+{
+    return instance->vTable->serialTotalTxFree(instance);
 }
 
 uint8_t serialRead(serialPort_t *instance)

--- a/src/main/drivers/serial.h
+++ b/src/main/drivers/serial.h
@@ -62,7 +62,8 @@ typedef struct serialPort {
 struct serialPortVTable {
     void (*serialWrite)(serialPort_t *instance, uint8_t ch);
 
-    uint8_t (*serialTotalBytesWaiting)(serialPort_t *instance);
+    uint8_t (*serialTotalRxWaiting)(serialPort_t *instance);
+    uint8_t (*serialTotalTxFree)(serialPort_t *instance);
 
     uint8_t (*serialRead)(serialPort_t *instance);
 
@@ -75,7 +76,8 @@ struct serialPortVTable {
 };
 
 void serialWrite(serialPort_t *instance, uint8_t ch);
-uint8_t serialTotalBytesWaiting(serialPort_t *instance);
+uint8_t serialRxBytesWaiting(serialPort_t *instance);
+uint8_t serialTxBytesFree(serialPort_t *instance);
 uint8_t serialRead(serialPort_t *instance);
 void serialSetBaudRate(serialPort_t *instance, uint32_t baudRate);
 void serialSetMode(serialPort_t *instance, portMode_t mode);

--- a/src/main/drivers/serial_softserial.h
+++ b/src/main/drivers/serial_softserial.h
@@ -28,7 +28,8 @@ serialPort_t *openSoftSerial(softSerialPortIndex_e portIndex, serialReceiveCallb
 
 // serialPort API
 void softSerialWriteByte(serialPort_t *instance, uint8_t ch);
-uint8_t softSerialTotalBytesWaiting(serialPort_t *instance);
+uint8_t softSerialRxBytesWaiting(serialPort_t *instance);
+uint8_t softSerialTxBytesFree(serialPort_t *instance);
 uint8_t softSerialReadByte(serialPort_t *instance);
 void softSerialSetBaudRate(serialPort_t *s, uint32_t baudRate);
 bool isSoftSerialTransmitBufferEmpty(serialPort_t *s);

--- a/src/main/drivers/serial_uart.h
+++ b/src/main/drivers/serial_uart.h
@@ -19,6 +19,10 @@
 
 // Since serial ports can be used for any function these buffer sizes should be equal
 // The two largest things that need to be sent are: 1, MSP responses, 2, UBLOX SVINFO packet.
+
+// Size must be a power of two due to various optimizations which use 'and' instead of 'mod'
+// Various serial routines return the buffer occupied size as uint8_t which would need to be extended in order to
+// increase size further.
 #define UART1_RX_BUFFER_SIZE    256
 #define UART1_TX_BUFFER_SIZE    256
 #define UART2_RX_BUFFER_SIZE    256
@@ -48,7 +52,8 @@ serialPort_t *uartOpen(USART_TypeDef *USARTx, serialReceiveCallbackPtr callback,
 
 // serialPort API
 void uartWrite(serialPort_t *instance, uint8_t ch);
-uint8_t uartTotalBytesWaiting(serialPort_t *instance);
+uint8_t uartTotalRxBytesWaiting(serialPort_t *instance);
+uint8_t uartTotalTxBytesFree(serialPort_t *instance);
 uint8_t uartRead(serialPort_t *instance);
 void uartSetBaudRate(serialPort_t *s, uint32_t baudRate);
 bool isUartTransmitBufferEmpty(serialPort_t *s);

--- a/src/main/io/flashfs.c
+++ b/src/main/io/flashfs.c
@@ -120,17 +120,33 @@ uint32_t flashfsGetSize()
     return m25p16_getGeometry()->totalSize;
 }
 
-const flashGeometry_t* flashfsGetGeometry()
-{
-    return m25p16_getGeometry();
-}
-
 static uint32_t flashfsTransmitBufferUsed()
 {
     if (bufferHead >= bufferTail)
         return bufferHead - bufferTail;
 
     return FLASHFS_WRITE_BUFFER_SIZE - bufferTail + bufferHead;
+}
+
+/**
+ * Get the size of the largest single write that flashfs could ever accept without blocking or data loss.
+ */
+uint32_t flashfsGetWriteBufferSize()
+{
+    return FLASHFS_WRITE_BUFFER_USABLE;
+}
+
+/**
+ * Get the number of bytes that can currently be written to flashfs without any blocking or data loss.
+ */
+uint32_t flashfsGetWriteBufferFreeSpace()
+{
+    return flashfsGetWriteBufferSize() - flashfsTransmitBufferUsed();
+}
+
+const flashGeometry_t* flashfsGetGeometry()
+{
+    return m25p16_getGeometry();
 }
 
 /**

--- a/src/main/io/flashfs.h
+++ b/src/main/io/flashfs.h
@@ -32,6 +32,8 @@ void flashfsEraseRange(uint32_t start, uint32_t end);
 
 uint32_t flashfsGetSize();
 uint32_t flashfsGetOffset();
+uint32_t flashfsGetWriteBufferFreeSpace();
+uint32_t flashfsGetWriteBufferSize();
 int flashfsIdentifyStartOfFreeSpace();
 const flashGeometry_t* flashfsGetGeometry();
 

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -360,7 +360,7 @@ void gpsThread(void)
 {
     // read out available GPS bytes
     if (gpsPort) {
-        while (serialTotalBytesWaiting(gpsPort))
+        while (serialRxBytesWaiting(gpsPort))
             gpsNewData(serialRead(gpsPort));
     }
 
@@ -1036,14 +1036,14 @@ void gpsEnablePassthrough(serialPort_t *gpsPassthroughPort)
 #endif
     char c;
     while(1) {
-        if (serialTotalBytesWaiting(gpsPort)) {
+        if (serialRxBytesWaiting(gpsPort)) {
             LED0_ON;
             c = serialRead(gpsPort);
             gpsNewData(c);
             serialWrite(gpsPassthroughPort, c);
             LED0_OFF;
         }
-        if (serialTotalBytesWaiting(gpsPassthroughPort)) {
+        if (serialRxBytesWaiting(gpsPassthroughPort)) {
             LED1_ON;
             serialWrite(gpsPort, serialRead(gpsPassthroughPort));
             LED1_OFF;

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -1743,7 +1743,7 @@ void cliProcess(void)
         return;
     }
 
-    while (serialTotalBytesWaiting(cliPort)) {
+    while (serialRxBytesWaiting(cliPort)) {
         uint8_t c = serialRead(cliPort);
         if (c == '\t' || c == '?') {
             // do tab completion

--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -1740,7 +1740,7 @@ void mspProcess(void)
 
         setCurrentPort(candidatePort);
 
-        while (serialTotalBytesWaiting(mspSerialPort)) {
+        while (serialRxBytesWaiting(mspSerialPort)) {
 
             uint8_t c = serialRead(mspSerialPort);
             bool consumed = mspProcessReceivedData(c);

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -506,7 +506,7 @@ void init(void)
 void processLoopback(void) {
     if (loopbackPort) {
         uint8_t bytesWaiting;
-        while ((bytesWaiting = serialTotalBytesWaiting(loopbackPort))) {
+        while ((bytesWaiting = serialRxBytesWaiting(loopbackPort))) {
             uint8_t b = serialRead(loopbackPort);
             serialWrite(loopbackPort, b);
         };

--- a/src/main/telemetry/hott.c
+++ b/src/main/telemetry/hott.c
@@ -371,7 +371,7 @@ static void processBinaryModeRequest(uint8_t address) {
 
 static void flushHottRxBuffer(void)
 {
-    while (serialTotalBytesWaiting(hottPort) > 0) {
+    while (serialRxBytesWaiting(hottPort) > 0) {
         serialRead(hottPort);
     }
 }
@@ -380,7 +380,7 @@ static void hottCheckSerialData(uint32_t currentMicros)
 {
     static bool lookingForRequest = true;
 
-    uint8_t bytesWaiting = serialTotalBytesWaiting(hottPort);
+    uint8_t bytesWaiting = serialRxBytesWaiting(hottPort);
 
     if (bytesWaiting <= 1) {
         return;

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -160,7 +160,7 @@ static void smartPortDataReceive(uint16_t c)
     static uint8_t lastChar;
     if (lastChar == FSSP_START_STOP) {
         smartPortState = SPSTATE_WORKING;
-        if (c == FSSP_SENSOR_ID1 && (serialTotalBytesWaiting(smartPortSerialPort) == 0)) {
+        if (c == FSSP_SENSOR_ID1 && (serialRxBytesWaiting(smartPortSerialPort) == 0)) {
             smartPortLastRequestTime = now;
             smartPortHasRequest = 1;
             // we only responde to these IDs
@@ -282,7 +282,7 @@ void handleSmartPortTelemetry(void)
         return;
     }
 
-    while (serialTotalBytesWaiting(smartPortSerialPort) > 0) {
+    while (serialRxBytesWaiting(smartPortSerialPort) > 0) {
         uint8_t c = serialRead(smartPortSerialPort);
         smartPortDataReceive(c);
     }

--- a/src/test/unit/telemetry_hott_unittest.cc
+++ b/src/test/unit/telemetry_hott_unittest.cc
@@ -177,7 +177,12 @@ uint32_t millis(void) {
 
 uint32_t micros(void) { return 0; }
 
-uint8_t serialTotalBytesWaiting(serialPort_t *instance) {
+uint8_t serialRxBytesWaiting(serialPort_t *instance) {
+    UNUSED(instance);
+    return 0;
+}
+
+uint8_t serialTxBytesFree(serialPort_t *instance) {
     UNUSED(instance);
     return 0;
 }


### PR DESCRIPTION
Uses the API that will be introduced in #1108 to make Blackbox aware of Tx buffer free space during Blackbox header writing. This allows Blackbox to avoid overrunning the serial Tx buffer space, which now allows logging at very slow baud rates such as 19200 over softserial.

In general this should fix reported problems with Blackbox headers becoming truncated while the rest of the log is fine.