### PR TITLE
Promote 'make test' to a top level folder feature.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -650,6 +650,7 @@ $(OBJECT_DIR)/$(TARGET)/%.o: %.S
 clean:
 	rm -f $(TARGET_BIN) $(TARGET_HEX) $(TARGET_ELF) $(TARGET_OBJS) $(TARGET_MAP)
 	rm -rf $(OBJECT_DIR)/$(TARGET)
+	cd src/test && $(MAKE) clean || true
 
 flash_$(TARGET): $(TARGET_HEX)
 	stty -F $(SERIAL_DEVICE) raw speed 115200 -crtscts cs8 -parenb -cstopb -ixon
@@ -680,6 +681,10 @@ help:
 	@echo ""
 	@echo "Valid TARGET values are: $(VALID_TARGETS)"
 	@echo ""
+
+## test        : run the cleanflight test suite
+test:
+	cd src/test && $(MAKE) test || true
 
 # rebuild everything when makefile changes
 $(TARGET_OBJS) : Makefile


### PR DESCRIPTION
Developers will find it easier, and many expect, to run the test suite from the top level folder.

This simple feature adds `make test` in the root folder of cleanflight. Associated changes also ensure `make clean` from the root folder cleans up after itself.

Thus removing a `cd` command from the iterative process of refactoring.