### PR TITLE
Failsafe - Allow re-arming after failsafe condition.

### DIFF
--- a/src/main/flight/failsafe.c
+++ b/src/main/flight/failsafe.c
@@ -199,7 +199,7 @@ void failsafeUpdateState(void)
 
                 // This will prevent the automatic rearm if failsafe shuts it down and prevents
                 // to restart accidently by just reconnect to the tx - you will have to switch off first to rearm
-//CT STOP THIS                ENABLE_ARMING_FLAG(PREVENT_ARMING);
+                ENABLE_ARMING_FLAG(PREVENT_ARMING);
                 failsafeState.active = false;
                 mwDisarm();
                 break;

--- a/src/main/flight/failsafe.c
+++ b/src/main/flight/failsafe.c
@@ -199,8 +199,7 @@ void failsafeUpdateState(void)
 
                 // This will prevent the automatic rearm if failsafe shuts it down and prevents
                 // to restart accidently by just reconnect to the tx - you will have to switch off first to rearm
-                ENABLE_ARMING_FLAG(PREVENT_ARMING);
-
+//CT STOP THIS                ENABLE_ARMING_FLAG(PREVENT_ARMING);
                 failsafeState.active = false;
                 mwDisarm();
                 break;

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -318,6 +318,9 @@ void annexCode(void)
 
 void mwDisarm(void)
 {
+    if (ARMING_FLAG(PREVENT_ARMING)) {
+    	DISABLE_ARMING_FLAG(PREVENT_ARMING);
+	}
     if (ARMING_FLAG(ARMED)) {
         DISABLE_ARMING_FLAG(ARMED);
 


### PR DESCRIPTION
With current code, if an aircraft goes through the CleanFlight Failsafe landing phase and enters 'Landed', there is a lock set on re-arming.  It is impossible to re-arm, even if the radio link is restored, without physically power cycling the aircraft.

This pull request allows re-arming after failsafe.  I do not propose a CLI setting for this, because I just want to re-arm at will  :-) but others may want a CLI entry - say allow_rearm_after_landing where 0 is current functionality 1 is you can rearm if you have signal.

The intent appears to have been based on a concern that intermittent signal could have unpredictable results.  

However, CleanFlight is quite good at detecting normal incoming signals, many of us have RSSI so we know we can talk reliably to the Rx, and there are situations where being able to re-arm without power cycling would be an advantage.

For instance:

- a quadcopter goes past signal range, you can get close enough to see it can arm safely, but it is still a long walk away, and (maybe) you have RSSI back to know Rx signal strength.  It might be nice to re-arm and fly back without walking or climbing all the way to the quad.  And indeed the quad may be inaccessible, behind a fence, or otherwise up a tree or difficult to access with no other possibility but to fly out.

-  we take off but have forgotten to put our Tx antenna on, or it was broken, quad goes failsafe and lands but is 200m away.  We replace antenna, arm, fly back - or we walk 200m.  Mostly we want just to arm and fly back.

- we are flying and go failsafe because signal is blocked by a nearby object.  We walk around the object and get good signal back, but cannot re-arm.  Quad is a long way away... :-)

I have not had issues with false re-arming since disabling this lock.  I think that's because CF is very good at cleaning bad PPM pulses.  The recent changes to rxfail and pulse checking make the original need to stop re-arming less of an issue, I think.

I hope this can go into the master, probably with a CLI control line to preserve current behaviour.

Discussed here #995 and briefly some time back here  #744

Please vote here for your preferred behaviour?

