### PR TITLE
Add command 'make cppcheck' and friend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,8 @@ VPATH		:= $(SRC_DIR):$(SRC_DIR)/startup
 USBFS_DIR	= $(ROOT)/lib/main/STM32_USB-FS-Device_Driver
 USBPERIPH_SRC = $(notdir $(wildcard $(USBFS_DIR)/src/*.c))
 
+CSOURCES        := $(shell find $(SRC_DIR) -name '*.c')
+
 ifeq ($(TARGET),$(filter $(TARGET),STM32F3DISCOVERY CHEBUZZF3 NAZE32PRO SPRACINGF3 SPARKY ALIENWIIF3 COLIBRI_RACE))
 
 STDPERIPH_DIR	= $(ROOT)/lib/main/STM32F30x_StdPeriph_Driver
@@ -615,6 +617,11 @@ LDFLAGS		 = -lm \
 # No user-serviceable parts below
 ###############################################################################
 
+CPPCHECK         = cppcheck $(CSOURCES) --enable=all --platform=unix64 \
+		   --std=c99 --inline-suppr --quiet --force \
+		   $(addprefix -I,$(INCLUDE_DIRS)) \
+		   -I/usr/include -I/usr/include/linux
+
 #
 # Things we will build
 #
@@ -683,6 +690,13 @@ unbrick_$(TARGET): $(TARGET_HEX)
 	stm32flash -w $(TARGET_HEX) -v -g 0x0 -b 115200 $(SERIAL_DEVICE)
 
 unbrick: unbrick_$(TARGET)
+
+## cppcheck    : run static analysis on C source code
+cppcheck: $(CSOURCES)
+	$(CPPCHECK)
+
+cppcheck-result.xml: $(CSOURCES)
+	$(CPPCHECK) --xml-version=2 2> cppcheck-result.xml
 
 help:
 	@echo ""


### PR DESCRIPTION
[Cppcheck](http://cppcheck.sourceforge.net/) is a static analysis tool for C/C++ code.

This PR adds a new command `make cppcheck` to Cleanflight.

There is an associated utility function `make cppcheck-result.xml`, which could be consumed by tools such as Jenkins.

Note: cppcheck run in this manner over Cleanflight is not fast, due to the combinatorial complexity of the many macro defines which must be examined. A slightly faster, but incomplete, run can be conducted by omitting `--force` in the arguments to cppcheck.

cppcheck has identified some code issues, which will be addressed in subsequent PRs.