### PR TITLE
Sync looptime to gyro interrupt 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,6 +230,7 @@ COMMON_SRC	 = build_config.c \
 		   flight/mixer.c \
 		   flight/lowpass.c \
 		   flight/filter.c \
+		   flight/synclooptime.c \
 		   drivers/bus_i2c_soft.c \
 		   drivers/serial.c \
 		   drivers/sound_beeper.c \

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -187,6 +187,8 @@ static void resetPidProfile(pidProfile_t *pidProfile)
     pidProfile->A_level = 5.0f;
     pidProfile->H_level = 3.0f;
     pidProfile->H_sensitivity = 75;
+
+    pidProfile->sync_looptime=1;
 }
 
 #ifdef GPS

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -188,7 +188,7 @@ static void resetPidProfile(pidProfile_t *pidProfile)
     pidProfile->H_level = 3.0f;
     pidProfile->H_sensitivity = 75;
 
-    pidProfile->sync_looptime=1;
+    pidProfile->sync_looptime=0;
 }
 
 #ifdef GPS

--- a/src/main/drivers/accgyro_mpu6050.c
+++ b/src/main/drivers/accgyro_mpu6050.c
@@ -34,6 +34,7 @@
 #include "sensor.h"
 #include "accgyro.h"
 #include "accgyro_mpu6050.h"
+ #include "flight/synclooptime.h"
 
 //#define DEBUG_MPU_DATA_READY_INTERRUPT
 
@@ -193,6 +194,8 @@ void MPU_DATA_READY_EXTI_Handler(void)
     }
 
     EXTI_ClearITPendingBit(mpu6050Config->exti_line);
+
+    lastGyroReadTime = micros();
 
 #ifdef DEBUG_MPU_DATA_READY_INTERRUPT
     // Measure the delta in micro seconds between calls to the interrupt handler

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -65,6 +65,7 @@ typedef struct pidProfile_s {
     uint8_t dterm_cut_hz;                   // (default 17Hz, Range 1-50Hz) Used for PT1 element in PID1, PID2 and PID5
     uint8_t pterm_cut_hz;                   // Used for fitlering Pterm noise on noisy frames
     uint8_t gyro_cut_hz;                    // Used for soft gyro filtering
+    uint8_t sync_looptime;                  // Used to enable looptime sync with gyro interrupt
 } pidProfile_t;
 
 #define DEGREES_TO_DECIDEGREES(angle) (angle * 10)

--- a/src/main/flight/synclooptime.c
+++ b/src/main/flight/synclooptime.c
@@ -1,6 +1,6 @@
 /*
 sync looptime with gyro interrupt
-nksreera
+author: nksreera
 */
 
 

--- a/src/main/flight/synclooptime.c
+++ b/src/main/flight/synclooptime.c
@@ -1,0 +1,9 @@
+/*
+sync looptime with gyro interrupt
+nksreera
+*/
+
+
+#include "stdint.h"
+
+uint32_t lastGyroReadTime = 0;

--- a/src/main/flight/synclooptime.h
+++ b/src/main/flight/synclooptime.h
@@ -1,7 +1,8 @@
 /*
 sync looptime with gyro interrupt
-nksreera
+author: nksreera
 */
 
 
+// Store the last gyro read time from the interrupt
 extern uint32_t lastGyroReadTime;

--- a/src/main/flight/synclooptime.h
+++ b/src/main/flight/synclooptime.h
@@ -1,0 +1,7 @@
+/*
+sync looptime with gyro interrupt
+nksreera
+*/
+
+
+extern uint32_t lastGyroReadTime;

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -494,6 +494,9 @@ const clivalue_t valueTable[] = {
 	{ "pterm_cut_hz",               VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.pterm_cut_hz, 0, 200 },
 	{ "gyro_cut_hz",                VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.gyro_cut_hz, 0, 200 },
 
+    { "sync_looptime",              VAR_UINT8  | PROFILE_VALUE, &masterConfig.profile[0].pidProfile.sync_looptime, 0, 1 },
+
+
 #ifdef BLACKBOX
     { "blackbox_rate_num",          VAR_UINT8  | MASTER_VALUE,  &masterConfig.blackbox_rate_num, 1, 32 },
     { "blackbox_rate_denom",        VAR_UINT8  | MASTER_VALUE,  &masterConfig.blackbox_rate_denom, 1, 32 },

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -79,6 +79,7 @@
 #include "config/config.h"
 #include "config/config_profile.h"
 #include "config/config_master.h"
+#include "flight/synclooptime.h"
 
 // June 2013     V2.2-dev
 
@@ -731,7 +732,7 @@ void loop(void)
     }
 
     currentTime = micros();
-    if (masterConfig.looptime == 0 || (int32_t)(currentTime - loopTime) >= 0) {
+    if (masterConfig.looptime == 0 || (int32_t)(currentTime - loopTime) >= 0 || previousTime < lastGyroReadTime) {
         loopTime = currentTime + masterConfig.looptime;
 
         imuUpdate(&currentProfile->accelerometerTrims);

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -732,7 +732,10 @@ void loop(void)
     }
 
     currentTime = micros();
-    if (masterConfig.looptime == 0 || (int32_t)(currentTime - loopTime) >= 0 || previousTime < lastGyroReadTime) {
+    if (masterConfig.looptime == 0  || 
+            (int32_t)(currentTime - loopTime) >= 0 || 
+            ( currentProfile->pidProfile.sync_looptime && previousTime < lastGyroReadTime)) {
+        
         loopTime = currentTime + masterConfig.looptime;
 
         imuUpdate(&currentProfile->accelerometerTrims);


### PR DESCRIPTION
gyro interrupt at lpf 42hz fires every 1000us, with this change the loop is executed as soon as a gyro read is available. 
this should benefit soft filters as well.

currently it is settable on a profile using cli
set sync_looptime=1

tested on naze32 loop time is at 2000us with accelerometer
and 1000us when acc_hardware=1

should be 1000us for f3 processors as well.

future additions would be to calculate gyro soft filters in the interrupt so if gyro_lpf is set to 256 the soft filters are evaluated every 125us. 