### PR TITLE
Created Unit Tests for sensorsAlign(), addresses issue #8

### DIFF
--- a/docs/Blackbox.md
+++ b/docs/Blackbox.md
@@ -58,9 +58,7 @@ The OpenLog ships with standard OpenLog 3 firmware installed. However, in order 
 it should be reflashed with the [OpenLog Light firmware][] or the special [OpenLog Blackbox firmware][] (this needs to
 be version 2.0 or higher to allow configuration of baud rates). 
 
-The Blackbox variant of the firmware ensures that the OpenLog is using the correct settings, and defaults to 115200
-baud. If you are using a looptime of 2500 or smaller, you should set the baud rate to 250000 instead to eliminate
-dropped frames.
+The Blackbox variant of the firmware ensures that the OpenLog is using the correct settings, and defaults to 115200 baud. If you are using a looptime of 2500 or smaller, you should set the baud rate to 250000 instead to eliminate dropped frames. OpenLog boards from some vendors ship pre-flashed with the OpenLog Light firmware. This will work, but the OpenLog Blackbox firmware will be less likely to have configuration issues (e.g. wrong baud rate), so it should be used if possible.
 
 You can find the Blackbox version of the OpenLog firmware [here](https://github.com/cleanflight/blackbox-firmware), 
 along with instructions for installing it onto your OpenLog.
@@ -118,12 +116,7 @@ baud,escape,esc#,mode,verb,echo,ignoreRX
 
 #### Serial port
 
-A hardware serial port is required to connect the OpenLog to your flight controller (such as `serial_port_1` on the
-Naze32, the two-pin Tx/Rx header in the center of the board). The Blackbox can not be used with softserial ports as they
-are too slow.
-
-Connect the "TX" pin of the serial port you've chosen to the OpenLog's "RXI" pin. Don't connect the serial port's RX
-pin to the OpenLog.
+A hardware serial port is required to connect the OpenLog to your flight controller. The Blackbox can not be used with softserial ports as they are too slow. Connect the "TX" pin of the serial port you've chosen to the OpenLog's "RXI" pin. Don't connect the serial port's RX pin to the OpenLog.
 
 #### Protection
 
@@ -157,9 +150,19 @@ pressing enter. Now choose the device that you want to log to:
 Enter `set blackbox_device=0` to switch to logging to a serial port (this is the default).
 
 You then need to let Cleanflight know which of [your serial ports][] you connected the OpenLog to. A 115200 baud port
-is required (such as `serial_port_1` on the Naze32, the two-pin Tx/Rx header in the center of the board).
+is required (such as `serial_port_1` on the Naze32, the two-pin Tx/Rx header in the center of the board). If you are using the Blackbox OpenLog firmware, a baud rate of 250000 may be used, which will allow 1:1 logging of frames even at faster looptimes.
 
-You can use the GUI to configure a port for the Blackbox feature on the Ports tab.
+You can use the GUI to configure a port for the Blackbox feature on the Ports tab. The serial port used for Blackbox cannot be shared with any other function (e.g. GPS, telemetry) except the MSP protocol. If MSP is used on the same port as Blackbox, then MSP will be active when the board is disarmed, and Blackbox will be active when the board is armed. This will mean that you can't use the configurator GUI or any other function that requires MSP, such as an OSD or a Bluetooth wireless configuration app, while the board is armed. 
+
+On the Naze32, the TX/RX pins on top of the board are connected to UART1, and are shared with the USB connector. Therefore, MSP must be enabled on UART1 in order to use the configuration GUI over USB. If Blackbox is connected to the pins on top of the Naze32, the configurator GUI will not work when the board is armed.
+
+On the Naze32, pins RC3 and RC4 on the side of the board are connected to UART2. If Blackbox is configured on UART2, MSP can still be used on UART1 when the board is armed, which means that the configuration GUI will continue to work simultanous with Blackbox logging. However, pins RC3 and RC4 are only available for use by UART2 if the receiver mode is _not_ PARALLEL_PWM. In other words, a PPM or Serial receiver must be used. If a PWM receiver is used, pins RC3 and RC4 are used for channel input from the receiver. Sharing UART1 between Blackbox and MSP is the only way to use Blackbox on a Naze32 with a PWM receiver.
+
+Boards other than the Naze32 may have more accessible hardware serial devices, in which case refer to their documentation to decide how to wire up the logger. The key criteria are: 
+
+* Must be hardware serial device. Not SoftSerial.
+* Cannot be shared with any other function (GPS, telemetry) except MSP.
+* If MSP is used on the same UART, MSP will stop working when the board is armed.
 
 ### Onboard dataflash
 Enter `set blackbox_device=1` to switch to logging to an onboard dataflash chip, if your flight controller has one.

--- a/docs/Blackbox.md
+++ b/docs/Blackbox.md
@@ -7,15 +7,14 @@
 This feature transmits your flight data information on every control loop iteration over a serial port to an external
 logging device to be recorded, or to a dataflash chip which is present on some flight controllers.
 
-After your flight, you can process the resulting logs on your computer to either turn them into CSV (comma-separated
-values) or render your flight log as a video using the tools `blackbox_decode` and `blackbox_render`. Those tools can be
-found in this repository:
-
-https://github.com/cleanflight/blackbox-tools
-
-You can also view your flight logs using your web browser with the interactive log viewer:
+After your flight, you can view the resulting logs using the interactive log viewer:
 
 https://github.com/cleanflight/blackbox-log-viewer
+
+You can also use the `blackbox_decode` tool to turn the logs into CSV files for analysis, or render your flight log as a
+video using the `blackbox_render` tool. Those tools can be found in this repository:
+
+https://github.com/cleanflight/blackbox-tools
 
 ## Logged data
 The blackbox records flight data on every iteration of the flight control loop. It records the current time in
@@ -33,38 +32,39 @@ renderer does not yet show any of the GPS information (this will be added later)
 The maximum data rate that can be recorded to the flight log is fairly restricted, so anything that increases the load
 can cause the flight log to drop frames and contain errors.
 
-The Blackbox was developed and tested on a quadcopter. It has also been tested on a tricopter. It should work on
-hexacopters or octocopters, but as they transmit more information to the flight log (due to having more motors), the 
-number of dropped frames may increase. The `blackbox_render` tool only supports tri and quadcopters (please send me 
-flight logs from other craft, and I can add support for them!)
+The Blackbox is typically used on tricopters and quadcopters. Although it will work on hexacopters and octocopters,
+because these craft have more motors to record, they must transmit more data to the flight log. This can increase the
+number of dropped frames. Although the browser-based log viewer supports hexacopters and octocopters, the command-line 
+`blackbox_render` tool currently only supports tri- and quadcopters.
 
-Cleanflight's `looptime` setting will decide how many times per second an update is saved to the flight log. The
-software was developed on a craft with a looptime of 2400. Any looptime smaller than this will put more strain on the
-data rate. The default looptime on Cleanflight is 3500. 
+Cleanflight's `looptime` setting decides how frequently an update is saved to the flight log. The default looptime on
+Cleanflight is 3500. If you're using a looptime smaller than about 2400, you may experience some dropped frames due to
+the high required data rate. In that case you will need to reduce the sampling rate in the Blackbox settings, or
+increase your logger's baudrate to 250000. See the later section on configuring the Blackbox feature for details.
 
-If you're using a looptime of 2300 or smaller, you will probably need to reduce the sampling rate in the Blackbox
-settings, or increase your logger's baudrate to 250000. See the later section on configuring the Blackbox feature for
-details.
+## Setting up logging
 
-## Hardware
+First, you must enable the Blackbox feature. In the [Cleanflight Configurator][] enter the Configuration tab,
+tick the "BLACKBOX" feature at the bottom of the page, and click "Save and reboot" 
 
-There are two options for storing your flight logs. You can either transmit the log data over a serial port to an 
-external logging device like the [OpenLog serial data logger][] to be recorded to a microSDHC card, or if you have a
-compatible flight controller you can store the logs on the onboard dataflash storage instead.
+Now you must decide which device to store your flight logs on. You can either transmit the log data over a serial port
+to an external logging device like the [OpenLog serial data logger][] to be recorded to a microSDHC card, or if you have
+a compatible flight controller you can store the logs on the onboard dataflash storage instead.
 
 ### OpenLog serial data logger
 
-The OpenLog ships with standard OpenLog 3 firmware installed. However, in order to reduce the number of dropped frames,
-it should be reflashed with the [OpenLog Light firmware][] or the special [OpenLog Blackbox firmware][] (this needs to
-be version 2.0 or higher to allow configuration of baud rates). 
+The OpenLog is a small logging device which attaches to your flight controller using a serial port and logs your
+flights to a MicroSD card.
 
-The Blackbox variant of the firmware ensures that the OpenLog is using the correct settings, and defaults to 115200 baud. If you are using a looptime of 2500 or smaller, you should set the baud rate to 250000 instead to eliminate dropped frames. OpenLog boards from some vendors ship pre-flashed with the OpenLog Light firmware. This will work, but the OpenLog Blackbox firmware will be less likely to have configuration issues (e.g. wrong baud rate), so it should be used if possible.
+The OpenLog ships from SparkFun with standard "OpenLog 3" firmware installed. Although this original OpenLog firmware
+will work with the Blackbox, in order to reduce the number of dropped frames it should be reflashed with the
+higher performance [OpenLog Blackbox firmware][]. The special Blackbox variant of the OpenLog firmware also ensures that
+the OpenLog is using Cleanflight compatible settings, and defaults to 115200 baud.
 
 You can find the Blackbox version of the OpenLog firmware [here](https://github.com/cleanflight/blackbox-firmware), 
 along with instructions for installing it onto your OpenLog.
 
 [OpenLog serial data logger]: https://www.sparkfun.com/products/9530
-[OpenLog Light firmware]: https://github.com/sparkfun/OpenLog/tree/master/firmware/OpenLog_v3_Light
 [OpenLog Blackbox firmware]: https://github.com/cleanflight/blackbox-firmware
 
 #### microSDHC
@@ -90,14 +90,60 @@ the best chance of writing at high speed. You must format it with either FAT, or
 
 [SD Association's special formatting tool]: https://www.sdcard.org/downloads/formatter_4/
 
+### Choosing a serial port for the OpenLog
+First, tell the Blackbox to log using a serial port (rather than to an onboard dataflash chip). Go to the
+Configurator's CLI tab, enter `set blackbox_device=0` to switch logging to serial (this is the default setting), and
+save.
+
+You need to let Cleanflight know which of [your serial ports][] you connect your OpenLog to (i.e. the Blackbox port),
+which you can do on the Configurator's Ports tab.
+
+A hardware serial port is required (such as UART1 on the Naze32, the two-pin Tx/Rx header in the center of the board).
+SoftSerial ports cannot be used as they are too slow. Blackbox needs to be set to at least 115200 baud on this port.
+When using fast looptimes (<2500), a baud rate of 250000 should be used instead in order to reduce dropped frames.
+
+The serial port used for Blackbox cannot be shared with any other function (e.g. GPS, telemetry) except the MSP
+protocol. If MSP is used on the same port as Blackbox, then MSP will be active when the board is disarmed, and Blackbox
+will be active when the board is armed. This will mean that you can't use the Configurator or any other function that
+requires MSP, such as an OSD or a Bluetooth wireless configuration app, while the board is armed.
+
+Connect the "TX" pin of the serial port you've chosen to the OpenLog's "RXI" pin. Don't connect the serial port's RX
+pin to the OpenLog, as this will cause the OpenLog to interfere with any shared functions on the serial port while
+disarmed.
+
+#### Naze32 serial port choices
+
+On the Naze32, the TX/RX pins on top of the board are connected to UART1, and are shared with the USB connector.
+Therefore, MSP must be enabled on UART1 in order to use the Configurator over USB. If Blackbox is connected to the pins
+on top of the Naze32, the Configurator will stop working once the board is armed. This configuration is usually a good
+choice if you don't already have an OSD installed which is using those pins while armed, and aren't using the FrSky
+telemetry pins.
+
+Pin RC3 on the side of the board is UART2's Tx pin. If Blackbox is configured on UART2, MSP can still be used on UART1
+when the board is armed, which means that the Configurator will continue to work simultaneously with Blackbox logging.
+However, the RC3 pin is only available for use by UART2 if the receiver mode is _not_ `PARALLEL_PWM`. In other words, a
+PPM or Serial receiver must be used. If a PWM receiver is used, the RC3 and RC4 pins are used for channel input from the
+receiver. Sharing UART1 between Blackbox and MSP is the only way to use Blackbox on a Naze32 with a PWM receiver.
+
+The OpenLog tolerates a power supply of between 3.3V and 12V. If you are powering your Naze32 with a standard 5V BEC,
+then you can use a spare motor header's +5V and GND pins to power the OpenLog with.
+
+#### Other flight controller hardware
+Boards other than the Naze32 may have more accessible hardware serial devices, in which case refer to their
+documentation to decide how to wire up the logger. The key criteria are:
+
+* Must be a hardware serial port. Not SoftSerial.
+* Cannot be shared with any other function (GPS, telemetry) except MSP.
+* If MSP is used on the same UART, MSP will stop working when the board is armed.
+
 #### OpenLog configuration
 
 Power up the OpenLog with a microSD card inside, wait 10 seconds or so, then power it down and plug the microSD card
-into your computer. You should find a "CONFIG.TXT" file on the card. You should see the baud rate that the OpenLog has
-been configured to. You probably want this to be set to either 115200 (the default) or 250000 (for craft with looptimes
-smaller than 2500).
+into your computer. You should find a "CONFIG.TXT" file on the card, open it up in a text editor. You should see the
+baud rate that the OpenLog has been configured for (usually 115200 or 9600 from the factory). Set the baud rate to match
+the rate you entered for the Blackbox in the Configurator's Port tab (typically 115200 or 250000).
 
-Save the file and put the card back into your OpenLog, it should use those settings from now on.
+Save the file and put the card back into your OpenLog, it will use those settings from now on.
 
 If your OpenLog didn't write a CONFIG.TXT file, create a CONFIG.TXT file with these contents and store it in the root
 of the MicroSD card:
@@ -107,18 +153,14 @@ of the MicroSD card:
 baud
 ```
 
-If you are using the official OpenLog Light firmware, use this configuration instead:
+If you are using the original OpenLog firmware, use this configuration instead:
 
 ```
 115200,26,0,0,1,0,1
 baud,escape,esc#,mode,verb,echo,ignoreRX
 ```
 
-#### Serial port
-
-A hardware serial port is required to connect the OpenLog to your flight controller. The Blackbox can not be used with softserial ports as they are too slow. Connect the "TX" pin of the serial port you've chosen to the OpenLog's "RXI" pin. Don't connect the serial port's RX pin to the OpenLog.
-
-#### Protection
+#### OpenLog protection
 
 The OpenLog can be wrapped in black electrical tape or heat-shrink in order to insulate it from conductive frames (like
 carbon fiber), but this makes its status LEDs impossible to see. I recommend wrapping it with some clear heatshrink
@@ -127,53 +169,31 @@ tubing instead.
 ![OpenLog installed](Wiring/blackbox-installation-1.jpg "OpenLog installed with double-sided tape, SDCard slot pointing outward")
 
 ### Onboard dataflash storage
-Some flight controllers have an onboard SPI NOR flash chip which can be used to store flight logs instead of using an 
-OpenLog.
+Some flight controllers have an onboard SPI NOR dataflash chip which can be used to store flight logs instead of using
+an OpenLog.
 
-The full version of the Naze32 and the CC3D have an onboard "m25p16" 2 megayte dataflash storage chip. This is a small
+The full version of the Naze32 and the CC3D have an onboard "m25p16" 2 megabyte dataflash storage chip. This is a small
 chip with 8 fat legs, which can be found at the base of the Naze32's direction arrow. This chip is not present on the
 "Acro" version of the Naze32.
 
+The SPRacingF3 has a larger 8 megabyte dataflash chip onboard which allows for longer recording times.
+
 These chips are also supported:
 
-* Micron/ST M25P16 - 16 Mbit
-* Micron N25Q064 - 64 Mbit
-* Winbond W25Q64 - 64 Mbit
-* Micron N25Q0128 - 128 Mbit
-* Winbond W25Q128 - 128 Mbit
+* Micron/ST M25P16 - 16 Mbit / 2 MByte
+* Micron N25Q064 - 64 Mbit / 8 MByte
+* Winbond W25Q64 - 64 Mbit / 8 MByte
+* Micron N25Q0128 - 128 Mbit / 16 MByte
+* Winbond W25Q128 - 128 Mbit / 16 MByte
 
-## Enabling the Blackbox (CLI)
-In the [Cleanflight Configurator][] , enter the CLI tab. Enable the Blackbox feature by typing in `feature BLACKBOX` and
-pressing enter. Now choose the device that you want to log to:
-
-### OpenLog serial data logger
-Enter `set blackbox_device=0` to switch to logging to a serial port (this is the default).
-
-You then need to let Cleanflight know which of [your serial ports][] you connected the OpenLog to. A 115200 baud port
-is required (such as `serial_port_1` on the Naze32, the two-pin Tx/Rx header in the center of the board). If you are using the Blackbox OpenLog firmware, a baud rate of 250000 may be used, which will allow 1:1 logging of frames even at faster looptimes.
-
-You can use the GUI to configure a port for the Blackbox feature on the Ports tab. The serial port used for Blackbox cannot be shared with any other function (e.g. GPS, telemetry) except the MSP protocol. If MSP is used on the same port as Blackbox, then MSP will be active when the board is disarmed, and Blackbox will be active when the board is armed. This will mean that you can't use the configurator GUI or any other function that requires MSP, such as an OSD or a Bluetooth wireless configuration app, while the board is armed. 
-
-On the Naze32, the TX/RX pins on top of the board are connected to UART1, and are shared with the USB connector. Therefore, MSP must be enabled on UART1 in order to use the configuration GUI over USB. If Blackbox is connected to the pins on top of the Naze32, the configurator GUI will not work when the board is armed.
-
-On the Naze32, pins RC3 and RC4 on the side of the board are connected to UART2. If Blackbox is configured on UART2, MSP can still be used on UART1 when the board is armed, which means that the configuration GUI will continue to work simultanous with Blackbox logging. However, pins RC3 and RC4 are only available for use by UART2 if the receiver mode is _not_ PARALLEL_PWM. In other words, a PPM or Serial receiver must be used. If a PWM receiver is used, pins RC3 and RC4 are used for channel input from the receiver. Sharing UART1 between Blackbox and MSP is the only way to use Blackbox on a Naze32 with a PWM receiver.
-
-Boards other than the Naze32 may have more accessible hardware serial devices, in which case refer to their documentation to decide how to wire up the logger. The key criteria are: 
-
-* Must be hardware serial device. Not SoftSerial.
-* Cannot be shared with any other function (GPS, telemetry) except MSP.
-* If MSP is used on the same UART, MSP will stop working when the board is armed.
-
-### Onboard dataflash
-Enter `set blackbox_device=1` to switch to logging to an onboard dataflash chip, if your flight controller has one.
+#### Enable recording to dataflash
+On the Configurator's CLI tab, you must enter `set blackbox_device=1` to switch to logging to an onboard dataflash chip,
+then save.
 
 [your serial ports]: https://github.com/cleanflight/cleanflight/blob/master/docs/Serial.md
 [Cleanflight Configurator]: https://chrome.google.com/webstore/detail/cleanflight-configurator/enacoimjcgeinfnnnpajinjgmkahmfgb?hl=en
 
 ## Configuring the Blackbox
-
-If you are using a short looptime like 2500 or smaller, try switching your OpenLog to 250000 baud (instead of the 
-default of 115200) and set that baud rate on the Blackbox's port in the Confgurator.
 
 The Blackbox currently provides two settings (`blackbox_rate_num` and `blackbox_rate_denom`) that allow you to control 
 the rate at which data is logged. These two together form a fraction (`blackbox_rate_num / blackbox_rate_denom`) which
@@ -199,10 +219,10 @@ is pretty small. At the default 1/1 logging rate, and a 2400 looptime, this is o
 flight. This could be long enough for you to investigate some flying problem with your craft, but you may want to reduce
 the logging rate in order to extend your recording time.
 
-To maximize your recording time, you could drop the rate way down to 1/32 (the smallest possible rate) which would
-result in a logging rate of about 10-20Hz and about 650 bytes/second of data. At that logging rate, the 2MB flash chip
-can store around 50 minutes of flight data, though the level of detail is severely reduced and you could not diagnose
-flight problems like vibration or PID setting issues.
+To maximize your recording time, you could drop the rate all the way down to 1/32 (the smallest possible rate) which
+would result in a logging rate of about 10-20Hz and about 650 bytes/second of data. At that logging rate, a 2MB
+dataflash chip can store around 50 minutes of flight data, though the level of detail is severely reduced and you could
+not diagnose flight problems like vibration or PID setting issues.
 
 ## Usage
 
@@ -241,18 +261,20 @@ modes tab. Once you've added a mode, Blackbox will only log flight data when the
 A log header will always be recorded at arming time, even if logging is paused. You can freely pause and resume logging 
 while in flight.
 
-## Converting logs to CSV or PNG
-After your flights, you'll have a series of flight log files with a .TXT extension. You'll need to decode these with
-the `blackbox_decode` tool to create CSV (comma-separated values) files for analysis, or render them into a series of PNG
-frames with `blackbox_render` tool, which you could then convert into a video using another software package.
+## Viewing recorded logs
+After your flights, you'll have a series of flight log files with a .TXT extension.
+
+You can view these .TXT flight log files interactively using your web browser with the Cleanflight Blackbox Explorer:
+
+https://github.com/cleanflight/blackbox-log-viewer
+
+This allows you to scroll around a graphed version of your log and examine your log in detail. You can also export a
+video of your log to share it with others!
+
+You can decode your logs with the `blackbox_decode` tool to create CSV (comma-separated values) files for analysis,
+or render them into a series of PNG frames with `blackbox_render` tool, which you could then convert into a video using
+another software package.
 
 You'll find those tools along with instructions for using them in this repository:
 
 https://github.com/cleanflight/blackbox-tools
-
-You can also view your .TXT flight log files interactively using your web browser with the Cleanflight Blackbox Explorer
-tool:
-
-https://github.com/cleanflight/blackbox-log-viewer
-
-This allows you to scroll around a graphed version of your log and examine your log in detail.

--- a/src/main/sensors/boardalignment.c
+++ b/src/main/sensors/boardalignment.c
@@ -44,9 +44,9 @@ void initBoardAlignment(boardAlignment_t *boardAlignment)
     standardBoardAlignment = false;
 
     fp_angles_t rotationAngles;
-    rotationAngles.angles.roll = degreesToRadians(boardAlignment->rollDegrees);
+    rotationAngles.angles.roll  = degreesToRadians(boardAlignment->rollDegrees );
     rotationAngles.angles.pitch = degreesToRadians(boardAlignment->pitchDegrees);
-    rotationAngles.angles.yaw = degreesToRadians(boardAlignment->yawDegrees);
+    rotationAngles.angles.yaw   = degreesToRadians(boardAlignment->yawDegrees  );
 
     buildRotationMatrix(&rotationAngles, boardRotation);
 }

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -111,6 +111,7 @@ LIBCLEANFLIGHT_SRC = \
 	io/serial.c \
 	rx/rx.c \
 	sensors/battery.c \
+	sensors/boardalignment.c \
 	telemetry/hott.c
 
 LIBCLEANFLIGHT_OBJ = $(LIBCLEANFLIGHT_SRC:%.c=$(OBJECT_DIR)/%.o)

--- a/src/test/unit/alignsensor_unittest.cc
+++ b/src/test/unit/alignsensor_unittest.cc
@@ -1,0 +1,269 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "math.h"
+#include "stdint.h"
+#include "time.h"
+
+extern "C" {
+#include "common/axis.h"
+#include "sensors/boardalignment.h"
+#include "sensors/sensors.h"
+}
+
+#include "gtest/gtest.h"
+
+/*
+ * This test file contains an independent method of rotating a vector.
+ * The output of alignSensor() is compared to the output of the test
+ * rotation method.
+ * 
+ * For each alignment condition (CW0, CW90, etc) the source vector under
+ * test is set to a unit vector along each axis (x-axis, y-axis, z-axis) 
+ * plus one additional random vector is tested.
+ */
+
+#define DEG2RAD 0.01745329251
+
+static void rotateVector(int16_t mat[3][3], int16_t vec[3], int16_t *out)
+{
+    int16_t tmp[3];
+
+    for(int i=0; i<3; i++) {
+        tmp[i] = 0;
+        for(int j=0; j<3; j++) {
+            tmp[i] += mat[j][i] * vec[j];
+        }
+    }
+    
+    out[0]=tmp[0];
+    out[1]=tmp[1];
+    out[2]=tmp[2];
+
+}
+
+//static void initXAxisRotation(int16_t mat[][3], int16_t angle)
+//{
+//    mat[0][0] =  1;
+//    mat[0][1] =  0;
+//    mat[0][2] =  0;
+//    mat[1][0] =  0;
+//    mat[1][1] =  cos(angle*DEG2RAD);
+//    mat[1][2] = -sin(angle*DEG2RAD);
+//    mat[2][0] =  0;
+//    mat[2][1] =  sin(angle*DEG2RAD);
+//    mat[2][2] =  cos(angle*DEG2RAD);
+//}
+
+static void initYAxisRotation(int16_t mat[][3], int16_t angle)
+{
+    mat[0][0] =  cos(angle*DEG2RAD);
+    mat[0][1] =  0;
+    mat[0][2] =  sin(angle*DEG2RAD);
+    mat[1][0] =  0;
+    mat[1][1] =  1;
+    mat[1][2] =  0;
+    mat[2][0] = -sin(angle*DEG2RAD);
+    mat[2][1] =  0;
+    mat[2][2] =  cos(angle*DEG2RAD);
+}
+
+static void initZAxisRotation(int16_t mat[][3], int16_t angle)
+{
+    mat[0][0] =  cos(angle*DEG2RAD);
+    mat[0][1] = -sin(angle*DEG2RAD);
+    mat[0][2] =  0;
+    mat[1][0] =  sin(angle*DEG2RAD);
+    mat[1][1] =  cos(angle*DEG2RAD);
+    mat[1][2] =  0;
+    mat[2][0] =  0;
+    mat[2][1] =  0;
+    mat[2][2] =  1;
+}
+
+static void testCW(sensor_align_e rotation, int16_t angle)
+{
+    int16_t src[XYZ_AXIS_COUNT];
+    int16_t dest[XYZ_AXIS_COUNT];
+    int16_t test[XYZ_AXIS_COUNT];
+
+    // unit vector along x-axis
+    src[X] = 1;
+    src[Y] = 0;
+    src[Z] = 0;
+    
+    int16_t matrix[3][3];
+    initZAxisRotation(matrix, angle);
+    rotateVector(matrix, src, test);
+
+    alignSensors(src, dest, rotation);
+    EXPECT_EQ(test[X], dest[X]) << "X-Unit alignment does not match in X-Axis. " << test[X] << " " << dest[X];
+    EXPECT_EQ(test[Y], dest[Y]) << "X-Unit alignment does not match in Y-Axis. " << test[Y] << " " << dest[Y];
+    EXPECT_EQ(test[Z], dest[Z]) << "X-Unit alignment does not match in Z-Axis. " << test[Z] << " " << dest[Z];
+
+    // unit vector along y-axis
+    src[X] = 0;
+    src[Y] = 1;
+    src[Z] = 0;
+
+    rotateVector(matrix, src, test);
+    alignSensors(src, dest, rotation);
+    EXPECT_EQ(test[X], dest[X]) << "Y-Unit alignment does not match in X-Axis. " << test[X] << " " << dest[X];
+    EXPECT_EQ(test[Y], dest[Y]) << "Y-Unit alignment does not match in Y-Axis. " << test[Y] << " " << dest[Y];
+    EXPECT_EQ(test[Z], dest[Z]) << "Y-Unit alignment does not match in Z-Axis. " << test[Z] << " " << dest[Z];
+
+    // unit vector along z-axis
+    src[X] = 0;
+    src[Y] = 0;
+    src[Z] = 1;
+
+    rotateVector(matrix, src, test);
+    alignSensors(src, dest, rotation);
+    EXPECT_EQ(test[X], dest[X]) << "Z-Unit alignment does not match in X-Axis. " << test[X] << " " << dest[X];
+    EXPECT_EQ(test[Y], dest[Y]) << "Z-Unit alignment does not match in Y-Axis. " << test[Y] << " " << dest[Y];
+    EXPECT_EQ(test[Z], dest[Z]) << "Z-Unit alignment does not match in Z-Axis. " << test[Z] << " " << dest[Z];
+
+    // random vector to test
+    src[X] = rand() % 5;
+    src[Y] = rand() % 5;
+    src[Z] = rand() % 5;
+
+    rotateVector(matrix, src, test);
+    alignSensors(src, dest, rotation);
+    EXPECT_EQ(test[X], dest[X]) << "Random alignment does not match in X-Axis. " << test[X] << " " << dest[X];
+    EXPECT_EQ(test[Y], dest[Y]) << "Random alignment does not match in Y-Axis. " << test[Y] << " " << dest[Y];
+    EXPECT_EQ(test[Z], dest[Z]) << "Random alignment does not match in Z-Axis. " << test[Z] << " " << dest[Z];
+}
+
+/*
+ * Since the order of flip and rotation matters, these tests make the
+ * assumption that the 'flip' occurs first, followed by clockwise rotation
+ */
+static void testCWFlip(sensor_align_e rotation, int16_t angle)
+{
+    int16_t src[XYZ_AXIS_COUNT];
+    int16_t dest[XYZ_AXIS_COUNT];
+    int16_t test[XYZ_AXIS_COUNT];
+
+    // unit vector along x-axis
+    src[X] = 1;
+    src[Y] = 0;
+    src[Z] = 0;
+    
+    int16_t matrix[3][3];
+    initYAxisRotation(matrix, 180);
+    rotateVector(matrix, src, test);
+    initZAxisRotation(matrix, angle);
+    rotateVector(matrix, test, test);
+
+    alignSensors(src, dest, rotation);
+
+    EXPECT_EQ(test[X], dest[X]) << "X-Unit alignment does not match in X-Axis. " << test[X] << " " << dest[X];
+    EXPECT_EQ(test[Y], dest[Y]) << "X-Unit alignment does not match in Y-Axis. " << test[Y] << " " << dest[Y];
+    EXPECT_EQ(test[Z], dest[Z]) << "X-Unit alignment does not match in Z-Axis. " << test[Z] << " " << dest[Z];
+
+    // unit vector along y-axis
+    src[X] = 0;
+    src[Y] = 1;
+    src[Z] = 0;
+
+    initYAxisRotation(matrix, 180);
+    rotateVector(matrix, src, test);
+    initZAxisRotation(matrix, angle);
+    rotateVector(matrix, test, test);
+
+    alignSensors(src, dest, rotation);
+
+    EXPECT_EQ(test[X], dest[X]) << "Y-Unit alignment does not match in X-Axis. " << test[X] << " " << dest[X];
+    EXPECT_EQ(test[Y], dest[Y]) << "Y-Unit alignment does not match in Y-Axis. " << test[Y] << " " << dest[Y];
+    EXPECT_EQ(test[Z], dest[Z]) << "Y-Unit alignment does not match in Z-Axis. " << test[Z] << " " << dest[Z];
+
+    // unit vector along z-axis
+    src[X] = 0;
+    src[Y] = 0;
+    src[Z] = 1;
+
+    initYAxisRotation(matrix, 180);
+    rotateVector(matrix, src, test);
+    initZAxisRotation(matrix, angle);
+    rotateVector(matrix, test, test);
+
+    alignSensors(src, dest, rotation);
+
+    EXPECT_EQ(test[X], dest[X]) << "Z-Unit alignment does not match in X-Axis. " << test[X] << " " << dest[X];
+    EXPECT_EQ(test[Y], dest[Y]) << "Z-Unit alignment does not match in Y-Axis. " << test[Y] << " " << dest[Y];
+    EXPECT_EQ(test[Z], dest[Z]) << "Z-Unit alignment does not match in Z-Axis. " << test[Z] << " " << dest[Z];
+
+     // random vector to test
+    src[X] = rand() % 5;
+    src[Y] = rand() % 5;
+    src[Z] = rand() % 5;
+
+    initYAxisRotation(matrix, 180);
+    rotateVector(matrix, src, test);
+    initZAxisRotation(matrix, angle);
+    rotateVector(matrix, test, test);
+
+    alignSensors(src, dest, rotation);
+
+    EXPECT_EQ(test[X], dest[X]) << "Random alignment does not match in X-Axis. " << test[X] << " " << dest[X];
+    EXPECT_EQ(test[Y], dest[Y]) << "Random alignment does not match in Y-Axis. " << test[Y] << " " << dest[Y];
+    EXPECT_EQ(test[Z], dest[Z]) << "Random alignment does not match in Z-Axis. " << test[Z] << " " << dest[Z];
+}
+ 
+
+TEST(AlignSensorTest, ClockwiseZeroDegrees)
+{
+    srand(time(NULL));
+    testCW(CW0_DEG, 0);
+}
+
+TEST(AlignSensorTest, ClockwiseNinetyDegrees)
+{
+    testCW(CW90_DEG, 90);
+}
+
+TEST(AlignSensorTest, ClockwiseOneEightyDegrees)
+{
+    testCW(CW180_DEG, 180);
+}
+
+TEST(AlignSensorTest, ClockwiseTwoSeventyDegrees)
+{
+    testCW(CW270_DEG, 270);
+}
+
+TEST(AlignSensorTest, ClockwiseZeroDegreesFlip)
+{
+    testCWFlip(CW0_DEG_FLIP, 0);
+}
+
+TEST(AlignSensorTest, ClockwiseNinetyDegreesFlip)
+{
+    testCWFlip(CW90_DEG_FLIP, 90);
+}
+
+TEST(AlignSensorTest, ClockwiseOneEightyDegreesFlip)
+{
+    testCWFlip(CW180_DEG_FLIP, 180);
+}
+
+TEST(AlignSensorTest, ClockwiseTwoSeventyDegreesFlip)
+{
+    testCWFlip(CW270_DEG_FLIP, 270);
+}
+

--- a/src/test/unit/battery_unittest.cc
+++ b/src/test/unit/battery_unittest.cc
@@ -193,6 +193,7 @@ TEST(BatteryTest, CellCount)
     }
 }
 
+//#define DEBUG_ROLLOVER_PATTERNS
 /**
  * These next two tests do not test any production code (!) but serves as an example of how to use a signed variable for timing purposes.
  *
@@ -216,7 +217,7 @@ TEST(BatteryTest, RollOverPattern1)
             }
 
             servicedAt = now;
-#if 1
+#ifdef DEBUG_ROLLOVER_PATTERNS
             printf("servicedAt: %d, diff: %d\n", servicedAt, diff);
 #endif
             serviceCount++;
@@ -249,7 +250,7 @@ TEST(BatteryTest, RollOverPattern2)
             }
 
             serviceAt = now + serviceInterval; // this can rollover
-#if 1
+#ifdef DEBUG_ROLLOVER_PATTERNS
             printf("servicedAt: %d, nextServiceAt: %d, diff: %d\n", now, serviceAt, diff);
 #endif
 


### PR DESCRIPTION
The unit test includes a simple independent implementation of a vector rotation. Each of the following sensor_align_e types are tested:
* CW0_DEG
* CW90_DEG
* CW180_DEG
* CW270_DEG
* CW0_DEG_FLIP
* CW90_DEG_FLIP
* CW180_DEG_FLIP
* CW270_DEG_FLIP

For each sensor_align_e type, three unit vectors and a random vector are tested.
* {1, 0, 0}
* {0, 1, 0}
* {0, 0, 1}
* {R, R, R} (where R is a random number)

The vector under test is rotated by using the functions defined in the test file and is also rotated using the sensorsAlign() function. The outputs of both are compared for equality. The outputs match for all test conditions.