### PR TITLE
Add a simple TOC to the front of the PDF manual

### DIFF
--- a/build_docs.sh
+++ b/build_docs.sh
@@ -3,7 +3,7 @@
 filename=Manual
 doc_files=(
 	'Introduction.md'
-  'Getting Started.md'
+ 'Getting Started.md'
 	'Safety.md'
 	'Installation.md'
 	'Configuration.md'
@@ -48,7 +48,8 @@ if which gimli >/dev/null; then
 		cat "$i" >> ${filename}.md
 	done
 	rm -f ${filename}.pdf
-	gimli -f ${filename}.md -stylesheet override.css
+	gimli -f ${filename}.md -stylesheet override.css \
+	  -w '--toc --title "Cleanflight Manual" --footer-right "[page]" --toc-depth 1'
 	rm ${filename}.md
 	popd >/dev/null
 else


### PR DESCRIPTION
I think the PDF version of the manual would benefit from a table of contents. Fortunately this can be auto generated by passing wkhtmltopdf options to gimli.