### PR TITLE
tests: Add unit tests for calculateThrottleAngleScale().

### DIFF
--- a/src/test/unit/flight_imu_unittest.cc
+++ b/src/test/unit/flight_imu_unittest.cc
@@ -124,6 +124,19 @@ TEST(FlightImuTest, TestEulerAngleCalculation)
     EXPECT_FLOAT_EQ(attitude.values.yaw, 2700);
 }
 
+TEST(FlightImuTest, TestCalculateThrottleAngleScale)
+{
+    ASSERT_TRUE(isinf(calculateThrottleAngleScale(0)));
+
+    EXPECT_FLOAT_EQ(calculateThrottleAngleScale(1), 515662.0f);
+
+    EXPECT_FLOAT_EQ(calculateThrottleAngleScale(450), (1800.0f / M_PIf) * 2);
+
+    EXPECT_FLOAT_EQ(calculateThrottleAngleScale(900), 1800.0f / M_PIf);
+
+    EXPECT_FLOAT_EQ(calculateThrottleAngleScale(901), 572.32184f);
+}
+
 // STUBS
 
 extern "C" {


### PR DESCRIPTION
Add a set of simple unit tests for `calculateThrottleAngleScale()`.

Because this returns a float, it is necessary to use EXPECT_FLOAT_EQ and be smart with the corner cases used.

```
$ ./obj/test/flight_imu_unittest 
Running main() from gtest_main.cc
[==========] Running 2 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 2 tests from FlightImuTest
[ RUN      ] FlightImuTest.TestCalculateHeading
[       OK ] FlightImuTest.TestCalculateHeading (0 ms)
[ RUN      ] FlightImuTest.TestCalculateThrottleAngleScale
[       OK ] FlightImuTest.TestCalculateThrottleAngleScale (0 ms)
[----------] 2 tests from FlightImuTest (0 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test case ran. (0 ms total)
[  PASSED  ] 2 tests.
```
