### PR TITLE
Add support for pid_at_min_throttle = 0 for 3D flight

### DIFF
--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -783,10 +783,20 @@ void mixTable(void)
             motor[i] -= maxThrottleDifference;
 
             if (feature(FEATURE_3D)) {
-                if ((rcData[THROTTLE]) > rxConfig->midrc) {
-                    motor[i] = constrain(motor[i], flight3DConfig->deadband3d_high, escAndServoConfig->maxthrottle);
+                if (mixerConfig->pid_at_min_throttle
+                        || rcData[THROTTLE] <= rxConfig->midrc - flight3DConfig->deadband3d_throttle
+                        || rcData[THROTTLE] >= rxConfig->midrc + flight3DConfig->deadband3d_throttle) {
+                    if (rcData[THROTTLE] > rxConfig->midrc) {
+                        motor[i] = constrain(motor[i], flight3DConfig->deadband3d_high, escAndServoConfig->maxthrottle);
+                    } else {
+                        motor[i] = constrain(motor[i], escAndServoConfig->mincommand, flight3DConfig->deadband3d_low);
+                    }
                 } else {
-                    motor[i] = constrain(motor[i], escAndServoConfig->mincommand, flight3DConfig->deadband3d_low);
+                    if (rcData[THROTTLE] > rxConfig->midrc) {
+                        motor[i] = flight3DConfig->deadband3d_high;
+                    } else {
+                        motor[i] = flight3DConfig->deadband3d_low;
+                    }
                 }
             } else {
                 if (isFailsafeActive) {


### PR DESCRIPTION
When `pid_at_min_throttle` is set to zero, this prevents the PID loop from affecting the motors while the throttle is inside the +-`deadband3d_throttle` region. In theory this could allow the motors to brake to a stop at more similar times, because the PID loop won't be trying to make attitude corrections right up until the instant that the switchover to the opposite spin direction happens.

The behaviour when `pid_at_min_throttle` is set to the default of `1` is unchanged.

Note that this has only been bench tested by me so far, never flight tested. It needs flight testing.

A Naze32 .hex file for testing can be found here:

https://github.com/sherlockflight/cleanflight-dev/releases/tag/3d-pid-at-min-throttle

Be sure to `dump` your configuration on the CLI tab before flashing this release and save it in a safe place.

Closes #1256