### PR TITLE
Flight mode dependent ACC on/off switching

### DIFF
--- a/src/main/config/runtime_config.c
+++ b/src/main/config/runtime_config.c
@@ -26,6 +26,7 @@ uint8_t stateFlags = 0;
 uint16_t flightModeFlags = 0;
 
 static uint32_t enabledSensors = 0;
+static uint32_t visibleSensors = 0xffffffff;    // all sensors visible by default
 
 /**
  * Enables the given flight mode.  A beep is sounded if the flight mode
@@ -57,7 +58,7 @@ uint16_t disableFlightMode(flightModeFlags_e mask)
 
 bool sensors(uint32_t mask)
 {
-    return enabledSensors & mask;
+    return enabledSensors & visibleSensors & mask;
 }
 
 void sensorsSet(uint32_t mask)
@@ -73,4 +74,14 @@ void sensorsClear(uint32_t mask)
 uint32_t sensorsMask(void)
 {
     return enabledSensors;
+}
+
+void sensorsVisible(uint32_t mask)
+{
+    visibleSensors |= mask;
+}
+
+void sensorsHidden(uint32_t mask)
+{
+    visibleSensors &= ~(mask);
 }

--- a/src/main/config/runtime_config.h
+++ b/src/main/config/runtime_config.h
@@ -70,5 +70,7 @@ bool sensors(uint32_t mask);
 void sensorsSet(uint32_t mask);
 void sensorsClear(uint32_t mask);
 uint32_t sensorsMask(void);
+void sensorsVisible(uint32_t mask);
+void sensorsHidden(uint32_t mask);
 
 void mwDisarm(void);

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -596,6 +596,18 @@ void processRx(void)
 
     bool canUseHorizonMode = true;
 
+    // dynamic (mode dependent) ACC on/off switching
+    if (ARMING_FLAG(ARMED)) {
+        if (IS_RC_MODE_ACTIVE(BOXANGLE) || IS_RC_MODE_ACTIVE(BOXHORIZON) || (feature(FEATURE_FAILSAFE) && failsafeIsActive())) {
+            sensorsVisible(SENSOR_ACC);
+        } else {
+            // acro mode - ACC sensor OFF to speed up the mainloop
+            sensorsHidden(SENSOR_ACC);
+        }
+    } else {
+        sensorsVisible(SENSOR_ACC);
+    }
+
     if ((IS_RC_MODE_ACTIVE(BOXANGLE) || (feature(FEATURE_FAILSAFE) && failsafeIsActive())) && (sensors(SENSOR_ACC))) {
         // bumpless transfer to Level mode
     	canUseHorizonMode = false;


### PR DESCRIPTION
This PR aims to have best of both world:

When entering the armed state in acro mode the ACC sensor will be hidden (disabled).
In any other state/mode the ACC sensor will be visible (enabled).

This is required to:

a) be capable of doing a failsafe landing in level mode.
b) have arming protection when angle > 25 degree.
c) fly in level/horizon mode.
d) have a fast looptime while flying acro.

It is still experimental and needs field testing.

__EDIT : Closed because this approach will not work.__
