### PR TITLE
Rename updateAccelerometerReadings() to accelerometerUpdate()

### DIFF
--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -302,7 +302,7 @@ void imuUpdate(rollAndPitchTrims_t *accelerometerTrims)
     gyroUpdate();
 
     if (sensors(SENSOR_ACC)) {
-        updateAccelerationReadings(accelerometerTrims); // TODO rename to accelerometerUpdate and rename many other 'Acceleration' references to be 'Accelerometer'
+        accelerometerUpdate(accelerometerTrims);
         imuCalculateEstimatedAttitude();
     } else {
         accADC[X] = 0;

--- a/src/main/sensors/acceleration.c
+++ b/src/main/sensors/acceleration.c
@@ -169,7 +169,7 @@ void applyAccelerationTrims(flightDynamicsTrims_t *accelerationTrims)
     accADC[Z] -= accelerationTrims->raw[Z];
 }
 
-void updateAccelerationReadings(rollAndPitchTrims_t *rollAndPitchTrims)
+void accelerometerUpdate(rollAndPitchTrims_t *rollAndPitchTrims)
 {
     if (!acc.read(accADC)) {
         return;

--- a/src/main/sensors/acceleration.h
+++ b/src/main/sensors/acceleration.h
@@ -52,5 +52,5 @@ typedef union {
 bool isAccelerationCalibrationComplete(void);
 void accSetCalibrationCycles(uint16_t calibrationCyclesRequired);
 void resetRollAndPitchTrims(rollAndPitchTrims_t *rollAndPitchTrims);
-void updateAccelerationReadings(rollAndPitchTrims_t *rollAndPitchTrims);
+void accelerometerUpdate(rollAndPitchTrims_t *rollAndPitchTrims);
 void setAccelerationTrims(flightDynamicsTrims_t *accelerationTrimsToUse);

--- a/src/test/unit/altitude_hold_unittest.cc
+++ b/src/test/unit/altitude_hold_unittest.cc
@@ -145,7 +145,7 @@ bool sensors(uint32_t mask)
     UNUSED(mask);
     return false;
 };
-void updateAccelerationReadings(rollAndPitchTrims_t *rollAndPitchTrims)
+void accelerometerUpdate(rollAndPitchTrims_t *rollAndPitchTrims)
 {
     UNUSED(rollAndPitchTrims);
 }

--- a/src/test/unit/flight_imu_unittest.cc
+++ b/src/test/unit/flight_imu_unittest.cc
@@ -113,7 +113,7 @@ bool sensors(uint32_t mask)
     UNUSED(mask);
     return false;
 };
-void updateAccelerationReadings(rollAndPitchTrims_t *rollAndPitchTrims)
+void accelerometerUpdate(rollAndPitchTrims_t *rollAndPitchTrims)
 {
     UNUSED(rollAndPitchTrims);
 }


### PR DESCRIPTION
Resolves a TODO.

Simple patch with sed. Confirmed no stray references with:

```
$ grep -r --exclude-dir=.git "updateAccelerationReadings"
$ 
```

All unit tests pass.
