### PR TITLE
serial: allow buffering to speed up USB virtual COM ports.

### DIFF
--- a/src/main/drivers/serial.c
+++ b/src/main/drivers/serial.c
@@ -65,3 +65,14 @@ void serialSetMode(serialPort_t *instance, portMode_t mode)
     instance->vTable->setMode(instance, mode);
 }
 
+void serialBeginWrite(serialPort_t *instance)
+{
+    if (instance->vTable->beginWrite)
+        instance->vTable->beginWrite(instance);
+}
+
+void serialEndWrite(serialPort_t *instance)
+{
+    if (instance->vTable->endWrite)
+        instance->vTable->endWrite(instance);
+}

--- a/src/main/drivers/serial.h
+++ b/src/main/drivers/serial.h
@@ -72,6 +72,10 @@ struct serialPortVTable {
     bool (*isSerialTransmitBufferEmpty)(serialPort_t *instance);
 
     void (*setMode)(serialPort_t *instance, portMode_t mode);
+
+    // Optional functions used to buffer large writes.
+    void (*beginWrite)(serialPort_t *instance);
+    void (*endWrite)(serialPort_t *instance);
 };
 
 void serialWrite(serialPort_t *instance, uint8_t ch);
@@ -82,3 +86,6 @@ void serialSetMode(serialPort_t *instance, portMode_t mode);
 bool isSerialTransmitBufferEmpty(serialPort_t *instance);
 void serialPrint(serialPort_t *instance, const char *str);
 uint32_t serialGetBaudRate(serialPort_t *instance);
+
+void serialBeginWrite(serialPort_t *instance);
+void serialEndWrite(serialPort_t *instance);

--- a/src/main/drivers/serial_uart.c
+++ b/src/main/drivers/serial_uart.c
@@ -286,5 +286,7 @@ const struct serialPortVTable uartVTable[] = {
         uartSetBaudRate,
         isUartTransmitBufferEmpty,
         uartSetMode,
+        .beginWrite = NULL,
+        .endWrite = NULL,
     }
 };

--- a/src/main/drivers/serial_usb_vcp.c
+++ b/src/main/drivers/serial_usb_vcp.c
@@ -27,6 +27,7 @@
 #include "usb_core.h"
 #include "usb_init.h"
 #include "hw_config.h"
+#include "common/utils.h"
 
 #include "drivers/system.h"
 
@@ -38,7 +39,7 @@
 
 static vcpPort_t vcpPort;
 
-void usbVcpSetBaudRate(serialPort_t *instance, uint32_t baudRate)
+static void usbVcpSetBaudRate(serialPort_t *instance, uint32_t baudRate)
 {
     UNUSED(instance);
     UNUSED(baudRate);
@@ -46,7 +47,7 @@ void usbVcpSetBaudRate(serialPort_t *instance, uint32_t baudRate)
     // TODO implement
 }
 
-void usbVcpSetMode(serialPort_t *instance, portMode_t mode)
+static void usbVcpSetMode(serialPort_t *instance, portMode_t mode)
 {
     UNUSED(instance);
     UNUSED(mode);
@@ -54,20 +55,20 @@ void usbVcpSetMode(serialPort_t *instance, portMode_t mode)
     // TODO implement
 }
 
-bool isUsbVcpTransmitBufferEmpty(serialPort_t *instance)
+static bool isUsbVcpTransmitBufferEmpty(serialPort_t *instance)
 {
     UNUSED(instance);
     return true;
 }
 
-uint8_t usbVcpAvailable(serialPort_t *instance)
+static uint8_t usbVcpAvailable(serialPort_t *instance)
 {
     UNUSED(instance);
 
     return receiveLength & 0xFF; // FIXME use uint32_t return type everywhere
 }
 
-uint8_t usbVcpRead(serialPort_t *instance)
+static uint8_t usbVcpRead(serialPort_t *instance)
 {
     UNUSED(instance);
 
@@ -82,24 +83,63 @@ uint8_t usbVcpRead(serialPort_t *instance)
     return buf[0];
 }
 
-void usbVcpWrite(serialPort_t *instance, uint8_t c)
+static bool usbVcpFlush(vcpPort_t *port)
 {
-    UNUSED(instance);
+    uint8_t count = port->txAt;
+    port->txAt = 0;
 
+    if (count == 0) {
+        return true;
+    }
+    if (!usbIsConnected() || !usbIsConfigured()) {
+        return false;
+    }
+    
     uint32_t txed;
     uint32_t start = millis();
 
-    if (!(usbIsConnected() && usbIsConfigured())) {
-        return;
-    }
-
     do {
-        txed = CDC_Send_DATA((uint8_t*)&c, 1);
-    } while (txed < 1 && (millis() - start < USB_TIMEOUT));
+        txed = CDC_Send_DATA(port->txBuf, count);
+    } while (txed != count && (millis() - start < USB_TIMEOUT));
 
+    return txed == count;
 }
 
-const struct serialPortVTable usbVTable[] = { { usbVcpWrite, usbVcpAvailable, usbVcpRead, usbVcpSetBaudRate, isUsbVcpTransmitBufferEmpty, usbVcpSetMode } };
+static void usbVcpWrite(serialPort_t *instance, uint8_t c)
+{
+    vcpPort_t *port = container_of(instance, vcpPort_t, port);
+
+    port->txBuf[port->txAt++] = c;
+    if (!port->buffering || port->txAt >= ARRAYLEN(port->txBuf)) {
+        usbVcpFlush(port);
+    }
+}
+
+static void usbVcpBeginWrite(serialPort_t *instance)
+{
+    vcpPort_t *port = container_of(instance, vcpPort_t, port);
+    port->buffering = true;
+}
+
+static void usbVcpEndWrite(serialPort_t *instance)
+{
+    vcpPort_t *port = container_of(instance, vcpPort_t, port);
+    port->buffering = false;
+    usbVcpFlush(port);
+}
+
+static const struct serialPortVTable usbVTable[] = {
+    {
+        .serialWrite = usbVcpWrite,
+        .serialTotalBytesWaiting = usbVcpAvailable,
+        .serialRead = usbVcpRead,
+        .serialSetBaudRate = usbVcpSetBaudRate,
+        .isSerialTransmitBufferEmpty = isUsbVcpTransmitBufferEmpty,
+        .setMode = usbVcpSetMode,
+        .beginWrite = usbVcpBeginWrite,
+        .endWrite = usbVcpEndWrite,
+    }
+};
 
 serialPort_t *usbVcpOpen(void)
 {

--- a/src/main/drivers/serial_usb_vcp.h
+++ b/src/main/drivers/serial_usb_vcp.h
@@ -22,13 +22,11 @@
 typedef struct {
     serialPort_t port;
 
+    // Buffer used during bulk writes.
+    uint8_t txBuf[20];
+    uint8_t txAt;
+    // Set if the port is in bulk write mode and can buffer.
+    bool buffering;
 } vcpPort_t;
 
 serialPort_t *usbVcpOpen(void);
-
-uint8_t usbVcpAvailable(serialPort_t *instance);
-
-uint8_t usbVcpRead(serialPort_t *instance);
-
-void usbVcpWrite(serialPort_t *instance, uint8_t ch);
-void usbPrintStr(const char *str);

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -512,6 +512,7 @@ typedef union {
 static void cliSetVar(const clivalue_t *var, const int_float_value_t value);
 static void cliPrintVar(const clivalue_t *var, uint32_t full);
 static void cliPrint(const char *str);
+static void cliPrintf(const char *fmt, ...);
 static void cliWrite(uint8_t ch);
 
 static void cliPrompt(void)
@@ -1746,8 +1747,27 @@ static void cliDefaults(char *cmdline)
 
 static void cliPrint(const char *str)
 {
+    serialBeginWrite(cliPort);
     while (*str)
         serialWrite(cliPort, *(str++));
+    serialEndWrite(cliPort);
+}
+
+static void cliPutch(void *port, char ch)
+{
+    serialWrite(port, ch);
+}
+
+static void cliPrintf(const char* fmt, ...)
+{
+    va_list va;
+    va_start(va, fmt);
+
+    serialBeginWrite(cliPort);
+    tfp_format(cliPort, cliPutch, fmt, va);
+    serialEndWrite(cliPort);
+    
+    va_end(va);
 }
 
 static void cliWrite(uint8_t ch)

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -527,7 +527,7 @@ static void cliShowParseError(void)
 
 static void cliShowArgumentRangeError(char *name, int min, int max)
 {
-    printf("%s must be between %d and %d\r\n", name, min, max);
+    cliPrintf("%s must be between %d and %d\r\n", name, min, max);
 }
 
 static char *processChannelRangeArgs(char *ptr, channelRange_t *range, uint8_t *validArgumentCount)
@@ -568,7 +568,7 @@ static void cliAux(char *cmdline)
         // print out aux channel settings
         for (i = 0; i < MAX_MODE_ACTIVATION_CONDITION_COUNT; i++) {
             modeActivationCondition_t *mac = &currentProfile->modeActivationConditions[i];
-            printf("aux %u %u %u %u %u\r\n",
+            cliPrintf("aux %u %u %u %u %u\r\n",
                 i,
                 mac->modeId,
                 mac->auxChannelIndex,
@@ -619,7 +619,7 @@ static void cliSerial(char *cmdline)
             if (!serialIsPortAvailable(masterConfig.serialConfig.portConfigs[i].identifier)) {
                 continue;
             };
-            printf("serial %d %d %ld %ld %ld %ld\r\n" ,
+            cliPrintf("serial %d %d %ld %ld %ld %ld\r\n" ,
                 masterConfig.serialConfig.portConfigs[i].identifier,
                 masterConfig.serialConfig.portConfigs[i].functionMask,
                 baudRates[masterConfig.serialConfig.portConfigs[i].msp_baudrateIndex],
@@ -715,7 +715,7 @@ static void cliAdjustmentRange(char *cmdline)
         // print out adjustment ranges channel settings
         for (i = 0; i < MAX_ADJUSTMENT_RANGE_COUNT; i++) {
             adjustmentRange_t *ar = &currentProfile->adjustmentRanges[i];
-            printf("adjrange %u %u %u %u %u %u %u\r\n",
+            cliPrintf("adjrange %u %u %u %u %u %u %u\r\n",
                 i,
                 ar->adjustmentIndex,
                 ar->auxChannelIndex,
@@ -795,11 +795,11 @@ static void cliMotorMix(char *cmdline)
             if (masterConfig.customMotorMixer[i].throttle == 0.0f)
                 break;
             num_motors++;
-            printf("#%d:\t", i);
-            printf("%s\t", ftoa(masterConfig.customMotorMixer[i].throttle, buf));
-            printf("%s\t", ftoa(masterConfig.customMotorMixer[i].roll, buf));
-            printf("%s\t", ftoa(masterConfig.customMotorMixer[i].pitch, buf));
-            printf("%s\r\n", ftoa(masterConfig.customMotorMixer[i].yaw, buf));
+            cliPrintf("#%d:\t", i);
+            cliPrintf("%s\t", ftoa(masterConfig.customMotorMixer[i].throttle, buf));
+            cliPrintf("%s\t", ftoa(masterConfig.customMotorMixer[i].roll, buf));
+            cliPrintf("%s\t", ftoa(masterConfig.customMotorMixer[i].pitch, buf));
+            cliPrintf("%s\r\n", ftoa(masterConfig.customMotorMixer[i].yaw, buf));
         }
         return;
     } else if (strncasecmp(cmdline, "reset", 5) == 0) {
@@ -817,7 +817,7 @@ static void cliMotorMix(char *cmdline)
                 }
                 if (strncasecmp(ptr, mixerNames[i], len) == 0) {
                     mixerLoadMix(i, masterConfig.customMotorMixer);
-                    printf("Loaded %s\r\n", mixerNames[i]);
+                    cliPrintf("Loaded %s\r\n", mixerNames[i]);
                     cliMotorMix("");
                     break;
                 }
@@ -869,7 +869,7 @@ static void cliLed(char *cmdline)
     if (isEmpty(cmdline)) {
         for (i = 0; i < MAX_LED_STRIP_LENGTH; i++) {
             generateLedConfig(i, ledConfigBuffer, sizeof(ledConfigBuffer));
-            printf("led %u %s\r\n", i, ledConfigBuffer);
+            cliPrintf("led %u %s\r\n", i, ledConfigBuffer);
         }
     } else {
         ptr = cmdline;
@@ -892,7 +892,7 @@ static void cliColor(char *cmdline)
 
     if (isEmpty(cmdline)) {
         for (i = 0; i < CONFIGURABLE_COLOR_COUNT; i++) {
-            printf("color %u %d,%u,%u\r\n",
+            cliPrintf("color %u %d,%u,%u\r\n",
                 i,
                 masterConfig.colors[i].h,
                 masterConfig.colors[i].s,
@@ -932,7 +932,7 @@ static void cliServo(char *cmdline)
         for (i = 0; i < MAX_SUPPORTED_SERVOS; i++) {
             servo = &currentProfile->servoConf[i];
 
-            printf("servo %u %d %d %d %d %d %d %d\r\n",
+            cliPrintf("servo %u %d %d %d %d %d %d %d\r\n",
                 i,
                 servo->min,
                 servo->max,
@@ -1027,7 +1027,7 @@ static void cliServoMix(char *cmdline)
             if (masterConfig.customServoMixer[i].rate == 0)
                 break;
 
-            printf("#%d:\t%d\t%d\t%d\t%d\t%d\t%d\t%d\r\n",
+            cliPrintf("#%d:\t%d\t%d\t%d\t%d\t%d\t%d\t%d\r\n",
                 i,
                 masterConfig.customServoMixer[i].targetChannel,
                 masterConfig.customServoMixer[i].inputSource,
@@ -1038,7 +1038,7 @@ static void cliServoMix(char *cmdline)
                 masterConfig.customServoMixer[i].box
             );
         }
-        printf("\r\n");
+        cliPrintf("\r\n");
         return;
     } else if (strncasecmp(cmdline, "reset", 5) == 0) {
         // erase custom mixer
@@ -1052,12 +1052,12 @@ static void cliServoMix(char *cmdline)
             len = strlen(++ptr);
             for (i = 0; ; i++) {
                 if (mixerNames[i] == NULL) {
-                    printf("Invalid name\r\n");
+                    cliPrintf("Invalid name\r\n");
                     break;
                 }
                 if (strncasecmp(ptr, mixerNames[i], len) == 0) {
                     servoMixerLoadMix(i, masterConfig.customServoMixer);
-                    printf("Loaded %s\r\n", mixerNames[i]);
+                    cliPrintf("Loaded %s\r\n", mixerNames[i]);
                     cliServoMix("");
                     break;
                 }
@@ -1070,16 +1070,16 @@ static void cliServoMix(char *cmdline)
 
         len = strlen(ptr);
         if (len == 0) {
-            printf("s");
+            cliPrintf("s");
             for (inputSource = 0; inputSource < INPUT_SOURCE_COUNT; inputSource++)
-                printf("\ti%d", inputSource);
-            printf("\r\n");
+                cliPrintf("\ti%d", inputSource);
+            cliPrintf("\r\n");
 
             for (servoIndex = 0; servoIndex < MAX_SUPPORTED_SERVOS; servoIndex++) {
-                printf("%d", servoIndex);
+                cliPrintf("%d", servoIndex);
                 for (inputSource = 0; inputSource < INPUT_SOURCE_COUNT; inputSource++)
-                    printf("\t%s  ", (currentProfile->servoConf[servoIndex].reversedSources & (1 << inputSource)) ? "r" : "n");
-                printf("\r\n");
+                    cliPrintf("\t%s  ", (currentProfile->servoConf[servoIndex].reversedSources & (1 << inputSource)) ? "r" : "n");
+                cliPrintf("\r\n");
             }
             return;
         }
@@ -1152,7 +1152,7 @@ static void cliFlashInfo(char *cmdline)
 
     UNUSED(cmdline);
 
-    printf("Flash sectors=%u, sectorSize=%u, pagesPerSector=%u, pageSize=%u, totalSize=%u, usedSize=%u\r\n",
+    cliPrintf("Flash sectors=%u, sectorSize=%u, pagesPerSector=%u, pageSize=%u, totalSize=%u, usedSize=%u\r\n",
             layout->sectors, layout->sectorSize, layout->pagesPerSector, layout->pageSize, layout->totalSize, flashfsGetOffset());
 }
 
@@ -1160,14 +1160,14 @@ static void cliFlashErase(char *cmdline)
 {
     UNUSED(cmdline);
 
-    printf("Erasing...\r\n");
+    cliPrintf("Erasing...\r\n");
     flashfsEraseCompletely();
 
     while (!flashfsIsReady()) {
         delay(100);
     }
 
-    printf("Done.\r\n");
+    cliPrintf("Done.\r\n");
 }
 
 #ifdef USE_FLASH_TOOLS
@@ -1184,7 +1184,7 @@ static void cliFlashWrite(char *cmdline)
         flashfsWrite((uint8_t*)text, strlen(text), true);
         flashfsFlushSync();
 
-        printf("Wrote %u bytes at %u.\r\n", strlen(text), address);
+        cliPrintf("Wrote %u bytes at %u.\r\n", strlen(text), address);
     }
 }
 
@@ -1203,7 +1203,7 @@ static void cliFlashRead(char *cmdline)
     } else {
         length = atoi(nextArg);
 
-        printf("Reading %u bytes at %u:\r\n", length, address);
+        cliPrintf("Reading %u bytes at %u:\r\n", length, address);
 
         while (length > 0) {
             int bytesRead;
@@ -1222,7 +1222,7 @@ static void cliFlashRead(char *cmdline)
                 break;
             }
         }
-        printf("\r\n");
+        cliPrintf("\r\n");
     }
 }
 
@@ -1240,7 +1240,7 @@ static void dumpValues(uint16_t mask)
             continue;
         }
 
-        printf("set %s = ", valueTable[i].name);
+        cliPrintf("set %s = ", valueTable[i].name);
         cliPrintVar(value, 0);
         cliPrint("\r\n");
     }
@@ -1257,7 +1257,7 @@ typedef enum {
 
 static const char* const sectionBreak = "\r\n";
 
-#define printSectionBreak() printf((char *)sectionBreak)
+#define printSectionBreak() cliPrintf((char *)sectionBreak)
 
 static void cliDump(char *cmdline)
 {
@@ -1289,9 +1289,9 @@ static void cliDump(char *cmdline)
         cliPrint("\r\n# mixer\r\n");
 
 #ifndef USE_QUAD_MIXER_ONLY
-        printf("mixer %s\r\n", mixerNames[masterConfig.mixerMode - 1]);
+        cliPrintf("mixer %s\r\n", mixerNames[masterConfig.mixerMode - 1]);
 
-        printf("mmix reset\r\n");
+        cliPrintf("mmix reset\r\n");
 
         for (i = 0; i < MAX_SUPPORTED_MOTORS; i++) {
             if (masterConfig.customMotorMixer[i].throttle == 0.0f)
@@ -1300,30 +1300,30 @@ static void cliDump(char *cmdline)
             roll = masterConfig.customMotorMixer[i].roll;
             pitch = masterConfig.customMotorMixer[i].pitch;
             yaw = masterConfig.customMotorMixer[i].yaw;
-            printf("mmix %d", i);
+            cliPrintf("mmix %d", i);
             if (thr < 0)
                 cliWrite(' ');
-            printf("%s", ftoa(thr, buf));
+            cliPrintf("%s", ftoa(thr, buf));
             if (roll < 0)
                 cliWrite(' ');
-            printf("%s", ftoa(roll, buf));
+            cliPrintf("%s", ftoa(roll, buf));
             if (pitch < 0)
                 cliWrite(' ');
-            printf("%s", ftoa(pitch, buf));
+            cliPrintf("%s", ftoa(pitch, buf));
             if (yaw < 0)
                 cliWrite(' ');
-            printf("%s\r\n", ftoa(yaw, buf));
+            cliPrintf("%s\r\n", ftoa(yaw, buf));
         }
 
         // print custom servo mixer if exists
-        printf("smix reset\r\n");
+        cliPrintf("smix reset\r\n");
 
         for (i = 0; i < MAX_SERVO_RULES; i++) {
 
             if (masterConfig.customServoMixer[i].rate == 0)
                 break;
 
-            printf("smix %d %d %d %d %d %d %d %d\r\n",
+            cliPrintf("smix %d %d %d %d %d %d %d %d\r\n",
                 i,
                 masterConfig.customServoMixer[i].targetChannel,
                 masterConfig.customServoMixer[i].inputSource,
@@ -1339,7 +1339,7 @@ static void cliDump(char *cmdline)
         for (i = 0; i < MAX_SUPPORTED_SERVOS; i++) {
             for (channel = 0; channel < INPUT_SOURCE_COUNT; channel++) {
                 if (servoDirection(i, channel) < 0) {
-                    printf("smix reverse %d %d r\r\n", i , channel);
+                    cliPrintf("smix reverse %d %d r\r\n", i , channel);
                 }
             }
         }
@@ -1352,13 +1352,13 @@ static void cliDump(char *cmdline)
         for (i = 0; ; i++) { // disable all feature first
             if (featureNames[i] == NULL)
                 break;
-            printf("feature -%s\r\n", featureNames[i]);
+            cliPrintf("feature -%s\r\n", featureNames[i]);
         }
         for (i = 0; ; i++) {  // reenable what we want.
             if (featureNames[i] == NULL)
                 break;
             if (mask & (1 << i))
-                printf("feature %s\r\n", featureNames[i]);
+                cliPrintf("feature %s\r\n", featureNames[i]);
         }
 
         cliPrint("\r\n\r\n# map\r\n");
@@ -1366,7 +1366,7 @@ static void cliDump(char *cmdline)
         for (i = 0; i < 8; i++)
             buf[masterConfig.rxConfig.rcmap[i]] = rcChannelLetters[i];
         buf[i] = '\0';
-        printf("map %s\r\n", buf);
+        cliPrintf("map %s\r\n", buf);
 
         cliPrint("\r\n\r\n# serial\r\n");
         cliSerial("");
@@ -1421,7 +1421,6 @@ void cliEnter(serialPort_t *serialPort)
 {
     cliMode = 1;
     cliPort = serialPort;
-    setPrintfSerialPort(cliPort);
     cliPrint("\r\nEntering CLI Mode, type 'exit' to return, or 'help'\r\n");
     cliPrompt();
 }
@@ -1456,7 +1455,7 @@ static void cliFeature(char *cmdline)
             if (featureNames[i] == NULL)
                 break;
             if (mask & (1 << i))
-                printf("%s ", featureNames[i]);
+                cliPrintf("%s ", featureNames[i]);
         }
         cliPrint("\r\n");
     } else if (strncasecmp(cmdline, "list", len) == 0) {
@@ -1464,7 +1463,7 @@ static void cliFeature(char *cmdline)
         for (i = 0; ; i++) {
             if (featureNames[i] == NULL)
                 break;
-            printf("%s ", featureNames[i]);
+            cliPrintf("%s ", featureNames[i]);
         }
         cliPrint("\r\n");
         return;
@@ -1505,7 +1504,7 @@ static void cliFeature(char *cmdline)
                     featureSet(mask);
                     cliPrint("Enabled");
                 }
-                printf(" %s\r\n", featureNames[i]);
+                cliPrintf(" %s\r\n", featureNames[i]);
                 break;
             }
         }
@@ -1530,10 +1529,10 @@ static void cliHelp(char *cmdline)
     for (i = 0; i < CMD_COUNT; i++) {
         cliPrint(cmdTable[i].name);
         if (cmdTable[i].description) {
-            printf(" - %s", cmdTable[i].description);
+            cliPrintf(" - %s", cmdTable[i].description);
         }
         if (cmdTable[i].args) {
-            printf("\r\n\t%s", cmdTable[i].args);
+            cliPrintf("\r\n\t%s", cmdTable[i].args);
         }
         cliPrint("\r\n");
     }
@@ -1563,7 +1562,7 @@ static void cliMap(char *cmdline)
     for (i = 0; i < 8; i++)
         out[masterConfig.rxConfig.rcmap[i]] = rcChannelLetters[i];
     out[i] = '\0';
-    printf("%s\r\n", out);
+    cliPrintf("%s\r\n", out);
 }
 
 #ifndef USE_QUAD_MIXER_ONLY
@@ -1575,14 +1574,14 @@ static void cliMixer(char *cmdline)
     len = strlen(cmdline);
 
     if (len == 0) {
-        printf("Mixer: %s\r\n", mixerNames[masterConfig.mixerMode - 1]);
+        cliPrintf("Mixer: %s\r\n", mixerNames[masterConfig.mixerMode - 1]);
         return;
     } else if (strncasecmp(cmdline, "list", len) == 0) {
         cliPrint("Available mixers: ");
         for (i = 0; ; i++) {
             if (mixerNames[i] == NULL)
                 break;
-            printf("%s ", mixerNames[i]);
+            cliPrintf("%s ", mixerNames[i]);
         }
         cliPrint("\r\n");
         return;
@@ -1644,7 +1643,7 @@ static void cliMotor(char *cmdline)
         }
     }
 
-    printf("motor %d: %d\r\n", motor_index, motor_disarmed[motor_index]);
+    cliPrintf("motor %d: %d\r\n", motor_index, motor_disarmed[motor_index]);
 }
 
 static void cliPlaySound(char *cmdline)
@@ -1665,7 +1664,7 @@ static void cliPlaySound(char *cmdline)
                 if ((name=beeperNameForTableIndex(i)) != NULL)
                     break;   //if name OK then play sound below
                 if (i == lastSoundIdx + 1) {     //prevent infinite loop
-                    printf("Error playing sound\r\n");
+                    cliPrintf("Error playing sound\r\n");
                     return;
                 }
             }
@@ -1673,13 +1672,13 @@ static void cliPlaySound(char *cmdline)
     } else {       //index value was given
         i = atoi(cmdline);
         if ((name=beeperNameForTableIndex(i)) == NULL) {
-            printf("No sound for index %d\r\n", i);
+            cliPrintf("No sound for index %d\r\n", i);
             return;
         }
     }
     lastSoundIdx = i;
     beeperSilence();
-    printf("Playing sound %d: %s\r\n", i, name);
+    cliPrintf("Playing sound %d: %s\r\n", i, name);
     beeper(beeperModeForTableIndex(i));
 #endif
 }
@@ -1689,7 +1688,7 @@ static void cliProfile(char *cmdline)
     int i;
 
     if (isEmpty(cmdline)) {
-        printf("profile %d\r\n", getCurrentProfile());
+        cliPrintf("profile %d\r\n", getCurrentProfile());
         return;
     } else {
         i = atoi(cmdline);
@@ -1707,7 +1706,7 @@ static void cliRateProfile(char *cmdline)
     int i;
 
     if (isEmpty(cmdline)) {
-        printf("rateprofile %d\r\n", getCurrentControlRateProfile());
+        cliPrintf("rateprofile %d\r\n", getCurrentControlRateProfile());
         return;
     } else {
         i = atoi(cmdline);
@@ -1810,16 +1809,16 @@ static void cliPrintVar(const clivalue_t *var, uint32_t full)
             break;
 
         case VAR_FLOAT:
-            printf("%s", ftoa(*(float *)ptr, buf));
+            cliPrintf("%s", ftoa(*(float *)ptr, buf));
             if (full) {
-                printf(" %s", ftoa((float)var->min, buf));
-                printf(" %s", ftoa((float)var->max, buf));
+                cliPrintf(" %s", ftoa((float)var->min, buf));
+                cliPrintf(" %s", ftoa((float)var->max, buf));
             }
             return; // return from case for float only
     }
-    printf("%d", value);
+    cliPrintf("%d", value);
     if (full)
-        printf(" %d %d", var->min, var->max);
+        cliPrintf(" %d %d", var->min, var->max);
 }
 
 static void cliSetVar(const clivalue_t *var, const int_float_value_t value)
@@ -1868,7 +1867,7 @@ static void cliSet(char *cmdline)
         cliPrint("Current settings: \r\n");
         for (i = 0; i < VALUE_COUNT; i++) {
             val = &valueTable[i];
-            printf("%s = ", valueTable[i].name);
+            cliPrintf("%s = ", valueTable[i].name);
             cliPrintVar(val, len); // when len is 1 (when * is passed as argument), it will print min/max values as well, for gui
             cliPrint("\r\n");
         }
@@ -1895,7 +1894,7 @@ static void cliSet(char *cmdline)
                     else
                         tmp.int_value = value;
                     cliSetVar(val, tmp);
-                    printf("%s set to ", valueTable[i].name);
+                    cliPrintf("%s set to ", valueTable[i].name);
                     cliPrintVar(val, 0);
                 } else {
                     cliPrint("Value assignment out of range\r\n");
@@ -1919,7 +1918,7 @@ static void cliGet(char *cmdline)
     for (i = 0; i < VALUE_COUNT; i++) {
         if (strstr(valueTable[i].name, cmdline)) {
             val = &valueTable[i];
-            printf("%s = ", valueTable[i].name);
+            cliPrintf("%s = ", valueTable[i].name);
             cliPrintVar(val, 0);
             cliPrint("\r\n");
 
@@ -1939,11 +1938,11 @@ static void cliStatus(char *cmdline)
 {
     UNUSED(cmdline);
 
-    printf("System Uptime: %d seconds, Voltage: %d * 0.1V (%dS battery)\r\n",
+    cliPrintf("System Uptime: %d seconds, Voltage: %d * 0.1V (%dS battery)\r\n",
         millis() / 1000, vbat, batteryCellCount);
 
 
-    printf("CPU Clock=%dMHz", (SystemCoreClock / 1000000));
+    cliPrintf("CPU Clock=%dMHz", (SystemCoreClock / 1000000));
 
 #ifndef CJMCU
     uint8_t i;
@@ -1961,10 +1960,10 @@ static void cliStatus(char *cmdline)
             uint8_t sensorHardwareIndex = detectedSensors[i];
             sensorHardware = sensorHardwareNames[i][sensorHardwareIndex];
 
-            printf(", %s=%s", sensorTypeNames[i], sensorHardware);
+            cliPrintf(", %s=%s", sensorTypeNames[i], sensorHardware);
 
             if (mask == SENSOR_ACC && acc.revisionCode) {
-                printf(".%c", acc.revisionCode);
+                cliPrintf(".%c", acc.revisionCode);
             }
         }
     }
@@ -1977,14 +1976,14 @@ static void cliStatus(char *cmdline)
     uint16_t i2cErrorCounter = 0;
 #endif
 
-    printf("Cycle Time: %d, I2C Errors: %d, config size: %d\r\n", cycleTime, i2cErrorCounter, sizeof(master_t));
+    cliPrintf("Cycle Time: %d, I2C Errors: %d, config size: %d\r\n", cycleTime, i2cErrorCounter, sizeof(master_t));
 }
 
 static void cliVersion(char *cmdline)
 {
     UNUSED(cmdline);
 
-    printf("# Cleanflight/%s %s %s / %s (%s)",
+    cliPrintf("# Cleanflight/%s %s %s / %s (%s)",
         targetName,
         FC_VERSION_STRING,
         buildDate,

--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -438,6 +438,8 @@ static uint32_t read32(void)
 
 static void headSerialResponse(uint8_t err, uint8_t responseBodySize)
 {
+    serialBeginWrite(mspSerialPort);
+    
     serialize8('$');
     serialize8('M');
     serialize8(err ? '!' : '>');
@@ -459,6 +461,7 @@ static void headSerialError(uint8_t responseBodySize)
 static void tailSerialReply(void)
 {
     serialize8(currentPort->checksum);
+    serialEndWrite(mspSerialPort);
 }
 
 static void s_struct(uint8_t *cb, uint8_t siz)


### PR DESCRIPTION
I noticed this when working on my Python MSP library.  MSP over a VCP is much less reliable when running on a virtual machine as it sens one USB packet per byte.  This patch adds support for buffering at the driver level and uses it in MSP and the CLI.

This makes the polled MSP_STATUS message fit in one USB frame instead of 20 and greatly speeds up the CLI.
