### PR TITLE
LuxMode double rcCommand in Level mode fix max_angle_inclination

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -151,10 +151,10 @@ static void pidLuxFloat(pidProfile_t *pidProfile, controlRateConfig_t *controlRa
          } else {
             // calculate error and limit the angle to the max inclination
 #ifdef GPS
-            errorAngle = (constrain(rcCommand[axis] + GPS_angle[axis], -((int) max_angle_inclination),
+            errorAngle = (constrain( (rcCommand[axis]*2) + GPS_angle[axis], -((int) max_angle_inclination),
                     +max_angle_inclination) - inclination.raw[axis] + angleTrim->raw[axis]) / 10.0f; // 16 bits is ok here
 #else
-            errorAngle = (constrain(rcCommand[axis], -((int) max_angle_inclination),
+            errorAngle = (constrain( (rcCommand[axis]*2), -((int) max_angle_inclination),
                     +max_angle_inclination) - inclination.raw[axis] + angleTrim->raw[axis]) / 10.0f; // 16 bits is ok here
 #endif
 


### PR DESCRIPTION
This pull request provides two benefits in LuxFloat's Level mode.

First, Level in Lux is very unresponsive to stick inputs.  For anyone accustomed to normal stick sensitivity it is nearly impossible to fly.  After doubling rcCommand in Level mode, responsiveness is appropriate for learners and usable for experienced pilots.

Second, it fixes an issue where max_angle_inclination is not handled correctly above settings of 500.  With current stock code, max_angle_inclination works fine for values below 500. For example, setting 350 limits max angle to 35 degrees.   But there is a bug if the user wants to set an angle greater than 50 degrees (500); the maximum achievable is stuck at 50 degrees.  For example, setting 700 results in a limit of 50 degrees.  This code change fixes that problem.

The reason why max_angle_inclination was limited at 500 is simple; rcCommand cannot exceed 500.  So although the ErrorAngle calculation limit could indeed be set greater than 500, the maximum possible input could not exceed 500.  This modification solves the problem neatly and simply.

The original issue was noted here #1072 and some discussion also here #1105.  The instability at high angles noted in #1105 is I think that they were holding angle in an attempt to get past 50 degrees, with I wind-up issues.  This pull request should solve both problems.

In flight there is instability with this modification if max_angle_inclination is set much more than 80... that is a separate issue.  I think it would be not unreasonable to limit max_angle_inclination in the CLI defaults to 800 for LuxFloat if that was possible.
