### PR TITLE
To prevent compiler warning in serial_cli.c

### DIFF
--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -579,13 +579,12 @@ static void cliRxFail(char *cmdline)
             rxFailsafeChannelConfiguration_t *channelFailsafeConfiguration = &masterConfig.rxConfig.failsafe_aux_channel_configurations[channel];
 
             uint16_t value;
-            rxFailsafeChannelMode_e mode;
+            rxFailsafeChannelMode_e mode = RX_FAILSAFE_MODE_HOLD;
 
             ptr = strchr(ptr, ' ');
             if (ptr) {
                 switch (*(++ptr)) {
                     case 'h':
-                        mode = RX_FAILSAFE_MODE_HOLD;
                         break;
 
                     case 's':


### PR DESCRIPTION
Because i like to compile without warnings...

This one in this case:
```c
%% serial_cli.c
./src/main/io/serial_cli.c: In function 'cliRxFail':
./src/main/io/serial_cli.c:609:52: warning: 'mode' may be used uninitialized in this function [-Wmaybe-uninitialized]
                 channelFailsafeConfiguration->mode = mode;
                                                    ^
```