### PR TITLE
CLI `rxfail` command now supports ALL channels...

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -405,11 +405,27 @@ static void resetConf(void)
     masterConfig.rxConfig.rx_min_usec = 885;          // any of first 4 channels below this value will trigger rx loss detection
     masterConfig.rxConfig.rx_max_usec = 2115;         // any of first 4 channels above this value will trigger rx loss detection
 
-    for (i = 0; i < MAX_AUX_CHANNEL_COUNT; i++) {
-        rxFailsafeChannelConfiguration_t *channelFailsafeConfiguration = &masterConfig.rxConfig.failsafe_aux_channel_configurations[i];
+    for (i = 0; i < MAX_SUPPORTED_RC_CHANNEL_COUNT; i++) {
+        rxFailsafeChannelConfiguration_t *channelFailsafeConfiguration = &masterConfig.rxConfig.failsafe_channel_configurations[i];
 
-        channelFailsafeConfiguration->mode = RX_FAILSAFE_MODE_HOLD;
-        channelFailsafeConfiguration->step = CHANNEL_VALUE_TO_RXFAIL_STEP(masterConfig.rxConfig.midrc);
+        switch (i) {
+            case ROLL:
+            case PITCH:
+            case YAW:
+                channelFailsafeConfiguration->mode = RX_FAILSAFE_MODE_SET;
+                channelFailsafeConfiguration->step = CHANNEL_VALUE_TO_RXFAIL_STEP(masterConfig.rxConfig.midrc);
+                break;
+
+            case THROTTLE:
+                channelFailsafeConfiguration->mode = RX_FAILSAFE_MODE_SET;
+                channelFailsafeConfiguration->step = CHANNEL_VALUE_TO_RXFAIL_STEP( (feature(FEATURE_3D)) ?  masterConfig.rxConfig.midrc: masterConfig.rxConfig.rx_min_usec );
+                break;
+
+            default:
+                channelFailsafeConfiguration->mode = RX_FAILSAFE_MODE_HOLD;
+                channelFailsafeConfiguration->step = CHANNEL_VALUE_TO_RXFAIL_STEP(masterConfig.rxConfig.midrc);
+                break;
+        }
     }
 
     masterConfig.rxConfig.rssi_channel = 0;

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -573,16 +573,16 @@ static void cliRxFail(char *cmdline)
 
     if (isEmpty(cmdline)) {
         // print out rxConfig failsafe settings
-        for (channel = 0; channel < MAX_AUX_CHANNEL_COUNT; channel++) {
+        for (channel = 0; channel < MAX_SUPPORTED_RC_CHANNEL_COUNT; channel++) {
             cliRxFail(itoa(channel, buf, 10));
         }
     } else {
         char *ptr = cmdline;
 
         channel = atoi(ptr++);
-        if ((channel < MAX_AUX_CHANNEL_COUNT)) {
+        if ((channel < MAX_SUPPORTED_RC_CHANNEL_COUNT)) {
 
-            rxFailsafeChannelConfiguration_t *channelFailsafeConfiguration = &masterConfig.rxConfig.failsafe_aux_channel_configurations[channel];
+            rxFailsafeChannelConfiguration_t *channelFailsafeConfiguration = &masterConfig.rxConfig.failsafe_channel_configurations[channel];
 
             uint16_t value;
             rxFailsafeChannelMode_e mode;
@@ -628,7 +628,7 @@ static void cliRxFail(char *cmdline)
                 RXFAIL_STEP_TO_CHANNEL_VALUE(channelFailsafeConfiguration->step)
             );
         } else {
-            printf("channel must be < %u\r\n", MAX_AUX_CHANNEL_COUNT);
+            printf("channel must be < %u\r\n", MAX_SUPPORTED_RC_CHANNEL_COUNT);
         }
     }
 }

--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -1171,10 +1171,10 @@ static bool processOutCommand(uint8_t cmdMSP)
         break;
 
     case MSP_RXFAIL_CONFIG:
-        headSerialReply(3 * (rxRuntimeConfig.channelCount - NON_AUX_CHANNEL_COUNT));
-        for (i = NON_AUX_CHANNEL_COUNT; i < rxRuntimeConfig.channelCount; i++) {
-            serialize8(masterConfig.rxConfig.failsafe_aux_channel_configurations[i - NON_AUX_CHANNEL_COUNT].mode);
-            serialize16(RXFAIL_STEP_TO_CHANNEL_VALUE(masterConfig.rxConfig.failsafe_aux_channel_configurations[i - NON_AUX_CHANNEL_COUNT].step));
+        headSerialReply(3 * (rxRuntimeConfig.channelCount));
+        for (i = 0; i < rxRuntimeConfig.channelCount; i++) {
+            serialize8(masterConfig.rxConfig.failsafe_channel_configurations[i].mode);
+            serialize16(RXFAIL_STEP_TO_CHANNEL_VALUE(masterConfig.rxConfig.failsafe_channel_configurations[i].step));
         }
         break;
 
@@ -1606,12 +1606,12 @@ static bool processInCommand(void)
     case MSP_SET_RXFAIL_CONFIG:
         {
             uint8_t channelCount = currentPort->dataSize / 3;
-            if (channelCount > MAX_AUX_CHANNEL_COUNT) {
+            if (channelCount > MAX_SUPPORTED_RC_CHANNEL_COUNT) {
                 headSerialError(0);
             } else {
-                for (i = NON_AUX_CHANNEL_COUNT; i < channelCount; i++) {
-                    masterConfig.rxConfig.failsafe_aux_channel_configurations[i - NON_AUX_CHANNEL_COUNT].mode = read8();
-                    masterConfig.rxConfig.failsafe_aux_channel_configurations[i - NON_AUX_CHANNEL_COUNT].step = CHANNEL_VALUE_TO_RXFAIL_STEP(read16());
+                for (i = 0; i < channelCount; i++) {
+                    masterConfig.rxConfig.failsafe_channel_configurations[i].mode = read8();
+                    masterConfig.rxConfig.failsafe_channel_configurations[i].step = CHANNEL_VALUE_TO_RXFAIL_STEP(read16());
                 }
             }
         }

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -326,29 +326,27 @@ static uint16_t calculateNonDataDrivenChannel(uint8_t chan, uint16_t sample)
 
 static uint16_t getRxfailValue(uint8_t channel)
 {
+    rxFailsafeChannelConfiguration_t *channelFailsafeConfiguration = &rxConfig->failsafe_channel_configurations[channel];
+
+    if(channelFailsafeConfiguration->mode != RX_FAILSAFE_MODE_SET)
+        return rcData[channel];
+
+    // (mode == RX_FAILSAFE_MODE_SET)
     switch (channel) {
         case ROLL:
         case PITCH:
         case YAW:
             return rxConfig->midrc;
+
         case THROTTLE:
             if (feature(FEATURE_3D))
                 return rxConfig->midrc;
             else
                 return rxConfig->rx_min_usec;
-    }
 
-    rxFailsafeChannelConfiguration_t *channelFailsafeConfiguration = &rxConfig->failsafe_aux_channel_configurations[channel - NON_AUX_CHANNEL_COUNT];
-
-    switch(channelFailsafeConfiguration->mode) {
         default:
-        case RX_FAILSAFE_MODE_HOLD:
-            return rcData[channel];
-
-        case RX_FAILSAFE_MODE_SET:
             return RXFAIL_STEP_TO_CHANNEL_VALUE(channelFailsafeConfiguration->step);
     }
-
 }
 
 STATIC_UNIT_TESTED uint16_t applyRxChannelRangeConfiguraton(int sample, rxChannelRangeConfiguration_t range)

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -109,7 +109,7 @@ typedef struct rxConfig_s {
 
     uint16_t rx_min_usec;
     uint16_t rx_max_usec;
-    rxFailsafeChannelConfiguration_t failsafe_aux_channel_configurations[MAX_AUX_CHANNEL_COUNT];
+    rxFailsafeChannelConfiguration_t failsafe_channel_configurations[MAX_SUPPORTED_RC_CHANNEL_COUNT];
 
     rxChannelRangeConfiguration_t channelRanges[NON_AUX_CHANNEL_COUNT];
 } rxConfig_t;


### PR DESCRIPTION
This modification provides the same safety for beginners and more control for advanced users.

- Channels 0-3 (RPYT) can be set to `h` to hold last value, or to `s` to have automatic control. This means RPY to mid stick and T to `rx_min_usec` (or mid stick for 3D mode).

- Channels 4..n are the aux channels. These can be set to `h` to hold last value, or to `s` to set a pre-defined value with `rxfail 4 s 1500.

Initialization and MSP messages are adapted to this.