### PR TITLE
Fix incorrect DMA index for RSSI and External (F1 proc)

### DIFF
--- a/src/main/drivers/adc_stm32f10x.c
+++ b/src/main/drivers/adc_stm32f10x.c
@@ -73,17 +73,6 @@ void adcInit(drv_adc_config_t *init)
     }
 #endif
 
-#ifdef EXTERNAL1_ADC_GPIO
-    if (init->enableExternal1) {
-        GPIO_InitStructure.GPIO_Pin = EXTERNAL1_ADC_GPIO_PIN;
-        GPIO_Init(EXTERNAL1_ADC_GPIO, &GPIO_InitStructure);
-        adcConfig[ADC_EXTERNAL1].adcChannel = EXTERNAL1_ADC_CHANNEL;
-        adcConfig[ADC_EXTERNAL1].dmaIndex = configuredAdcChannels++;
-        adcConfig[ADC_EXTERNAL1].enabled = true;
-        adcConfig[ADC_EXTERNAL1].sampleTime = ADC_SampleTime_239Cycles5;
-    }
-#endif
-
 #ifdef RSSI_ADC_GPIO
     if (init->enableRSSI) {
         GPIO_InitStructure.GPIO_Pin = RSSI_ADC_GPIO_PIN;
@@ -92,6 +81,17 @@ void adcInit(drv_adc_config_t *init)
         adcConfig[ADC_RSSI].dmaIndex = configuredAdcChannels++;
         adcConfig[ADC_RSSI].enabled = true;
         adcConfig[ADC_RSSI].sampleTime = ADC_SampleTime_239Cycles5;
+    }
+#endif
+
+#ifdef EXTERNAL1_ADC_GPIO
+    if (init->enableExternal1) {
+        GPIO_InitStructure.GPIO_Pin = EXTERNAL1_ADC_GPIO_PIN;
+        GPIO_Init(EXTERNAL1_ADC_GPIO, &GPIO_InitStructure);
+        adcConfig[ADC_EXTERNAL1].adcChannel = EXTERNAL1_ADC_CHANNEL;
+        adcConfig[ADC_EXTERNAL1].dmaIndex = configuredAdcChannels++;
+        adcConfig[ADC_EXTERNAL1].enabled = true;
+        adcConfig[ADC_EXTERNAL1].sampleTime = ADC_SampleTime_239Cycles5;
     }
 #endif
 


### PR DESCRIPTION
RSSI measurement has been broken a while ago due to a wrong indexation of DMA (swap between RSSI and External inputs).
This correction is only needed for F1 processor (in drivers/adc_stm32f10x.c). 
DMA indexation is fine for F3 (in adc_stm32f30x.c).
