### PR TITLE
wrong indexes for servos in mixer.h

### DIFF
--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -118,11 +118,11 @@ enum {
 typedef enum {
     SERVO_GIMBAL_PITCH = 0,
     SERVO_GIMBAL_ROLL = 1,
-    SERVO_FLAPS = 2,
-    SERVO_FLAPPERON_1 = 3,
-    SERVO_FLAPPERON_2 = 4,
-    SERVO_RUDDER = 5,
-    SERVO_ELEVATOR = 6,
+    //SERVO_FLAPS = 2,
+    SERVO_FLAPPERON_1 = 2,
+    SERVO_FLAPPERON_2 = 3,
+    SERVO_RUDDER = 4,
+    SERVO_ELEVATOR = 5,
     SERVO_THROTTLE = 7, // for internal combustion (IC) planes
 
     SERVO_BICOPTER_LEFT = 4,


### PR DESCRIPTION
Because I am trying to setup an airplane with new navigation code from https://github.com/digitalentity/cleanflight I found that mixer AIRPLANE command had wrong values for servos in CC3D atom. Changing this through smix "manual" solved the problem:

smix 
smix 0 2 0 100 0 0 100 0
smix 1 3 0 100 0 0 100 0
smix 2 4 2 100 0 0 100 0
smix 3 5 1 100 0 0 100 0

So the index in mixer.h are worng (AFAIK). May be my dirty change solves the problem or may be somebody could take a look and find a better solution.

After the merge of PR #1283 I am now able to use servo command like this:

servo 3 1000 2000 1500 90 90 -100 -1
servo 5 1000 2000 1500 90 90 -100 -1

New added problems with Chrome configurator (https://github.com/cleanflight/cleanflight-configurator/issues/242#issuecomment-138059790) don't allow me to finish my setup, but that is another story,,,