### PR TITLE
Fix false RX loss detection on EEPROM read/write

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -829,6 +829,8 @@ void readEEPROM(void)
     if (!isEEPROMContentValid())
         failureMode(10);
 
+    suspendRxSignal();
+
     // Read flash
     memcpy(&masterConfig, (char *) CONFIG_START_FLASH_ADDRESS, sizeof(master_t));
 
@@ -844,6 +846,8 @@ void readEEPROM(void)
 
     validateAndFixConfig();
     activateConfig();
+
+    resumeRxSignal();
 }
 
 void readEEPROMAndNotify(void)
@@ -861,6 +865,8 @@ void writeEEPROM(void)
     FLASH_Status status = 0;
     uint32_t wordOffset;
     int8_t attemptsRemaining = 3;
+
+    suspendRxSignal();
 
     // prepare checksum/version constants
     masterConfig.version = EEPROM_CONF_VERSION;
@@ -903,6 +909,8 @@ void writeEEPROM(void)
     if (status != FLASH_COMPLETE || !isEEPROMContentValid()) {
         failureMode(10);
     }
+
+    resumeRxSignal();
 }
 
 void ensureEEPROMContainsValidData(void)

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -142,3 +142,5 @@ uint8_t serialRxFrameStatus(rxConfig_t *rxConfig);
 void updateRSSI(uint32_t currentTime);
 void resetAllRxChannelRangeConfigurations(rxChannelRangeConfiguration_t *rxChannelRangeConfiguration);
 
+void suspendRxSignal(void);
+void resumeRxSignal(void);


### PR DESCRIPTION
Fixes issue #1257

The problem is caused by hardware counters (timekeeping and PPM/PWM measurement) that keep running while the firmware is frozen. The result is misinterpretation of received data.

EEPROM read & write now call a suspend and resume function to make RX ignore incoming wrong data during reads/writes (and flush the wrong data on resume).