### PR TITLE
Bug Fix : Telemetry Smartport Current amperage is 10 times too big

### DIFF
--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -331,7 +331,7 @@ void handleSmartPortTelemetry(void)
                 break;
             case FSSP_DATAID_CURRENT    :
                 if (feature(FEATURE_CURRENT_METER)) {
-                    smartPortSendPackage(id, amperage); // given in 10mA steps, unknown requested unit
+                    smartPortSendPackage(id, amperage / 10); // given in 10mA steps, unknown requested unit
                     smartPortHasRequest = 0;
                 }
                 break;


### PR DESCRIPTION
Telemetry Smartport Current amperage is reported 10x too big.

Bug has been tested and verified on SPRacingF3 using an analog current sensor.
The SPRacinF3 was connected to an X4R-SB receiver using SBUS and Smartport.
The Telemetry was received on a Taranis and compared to a Multimeter inline with the Battery.