### PR TITLE
BlackBox - Enable logging by Tx switch

### DIFF
--- a/docs/Modes.md
+++ b/docs/Modes.md
@@ -27,6 +27,7 @@ auxillary receiver channels and other events such as failsafe detection.
 | 20      | 19     | TELEMETRY  | Enable telemetry via switch                                          |
 | 21      | 20     | AUTOTUNE   | Autotune Pitch/Roll PIDs                                             |
 | 22      | 21     | SONAR      | Altitude hold mode (sonar sensor only)                               |
+| 26      | 25     | BLACKBOX   | Enable BlackBox logging                                              |
 
 ## Mode details
 

--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1187,25 +1187,22 @@ static void blackboxLogIteration(bool writeFrames)
          * Don't log a slow frame if the slow data didn't change ("I" frames are already large enough without adding
          * an additional item to write at the same time)
          */
-        writeSlowFrameIfNeeded(false);
         if (writeFrames) {
+            writeSlowFrameIfNeeded(false);
             loadMainState();
             writeIntraframe();
         }
     } else {
         blackboxCheckAndLogArmingBeep();
         
-        if (blackboxShouldLogPFrame(blackboxPFrameIndex)) {
-            /*
+        if (blackboxShouldLogPFrame(blackboxPFrameIndex) && writeFrames) {
+             /*
              * We assume that slow frames are only interesting in that they aid the interpretation of the main data stream.
              * So only log slow frames during loop iterations where we log a main frame.
              */
             writeSlowFrameIfNeeded(true);
-
-            if (writeFrames) {
-                loadMainState();
-                writeInterframe();
-            }
+            loadMainState();
+            writeInterframe();
         }
 #ifdef GPS
         if (feature(FEATURE_GPS) && writeFrames) {

--- a/src/main/io/rc_controls.c
+++ b/src/main/io/rc_controls.c
@@ -302,6 +302,17 @@ void processRcStickPositions(rxConfig_t *rxConfig, throttleStatus_e throttleStat
 
 }
 
+bool isModeActivationConditionPresent(modeActivationCondition_t *modeActivationConditions, boxId_e modeId)
+{
+    uint8_t index;
+
+    for (index = 0; index < MAX_MODE_ACTIVATION_CONDITION_COUNT; index++) {
+        modeActivationCondition_t *modeActivationCondition = &modeActivationConditions[index];
+        if (modeActivationCondition->modeId == modeId) return true;
+    }
+    return false;
+}
+
 bool isRangeActive(uint8_t auxChannelIndex, channelRange_t *range) {
     if (!IS_RANGE_USABLE(range)) {
         return false;

--- a/src/main/io/rc_controls.c
+++ b/src/main/io/rc_controls.c
@@ -735,8 +735,6 @@ int32_t getRcStickDeflection(int32_t axis, uint16_t midrc) {
 
 void useRcControlsConfig(modeActivationCondition_t *modeActivationConditions, escAndServoConfig_t *escAndServoConfigToUse, pidProfile_t *pidProfileToUse)
 {
-    uint8_t index;
-
     escAndServoConfig = escAndServoConfigToUse;
     pidProfile = pidProfileToUse;
 

--- a/src/main/io/rc_controls.c
+++ b/src/main/io/rc_controls.c
@@ -308,7 +308,7 @@ bool isModeActivationConditionPresent(modeActivationCondition_t *modeActivationC
 
     for (index = 0; index < MAX_MODE_ACTIVATION_CONDITION_COUNT; index++) {
         modeActivationCondition_t *modeActivationCondition = &modeActivationConditions[index];
-        if (modeActivationCondition->modeId == modeId) return true;
+        if (modeActivationCondition->modeId == modeId && IS_RANGE_USABLE(&modeActivationCondition->range)) return true;
     }
     return false;
 }
@@ -740,15 +740,7 @@ void useRcControlsConfig(modeActivationCondition_t *modeActivationConditions, es
     escAndServoConfig = escAndServoConfigToUse;
     pidProfile = pidProfileToUse;
 
-    isUsingSticksToArm = true;
-
-    for (index = 0; index < MAX_MODE_ACTIVATION_CONDITION_COUNT; index++) {
-        modeActivationCondition_t *modeActivationCondition = &modeActivationConditions[index];
-        if (modeActivationCondition->modeId == BOXARM && IS_RANGE_USABLE(&modeActivationCondition->range)) {
-            isUsingSticksToArm = false;
-            break;
-        }
-    }
+    isUsingSticksToArm = !isModeActivationConditionPresent(modeActivationConditions, BOXARM);
 }
 
 void resetAdjustmentStates(void)

--- a/src/main/io/rc_controls.h
+++ b/src/main/io/rc_controls.h
@@ -46,6 +46,7 @@ typedef enum {
     BOXSERVO1,
     BOXSERVO2,
     BOXSERVO3,
+    BOXBLACKBOX,
     CHECKBOX_ITEM_COUNT
 } boxId_e;
 
@@ -239,3 +240,4 @@ void processRcAdjustments(controlRateConfig_t *controlRateConfig, rxConfig_t *rx
 bool isUsingSticksForArming(void);
 
 int32_t getRcStickDeflection(int32_t axis, uint16_t midrc);
+bool isModeActivationConditionPresent(modeActivationCondition_t *modeActivationConditions, boxId_e modeId);

--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -341,7 +341,7 @@ static const box_t boxes[CHECKBOX_ITEM_COUNT + 1] = {
     { BOXSERVO1, "SERVO1;", 23 },
     { BOXSERVO2, "SERVO2;", 24 },
     { BOXSERVO3, "SERVO3;", 25 },
-    
+    { BOXBLACKBOX, "BLACKBOX;", 26 },
     { CHECKBOX_ITEM_COUNT, NULL, 0xFF }
 };
 
@@ -680,6 +680,7 @@ void mspInit(serialConfig_t *serialConfig)
         activeBoxIds[activeBoxIdCount++] = BOXSONAR;
     }
 
+
 #ifdef USE_SERVOS
     if (masterConfig.mixerMode == MIXER_CUSTOM_AIRPLANE) {
         activeBoxIds[activeBoxIdCount++] = BOXSERVO1;
@@ -687,7 +688,11 @@ void mspInit(serialConfig_t *serialConfig)
         activeBoxIds[activeBoxIdCount++] = BOXSERVO3;
     }
 #endif
-
+#ifdef BLACKBOX
+    if (feature(FEATURE_BLACKBOX)){
+        activeBoxIds[activeBoxIdCount++] = BOXBLACKBOX;
+    }
+#endif
     memset(mspPorts, 0x00, sizeof(mspPorts));
     mspAllocateSerialPorts(serialConfig);
 }
@@ -808,7 +813,8 @@ static bool processOutCommand(uint8_t cmdMSP)
             IS_ENABLED(IS_RC_MODE_ACTIVE(BOXTELEMETRY)) << BOXTELEMETRY |
             IS_ENABLED(IS_RC_MODE_ACTIVE(BOXAUTOTUNE)) << BOXAUTOTUNE |
             IS_ENABLED(FLIGHT_MODE(SONAR_MODE)) << BOXSONAR |
-            IS_ENABLED(ARMING_FLAG(ARMED)) << BOXARM;
+            IS_ENABLED(ARMING_FLAG(ARMED)) << BOXARM |
+            IS_ENABLED(IS_RC_MODE_ACTIVE(BOXBLACKBOX)) << BOXBLACKBOX;
         for (i = 0; i < activeBoxIdCount; i++) {
             int flag = (tmp & (1 << activeBoxIds[i]));
             if (flag)


### PR DESCRIPTION
This PR will add mode switch for BlackBox. If no switch defined - old functionality (log always) will remain. Only events and slow frames will be logged if blackbox in suspended state. 

Example:
![screen shot 2015-07-14 at 09 38 26](https://cloud.githubusercontent.com/assets/2101514/8668510/1cb573d4-2a0c-11e5-87bb-ce08d5aa3512.png)

Probably @thenickdude  will make rendering of this way better!

Configurator screen (well, there is no code change of course):

![screen shot 2015-07-14 at 09 40 21](https://cloud.githubusercontent.com/assets/2101514/8668523/59011bfe-2a0c-11e5-87fd-dc270080c83a.png)

Check it out guys and let me know what do you think.