### PR TITLE
Ledstrip - fix to memset in applyDefaultColors

### DIFF
--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -1017,7 +1017,7 @@ bool parseColor(uint8_t index, const char *colorConfig)
 
 void applyDefaultColors(hsvColor_t *colors, uint8_t colorCount)
 {
-    memset(colors, 0, colorCount * sizeof(colors));
+    memset(colors, 0, colorCount * sizeof(*colors));
     for (uint8_t colorIndex = 0; colorIndex < colorCount && colorIndex < (sizeof(defaultColors) / sizeof(defaultColors[0])); colorIndex++) {
         *colors++ = *defaultColors[colorIndex];
     }


### PR DESCRIPTION
Size argument passed to memset was calculated incorrectly.