### PR TITLE
Configurable Baro Type

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -128,7 +128,7 @@ static uint32_t activeFeaturesLatch = 0;
 static uint8_t currentControlRateProfileIndex = 0;
 controlRateConfig_t *currentControlRateProfile;
 
-static const uint8_t EEPROM_CONF_VERSION = 104;
+static const uint8_t EEPROM_CONF_VERSION = 105;
 
 static void resetAccelerometerTrims(flightDynamicsTrims_t *accelerometerTrims)
 {

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -392,6 +392,7 @@ static void resetConf(void)
     masterConfig.gyroConfig.gyroMovementCalibrationThreshold = 32;
 
     masterConfig.mag_hardware = MAG_DEFAULT;     // default/autodetect
+    masterConfig.baro_hardware = BARO_DEFAULT;   // default/autodetect
 
     resetBatteryConfig(&masterConfig.batteryConfig);
 

--- a/src/main/config/config_master.h
+++ b/src/main/config/config_master.h
@@ -53,6 +53,7 @@ typedef struct master_t {
     gyroConfig_t gyroConfig;
 
     uint8_t mag_hardware;                   // Which mag hardware to use on boards with more than one device
+    uint8_t baro_hardware;                  // Barometer hardware to use
 
     uint16_t max_angle_inclination;         // max inclination allowed in angle (level) mode. default 500 (50 degrees).
     flightDynamicsTrims_t accZero;

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -454,6 +454,7 @@ const clivalue_t valueTable[] = {
     { "baro_noise_lpf",             VAR_FLOAT  | PROFILE_VALUE, &masterConfig.profile[0].barometerConfig.baro_noise_lpf, 0, 1 },
     { "baro_cf_vel",                VAR_FLOAT  | PROFILE_VALUE, &masterConfig.profile[0].barometerConfig.baro_cf_vel, 0, 1 },
     { "baro_cf_alt",                VAR_FLOAT  | PROFILE_VALUE, &masterConfig.profile[0].barometerConfig.baro_cf_alt, 0, 1 },
+    { "baro_hardware",              VAR_UINT8  | MASTER_VALUE,  &masterConfig.baro_hardware, 0, BARO_MAX },
 
     { "mag_hardware",               VAR_UINT8  | MASTER_VALUE,  &masterConfig.mag_hardware, 0, MAG_MAX },
     { "mag_declination",            VAR_INT16  | PROFILE_VALUE, &masterConfig.profile[0].mag_declination, -18000, 18000 },

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -371,7 +371,7 @@ void init(void)
     }
 #endif
 
-    if (!sensorsAutodetect(&masterConfig.sensorAlignmentConfig, masterConfig.gyro_lpf, masterConfig.acc_hardware, masterConfig.mag_hardware, currentProfile->mag_declination)) {
+    if (!sensorsAutodetect(&masterConfig.sensorAlignmentConfig, masterConfig.gyro_lpf, masterConfig.acc_hardware, masterConfig.mag_hardware, masterConfig.baro_hardware, currentProfile->mag_declination)) {
         // if gyro was not detected due to whatever reason, we give up now.
         failureMode(3);
     }

--- a/src/main/sensors/barometer.h
+++ b/src/main/sensors/barometer.h
@@ -18,13 +18,14 @@
 #pragma once
 
 typedef enum {
-    BARO_NONE = 0,
-    BARO_DEFAULT = 1,
+    BARO_DEFAULT = 0,
+    BARO_NONE = 1,
     BARO_BMP085 = 2,
     BARO_MS5611 = 3
 } baroSensor_e;
 
 #define BARO_SAMPLE_COUNT_MAX   48
+#define BARO_MAX BARO_MS5611
 
 typedef struct barometerConfig_s {
     uint8_t baro_sample_count;              // size of baro filter array

--- a/src/main/sensors/initialisation.c
+++ b/src/main/sensors/initialisation.c
@@ -408,12 +408,12 @@ retry:
     sensorsSet(SENSOR_ACC);
 }
 
-static void detectBaro()
+static void detectBaro(baroSensor_e baroHardwareToUse)
 {
 #ifdef BARO
     // Detect what pressure sensors are available. baro->update() is set to sensor-specific update function
 
-    baroSensor_e baroHardware = BARO_DEFAULT;
+    baroSensor_e baroHardware = baroHardwareToUse;
 
 #ifdef USE_BARO_BMP085
 
@@ -587,7 +587,7 @@ void reconfigureAlignment(sensorAlignmentConfig_t *sensorAlignmentConfig)
     }
 }
 
-bool sensorsAutodetect(sensorAlignmentConfig_t *sensorAlignmentConfig, uint16_t gyroLpf, uint8_t accHardwareToUse, uint8_t magHardwareToUse, int16_t magDeclinationFromConfig)
+bool sensorsAutodetect(sensorAlignmentConfig_t *sensorAlignmentConfig, uint16_t gyroLpf, uint8_t accHardwareToUse, uint8_t magHardwareToUse, uint8_t baroHardwareToUse, int16_t magDeclinationFromConfig)
 {
     int16_t deg, min;
 
@@ -598,7 +598,7 @@ bool sensorsAutodetect(sensorAlignmentConfig_t *sensorAlignmentConfig, uint16_t 
         return false;
     }
     detectAcc(accHardwareToUse);
-    detectBaro();
+    detectBaro(baroHardwareToUse);
 
 
     // Now time to init things, acc first

--- a/src/main/sensors/initialisation.h
+++ b/src/main/sensors/initialisation.h
@@ -17,4 +17,4 @@
 
 #pragma once
 
-bool sensorsAutodetect(sensorAlignmentConfig_t *sensorAlignmentConfig, uint16_t gyroLpf, uint8_t accHardwareToUse, uint8_t magHardwareToUse, int16_t magDeclinationFromConfig);
+bool sensorsAutodetect(sensorAlignmentConfig_t *sensorAlignmentConfig, uint16_t gyroLpf, uint8_t accHardwareToUse, uint8_t magHardwareToUse, uint8_t baroHardwareToUse, int16_t magDeclinationFromConfig);


### PR DESCRIPTION
We can disable/configure mag, acc, but why not baro?

On some boards disabling a baro gives better performance. It is wise to make this one configurable like well acc and mag.
cli setting
set baro_hardware