### PR TITLE
RX - Corrections to RX fail detection, hold and preset, when using a PWM connection (2)

### DIFF
--- a/src/main/drivers/pwm_rx.h
+++ b/src/main/drivers/pwm_rx.h
@@ -30,9 +30,8 @@ void ppmAvoidPWMTimerClash(const timerHardware_t *timerHardwarePtr, TIM_TypeDef 
 
 void pwmInConfig(const timerHardware_t *timerHardwarePtr, uint8_t channel);
 uint16_t pwmRead(uint8_t channel);
-uint16_t ppmRead(uint8_t channel);
 
-bool isPPMDataBeingReceived(void);
-void resetPPMDataReceivedState(void);
+bool isPXMDataBeingReceived(void);
+void resetPXMDataReceivedState(void);
 
 void pwmRxInit(inputFilteringMode_e initialInputFilteringMode);

--- a/src/main/rx/pwm.c
+++ b/src/main/rx/pwm.c
@@ -40,23 +40,17 @@ static uint16_t pwmReadRawRC(rxRuntimeConfig_t *rxRuntimeConfigPtr, uint8_t chan
     return pwmRead(channel);
 }
 
-static uint16_t ppmReadRawRC(rxRuntimeConfig_t *rxRuntimeConfigPtr, uint8_t channel)
-{
-    UNUSED(rxRuntimeConfigPtr);
-    return ppmRead(channel);
-}
-
 void rxPwmInit(rxRuntimeConfig_t *rxRuntimeConfigPtr, rcReadRawDataPtr *callback)
 {
     UNUSED(rxRuntimeConfigPtr);
     // configure PWM/CPPM read function and max number of channels. serial rx below will override both of these, if enabled
+    *callback = pwmReadRawRC;
+
     if (feature(FEATURE_RX_PARALLEL_PWM)) {
         rxRuntimeConfigPtr->channelCount = MAX_SUPPORTED_RC_PARALLEL_PWM_CHANNEL_COUNT;
-        *callback = pwmReadRawRC;
     }
     if (feature(FEATURE_RX_PPM)) {
         rxRuntimeConfigPtr->channelCount = MAX_SUPPORTED_RC_PPM_CHANNEL_COUNT;
-        *callback = ppmReadRawRC;
     }
 }
 

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -274,16 +274,15 @@ void updateRx(uint32_t currentTime)
         }
     }
 
-    if ((feature(FEATURE_RX_SERIAL | FEATURE_RX_MSP) && rxDataReceived)
-          || feature(FEATURE_RX_PARALLEL_PWM)) {
+    if (feature(FEATURE_RX_SERIAL | FEATURE_RX_MSP) && rxDataReceived) {
         needRxSignalBefore = currentTime + DELAY_10_HZ;
     }
 
-    if (feature(FEATURE_RX_PPM)) {
-        if (isPPMDataBeingReceived()) {
+    if (feature(FEATURE_RX_PPM | FEATURE_RX_PARALLEL_PWM)) {
+        if (isPXMDataBeingReceived()) {
             rxSignalReceived = true;
             needRxSignalBefore = currentTime + DELAY_10_HZ;
-            resetPPMDataReceivedState();
+            resetPXMDataReceivedState();
         }
         shouldCheckPulse = rxSignalReceived;
     }


### PR DESCRIPTION
This is to correct and progress the code added with pull request #1190 

COMMIT MESSAGE:
Revert bad, keep good and adding to PR #1190

This partly reverts commit 95840ae512e09bc669e9dc964af6e890f2fd360e
AND, except for the renamed parameter `chan` to `channel`,
commit d2c40076db67d76ac4798d3b07e068ecf0089884.

Implemented pwm channel received/overflowed flags.
Treat PWM datasets like PPM frames.
Combine PWM/PPM data in union.
Refactor/renamed some common functions/variables to *pxm* to indicate used by both, pwm and ppm.