### PR TITLE
Fix for compiler warning in serial_cli.c

### DIFF
--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -585,21 +585,18 @@ static void cliRxFail(char *cmdline)
             rxFailsafeChannelConfiguration_t *channelFailsafeConfiguration = &masterConfig.rxConfig.failsafe_aux_channel_configurations[channel];
 
             uint16_t value;
-            char modeCharacter = '?';
+            rxFailsafeChannelMode_e mode = RX_FAILSAFE_MODE_HOLD;
 
             ptr = strchr(ptr, ' ');
             if (ptr) {
                 switch (*(++ptr)) {
                     case 'h':
-                        channelFailsafeConfiguration->mode = RX_FAILSAFE_MODE_HOLD;
-                        modeCharacter = 'h';
+                        mode = RX_FAILSAFE_MODE_HOLD;
                         break;
 
                     case 's':
-                        channelFailsafeConfiguration->mode = RX_FAILSAFE_MODE_SET;
-                        modeCharacter = 's';
+                        mode = RX_FAILSAFE_MODE_SET;
                         break;
-
                     default:
                         cliShowParseError();
                         return;
@@ -615,9 +612,11 @@ static void cliRxFail(char *cmdline)
                     return;
                 }
 
+                channelFailsafeConfiguration->mode = mode;
                 channelFailsafeConfiguration->step = value;
             }
 
+            char modeCharacter = channelFailsafeConfiguration->mode == RX_FAILSAFE_MODE_SET ? 's' : 'h';
             // triple use of printf below
             // 1. acknowledge interpretation on command,
             // 2. query current setting on single item,

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -585,18 +585,21 @@ static void cliRxFail(char *cmdline)
             rxFailsafeChannelConfiguration_t *channelFailsafeConfiguration = &masterConfig.rxConfig.failsafe_aux_channel_configurations[channel];
 
             uint16_t value;
-            rxFailsafeChannelMode_e mode = RX_FAILSAFE_MODE_HOLD;
+            char modeCharacter = '?';
 
             ptr = strchr(ptr, ' ');
             if (ptr) {
                 switch (*(++ptr)) {
                     case 'h':
-                        mode = RX_FAILSAFE_MODE_HOLD;
+                        channelFailsafeConfiguration->mode = RX_FAILSAFE_MODE_HOLD;
+                        modeCharacter = 'h';
                         break;
 
                     case 's':
-                        mode = RX_FAILSAFE_MODE_SET;
+                        channelFailsafeConfiguration->mode = RX_FAILSAFE_MODE_SET;
+                        modeCharacter = 's';
                         break;
+
                     default:
                         cliShowParseError();
                         return;
@@ -612,11 +615,9 @@ static void cliRxFail(char *cmdline)
                     return;
                 }
 
-                channelFailsafeConfiguration->mode = mode;
                 channelFailsafeConfiguration->step = value;
             }
 
-            char modeCharacter = channelFailsafeConfiguration->mode == RX_FAILSAFE_MODE_SET ? 's' : 'h';
             // triple use of printf below
             // 1. acknowledge interpretation on command,
             // 2. query current setting on single item,

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -585,7 +585,7 @@ static void cliRxFail(char *cmdline)
             rxFailsafeChannelConfiguration_t *channelFailsafeConfiguration = &masterConfig.rxConfig.failsafe_aux_channel_configurations[channel];
 
             uint16_t value;
-            rxFailsafeChannelMode_e mode;
+            rxFailsafeChannelMode_e mode = RX_FAILSAFE_MODE_HOLD;
 
             ptr = strchr(ptr, ' ');
             if (ptr) {


### PR DESCRIPTION
During clean compile, I got the following compiler warning:

    %% serial_cli.c
    ./src/main/io/serial_cli.c: In function 'cliRxFail':
    ./src/main/io/serial_cli.c:615:52: warning: 'mode' may be used uninitialized in this function [-Wmaybe-uninitialized]
                     channelFailsafeConfiguration->mode = mode;
                                                        ^

In the default case for a switch, no value was assigned to variable *mode*. The default case has a return statement in it, so leaving mode unassigned would not be a problem in reality. Minor changes to avoid the compiler warning.