### PR TITLE
Remove TPA from Iterm PID1

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -799,7 +799,7 @@ static void pidRewrite(pidProfile_t *pidProfile, controlRateConfig_t *controlRat
         // Precision is critical, as I prevents from long-time drift. Thus, 32 bits integrator is used.
         // Time correction (to avoid different I scaling for different builds based on average cycle time)
         // is normalized to cycle time = 2048.
-        errorGyroI[axis] = errorGyroI[axis] + ((RateError * cycleTime) >> 11) * pidProfile->I8[axis] * PIDweight[axis] / 100;
+        errorGyroI[axis] = errorGyroI[axis] + ((RateError * cycleTime) >> 11) * pidProfile->I8[axis];
 
         // limit maximum integrator value to prevent WindUp - accumulating extreme values when system is saturated.
         // I coefficient (I8) moved before integration to make limiting independent from PID settings


### PR DESCRIPTION
When https://github.com/cleanflight/cleanflight/pull/1103 gets merged than this one is additional to also remove TPA from iterm of PID1 as well. 