### PR TITLE
RX - Corrections to RX fail detection, hold and preset, when using a PWM connection

### DIFF
--- a/src/main/drivers/pwm_rx.c
+++ b/src/main/drivers/pwm_rx.c
@@ -341,6 +341,8 @@ void ppmInConfig(const timerHardware_t *timerHardwarePtr)
 
 uint16_t pwmRead(uint8_t channel)
 {
-    return captures[channel];
+    uint16_t capture = captures[channel];
+    captures[channel] = PPM_RCVR_TIMEOUT;
+    return capture;
 }
 

--- a/src/main/drivers/pwm_rx.c
+++ b/src/main/drivers/pwm_rx.c
@@ -339,6 +339,11 @@ void ppmInConfig(const timerHardware_t *timerHardwarePtr)
     timerChConfigCallbacks(timerHardwarePtr, &self->edgeCb, &self->overflowCb);
 }
 
+uint16_t ppmRead(uint8_t channel)
+{
+    return captures[channel];
+}
+
 uint16_t pwmRead(uint8_t channel)
 {
     uint16_t capture = captures[channel];

--- a/src/main/drivers/pwm_rx.h
+++ b/src/main/drivers/pwm_rx.h
@@ -30,6 +30,7 @@ void ppmAvoidPWMTimerClash(const timerHardware_t *timerHardwarePtr, TIM_TypeDef 
 
 void pwmInConfig(const timerHardware_t *timerHardwarePtr, uint8_t channel);
 uint16_t pwmRead(uint8_t channel);
+uint16_t ppmRead(uint8_t channel);
 
 bool isPPMDataBeingReceived(void);
 void resetPPMDataReceivedState(void);

--- a/src/main/rx/pwm.c
+++ b/src/main/rx/pwm.c
@@ -34,23 +34,29 @@
 #include "rx/rx.h"
 #include "rx/pwm.h"
 
-static uint16_t pwmReadRawRC(rxRuntimeConfig_t *rxRuntimeConfigPtr, uint8_t chan)
+static uint16_t pwmReadRawRC(rxRuntimeConfig_t *rxRuntimeConfigPtr, uint8_t channel)
 {
     UNUSED(rxRuntimeConfigPtr);
-    return pwmRead(chan);
+    return pwmRead(channel);
+}
+
+static uint16_t ppmReadRawRC(rxRuntimeConfig_t *rxRuntimeConfigPtr, uint8_t channel)
+{
+    UNUSED(rxRuntimeConfigPtr);
+    return ppmRead(channel);
 }
 
 void rxPwmInit(rxRuntimeConfig_t *rxRuntimeConfigPtr, rcReadRawDataPtr *callback)
 {
     UNUSED(rxRuntimeConfigPtr);
     // configure PWM/CPPM read function and max number of channels. serial rx below will override both of these, if enabled
-    *callback = pwmReadRawRC;
-
     if (feature(FEATURE_RX_PARALLEL_PWM)) {
         rxRuntimeConfigPtr->channelCount = MAX_SUPPORTED_RC_PARALLEL_PWM_CHANNEL_COUNT;
+        *callback = pwmReadRawRC;
     }
     if (feature(FEATURE_RX_PPM)) {
         rxRuntimeConfigPtr->channelCount = MAX_SUPPORTED_RC_PPM_CHANNEL_COUNT;
+        *callback = ppmReadRawRC;
     }
 }
 


### PR DESCRIPTION
@hydra This is an important update to #995.

RX hold values were not preserved and FC preset values were only applied after an initial jump to the RX failsafe preset value under the following conditions:

Use PWM. Set channels 1-4 (sticks) to failsafe OFF. Set aux channel to a preset failsafe value.

This PR has been tested with PWM, PPM and SUMD (using GR-12), in all cases FC hold function `rxfail 0 h 1600`and FC preset function `rxfail 0 s 1600` worked well.

More has changes, please see commit message for details.