### PR TITLE
Corrected tilt angle calculation in sonar driver.

### DIFF
--- a/src/main/drivers/sonar_hcsr04.c
+++ b/src/main/drivers/sonar_hcsr04.c
@@ -164,7 +164,7 @@ int32_t hcsr04_get_distance(void)
     int32_t distance = measurement / 59;
 
     // this sonar range is up to 4meter , but 3meter is the safe working range (+tilted and roll)
-    if (distance > 300)
+    if (distance > SONAR_MAX_RANGE)
         distance = -1;
 
     return distance;

--- a/src/main/drivers/sonar_hcsr04.h
+++ b/src/main/drivers/sonar_hcsr04.h
@@ -26,6 +26,7 @@ typedef struct sonarHardware_s {
 } sonarHardware_t;
 
 #define SONAR_GPIO GPIOB
+#define SONAR_MAX_RANGE 300
 
 void hcsr04_init(const sonarHardware_t *sonarHardware);
 

--- a/src/main/sensors/sonar.c
+++ b/src/main/sensors/sonar.c
@@ -127,9 +127,10 @@ int32_t sonarCalculateAltitude(int32_t sonarAlt, int16_t tiltAngle)
     // calculate sonar altitude only if the sonar is facing downwards(<25deg)
     if (tiltAngle > 250)
         calculatedAltitude = -1;
-    else
-        calculatedAltitude = sonarAlt * (900.0f - tiltAngle) / 900.0f;
-
+    else {
+        float angleRadians = 0.0174f * (tiltAngle / 10.0f);
+        calculatedAltitude = sonarAlt * cos_approx(angleRadians);
+    }
     return calculatedAltitude;
 }
 


### PR DESCRIPTION
A simple ratio was being used to calculate sonar distance tilt
compensation.  The ratio was producing errors of nearly 25% at 25
degrees of tilt.  Modified driver to use cosine calculation to improve
accuracy to less than 3% at 25 degrees of tilt.