### PR TITLE
Fix small typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Cleanflight also has additional features not found in baseflight.
 * Configurable serial ports for Serial RX, Telemetry, MSP, GPS - Use most devices on any port, softserial too.
 + more many minor bug fixes.
 
-For a list of features, changes and some discussion please review the thread on MultiWii forums and consult the documenation.
+For a list of features, changes and some discussion please review the thread on MultiWii forums and consult the documentation.
 
 http://www.multiwii.com/forum/viewtopic.php?f=23&t=5149
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Clean-code version of baseflight flight-controller - flight controllers are used
 This fork differs from baseflight in that it attempts to use modern software development practices which result in:
 
 1. greater reliability through code robustness and automated testing. 
-2. easier maintainance through code cleanliness.
+2. easier maintenance through code cleanliness.
 3. easier to develop new features. 
 4. easier to re-use code though code de-coupling and modularisation.
 
@@ -41,7 +41,7 @@ Cleanflight also has additional features not found in baseflight.
 * Rate profiles and in-flight selection of them.
 * Graupner PPM failsafe.
 * Graupner HoTT telemetry.
-* Multiple simultantious telemetry providers.
+* Multiple simultaneous telemetry providers.
 * Configurable serial ports for Serial RX, Telemetry, MSP, GPS - Use most devices on any port, softserial too.
 + more many minor bug fixes.
 
@@ -71,7 +71,7 @@ Etiquette: Don't ask to ask and please wait around long enough for a reply - som
 
 ## Videos
 
-There is a dedicated Cleanflight youtube channel which has progress update videos, flight demonstrations, instrutions and other related videos.
+There is a dedicated Cleanflight youtube channel which has progress update videos, flight demonstrations, instructions and other related videos.
 
 https://www.youtube.com/playlist?list=PL6H1fAj_XUNVBEcp8vbMH2DrllZAGWkt8
 
@@ -79,7 +79,7 @@ Please subscribe and '+1' the videos if you find them useful.
 
 ## Configuration Tool
 
-To configure Cleanflight you should use the Cleanlight-configurator GUI tool (Windows/OSX/Linux) that can be found here:
+To configure Cleanflight you should use the Cleanflight-configurator GUI tool (Windows/OSX/Linux) that can be found here:
 
 https://chrome.google.com/webstore/detail/cleanflight-configurator/enacoimjcgeinfnnnpajinjgmkahmfgb
 


### PR DESCRIPTION
Resolves typos noticed in the initial user documentation (ironically, "documentation" was one of the incorrect words).