### PR TITLE
Updated Ubuntu gcc toolchain version date

### DIFF
--- a/docs/development/Building in Ubuntu.md
+++ b/docs/development/Building in Ubuntu.md
@@ -22,19 +22,24 @@ sudo add-apt-repository ppa:terry.guo/gcc-arm-embedded
 sudo apt-get update
 ```
 
-For Ubuntu 14.10 (current release, called Utopic Unicorn), you should pin:
+For Ubuntu 15.04 (current release, called Vivid Vervet), you should pin:
 ```
-sudo apt-get install gcc-arm-none-eabi=4.9.3.2014q4-0utopic12
+sudo apt-get install gcc-arm-none-eabi=4.9.3.2015q2-1vivid1
+```
+
+For Ubuntu 14.10 (previous release, called Utopic Unicorn), you should pin:
+```
+sudo apt-get install gcc-arm-none-eabi=4.9.3.2015q2-1utopic1
 ```
 
 For Ubuntu 14.04 (an LTS as of Q1'2015, called Trusty Tahr), you should pin:
 ```
-sudo apt-get install gcc-arm-none-eabi=4.9.3.2014q4-0trusty12
+sudo apt-get install gcc-arm-none-eabi=4.9.3.2015q2-1trusty1
 ```
 
 For Ubuntu 12.04 (previous LTS, called Precise Penguin), you should pin:
 ```
-sudo apt-get install gcc-arm-none-eabi=4.9.3.2014q4-0precise12
+sudo apt-get install gcc-arm-none-eabi=4.9.3.2015q2-1precise1
 ```
 
 ## Building on Ubuntu


### PR DESCRIPTION
There is a updated gcc 4.9.3 toolchain from https://launchpad.net/~terry.guo/+archive/ubuntu/gcc-arm-embedded. The previous version is no longer hosted on Terry Guo's page.

This pull request updates the doc with the correct date/version and includes the version for Ubuntu 15.04.
