### PR TITLE
imu: Replace MAGIC_NUMBER with proper array size reference.

### DIFF
--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -63,7 +63,7 @@ float gyroScaleRad;
 
 
 rollAndPitchInclination_t inclination = { { 0, 0 } };     // absolute angle inclination in multiple of 0.1 degree    180 deg = 1800
-float anglerad[2] = { 0.0f, 0.0f };    // absolute angle inclination in radians
+float anglerad[ANGLE_INDEX_COUNT] = { 0.0f, 0.0f };    // absolute angle inclination in radians
 
 static imuRuntimeConfig_t *imuRuntimeConfig;
 static pidProfile_t *pidProfile;


### PR DESCRIPTION
 Keep behaviour consistent with `GPS_angle[ANGLE_INDEX_COUNT]`, which is the other use of enums `AI_ROLL` and `AI_PITCH`.

Unit tests pass after this change.