### PR TITLE
Changed behavior of PR #1233 - solves issue #1254

### DIFF
--- a/docs/Rx.md
+++ b/docs/Rx.md
@@ -144,13 +144,14 @@ Signal loss can be detected when:
 ### RX loss configuration
 
 The `rxfail` cli command is used to configure per-channel rx-loss behaviour.
-You can use the `rxfail` command to change this behaviour, a channel can either be AUTOMATIC, HOLD or SET.
+You can use the `rxfail` command to change this behaviour.
+A flight channel can either be AUTOMATIC or HOLD, an AUX channel can either be SET or HOLD.  
 
-* AUTOMATIC - Flight channels are set to safe values (low throttle, mid position for yaw/pitch/roll), all AUX channels HOLD last value.
+* AUTOMATIC - Flight channels are set to safe values (low throttle, mid position for yaw/pitch/roll).
 * HOLD - Channel holds the last value.
 * SET - Channel is set to a specific configured value. 
 
-The default mode for all channels is AUTOMATIC.
+The default mode is AUTOMATIC for flight channels and HOLD for AUX channels. 
 
 The rxfail command can be used in conjunction with mode ranges to trigger various actions.
 
@@ -232,8 +233,12 @@ Set the RX for 'No Pulses'.  Turn OFF TX and RX, Turn ON RX.  Press and release 
 
 ### Graupner GR-24 PWM
 
-Set failsafe on channels 1-4 set to OFF in the receiver settings (via transmitter menu).
+Set failsafe on the throttle channel in the receiver settings (via transmitter menu) to a value below `rx_min_usec` using channel mode FAILSAFE.
+This is the prefered way, since this is *much faster* detected by the FC then a channel that sends no pulses (OFF).
 
+__NOTE:__
+One or more control channels may be set to OFF to signal a failsafe condition to the FC, all other channels *must* be set to either HOLD or OFF. 
+Do __NOT USE__ the mode indicated with FAILSAFE instead, as this combination is NOT handled correctly by the FC.
 
 ## Receiver Channel Range Configuration.
 

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -407,8 +407,8 @@ static void resetConf(void)
 
     for (i = 0; i < MAX_SUPPORTED_RC_CHANNEL_COUNT; i++) {
         rxFailsafeChannelConfiguration_t *channelFailsafeConfiguration = &masterConfig.rxConfig.failsafe_channel_configurations[i];
-        channelFailsafeConfiguration->mode = RX_FAILSAFE_MODE_AUTO;
-        channelFailsafeConfiguration->step = CHANNEL_VALUE_TO_RXFAIL_STEP(masterConfig.rxConfig.midrc);
+        channelFailsafeConfiguration->mode = (i < NON_AUX_CHANNEL_COUNT) ? RX_FAILSAFE_MODE_AUTO : RX_FAILSAFE_MODE_HOLD;
+        channelFailsafeConfiguration->step = (i == THROTTLE) ? masterConfig.rxConfig.rx_min_usec : CHANNEL_VALUE_TO_RXFAIL_STEP(masterConfig.rxConfig.midrc);
     }
 
     masterConfig.rxConfig.rssi_channel = 0;

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -346,27 +346,29 @@ static uint16_t getRxfailValue(uint8_t channel)
     rxFailsafeChannelConfiguration_t *channelFailsafeConfiguration = &rxConfig->failsafe_channel_configurations[channel];
 
     switch(channelFailsafeConfiguration->mode) {
-        default:
         case RX_FAILSAFE_MODE_AUTO:
             switch (channel) {
                 case ROLL:
                 case PITCH:
                 case YAW:
                     return rxConfig->midrc;
+
                 case THROTTLE:
                     if (feature(FEATURE_3D))
                         return rxConfig->midrc;
                     else
                         return rxConfig->rx_min_usec;
             }
-            // fall though to HOLD if there's nothing specific to do.
+            /* no break */
+
+        default:
+        case RX_FAILSAFE_MODE_INVALID:
         case RX_FAILSAFE_MODE_HOLD:
             return rcData[channel];
 
         case RX_FAILSAFE_MODE_SET:
             return RXFAIL_STEP_TO_CHANNEL_VALUE(channelFailsafeConfiguration->step);
     }
-
 }
 
 STATIC_UNIT_TESTED uint16_t applyRxChannelRangeConfiguraton(int sample, rxChannelRangeConfiguration_t range)

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -85,9 +85,17 @@ typedef enum {
     RX_FAILSAFE_MODE_AUTO = 0,
     RX_FAILSAFE_MODE_HOLD,
     RX_FAILSAFE_MODE_SET,
+    RX_FAILSAFE_MODE_INVALID,
 } rxFailsafeChannelMode_e;
 
 #define RX_FAILSAFE_MODE_COUNT 3
+
+typedef enum {
+    RX_FAILSAFE_TYPE_FLIGHT = 0,
+    RX_FAILSAFE_TYPE_AUX,
+} rxFailsafeChannelType_e;
+
+#define RX_FAILSAFE_TYPE_COUNT 2
 
 typedef struct rxFailsafeChannelConfiguration_s {
     uint8_t mode; // See rxFailsafeChannelMode_e


### PR DESCRIPTION
Changed behavior of PR #1233 to make it safe. Solves issue #1254.

* Stick channels only have AUTO and HOLD mode (SET removed, which is safer).
* AUX channels now only have SET and HOLD mode (AUTO removed, did not add functionality).
* Added a rxfail parameter check in CLI.
* Modified RX documentation to reflect these changes (and more).