### PR TITLE
Selectively turning on/off the beeper through CLI

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -363,6 +363,7 @@ static void resetConf(void)
     setProfile(0);
     setControlRateProfile(0);
 
+    masterConfig.beeper_off.flags = BEEPER_OFF_FLAGS_MIN;
     masterConfig.version = EEPROM_CONF_VERSION;
     masterConfig.mixerMode = MIXER_QUADX;
     featureClearAll();

--- a/src/main/config/config_master.h
+++ b/src/main/config/config_master.h
@@ -99,6 +99,8 @@ typedef struct master_t {
     uint8_t blackbox_device;
 #endif
 
+    beeperOffConditions_t beeper_off;
+
     uint8_t magic_ef;                       // magic number, should be 0xEF
     uint8_t chk;                            // XOR checksum
 } master_t;

--- a/src/main/io/beeper.c
+++ b/src/main/io/beeper.c
@@ -15,32 +15,63 @@
  * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "stdbool.h"
-#include "stdint.h"
-#include "stdlib.h"
-
+#include <stdbool.h>
 #include "platform.h"
-#include "build_config.h"
+
+#include "common/maths.h"
+#include "common/axis.h"
+#include "common/color.h"
+#include "common/utils.h"
 
 #include "drivers/gpio.h"
-#include "drivers/sound_beeper.h"
+#include "drivers/sensor.h"
 #include "drivers/system.h"
-#include "sensors/battery.h"
-#include "sensors/sensors.h"
+#include "drivers/serial.h"
+#include "drivers/compass.h"
+#include "drivers/timer.h"
+#include "drivers/pwm_rx.h"
+#include "drivers/accgyro.h"
+#include "drivers/light_led.h"
+#include "drivers/sound_beeper.h"
 
-#include "rx/rx.h"
+#include "sensors/sensors.h"
+#include "sensors/boardalignment.h"
+#include "sensors/sonar.h"
+#include "sensors/compass.h"
+#include "sensors/acceleration.h"
+#include "sensors/barometer.h"
+#include "sensors/gyro.h"
+#include "sensors/battery.h"
+
+#include "io/display.h"
+#include "io/escservo.h"
 #include "io/rc_controls.h"
+#include "io/gimbal.h"
+#include "io/gps.h"
+#include "io/ledstrip.h"
+#include "io/serial.h"
+#include "io/serial_cli.h"
+#include "io/serial_msp.h"
 #include "io/statusindicator.h"
 
-#ifdef GPS
-#include "io/gps.h"
-#endif
+#include "rx/rx.h"
+#include "rx/msp.h"
+
+#include "telemetry/telemetry.h"
+
+#include "flight/mixer.h"
+#include "flight/altitudehold.h"
+#include "flight/failsafe.h"
+#include "flight/imu.h"
+#include "flight/navigation.h"
+
+#include "io/beeper.h"
 
 #include "config/runtime_config.h"
 #include "config/config.h"
+#include "config/config_profile.h"
+#include "config/config_master.h"
 
-
-#include "io/beeper.h"
 
 #if FLASH_SIZE > 64
 #define BEEPER_NAMES
@@ -302,7 +333,8 @@ void beeperUpdate(void)
     if (!beeperIsOn) {
         beeperIsOn = 1;
         if (currentBeeperEntry->sequence[beeperPos] != 0) {
-            BEEP_ON;
+        	if (!(masterConfig.beeper_off.flags & (1 << (currentBeeperEntry->mode - 1))))
+                BEEP_ON;
             warningLedEnable();
             warningLedRefresh();
             // if this was arming beep then mark time (for blackbox)

--- a/src/main/io/beeper.h
+++ b/src/main/io/beeper.h
@@ -37,7 +37,15 @@ typedef enum {
     BEEPER_READY_BEEP,              // Ring a tone when GPS is locked and ready
     BEEPER_MULTI_BEEPS,             // Internal value used by 'beeperConfirmationBeeps()'.
     BEEPER_ARMED,                   // Warning beeps when board is armed (repeats until board is disarmed or throttle is increased)
+    BEEPER_CASE_MAX
 } beeperMode_e;
+
+#define BEEPER_OFF_FLAGS_MIN  0
+#define BEEPER_OFF_FLAGS_MAX  ((1 << (BEEPER_CASE_MAX - 1)) - 1)
+
+typedef struct beeperOffConditions_t {
+    uint32_t flags;
+} beeperOffConditions_t;
 
 void beeper(beeperMode_e mode);
 void beeperSilence(void);
@@ -47,3 +55,22 @@ uint32_t getArmingBeepTimeMicros(void);
 beeperMode_e beeperModeForTableIndex(int idx);
 const char *beeperNameForTableIndex(int idx);
 int beeperTableEntryCount(void);
+
+/* CLI  beeper_off_flags  =  sum of each desired beeper turned off case
+BEEPER_GYRO_CALIBRATED,			1
+BEEPER_RX_LOST_LANDING,			2		// Beeps SOS when armed and TX is turned off or signal lost (autolanding/autodisarm)
+BEEPER_RX_LOST,         		4		// Beeps when TX is turned off or signal lost (repeat until TX is okay)
+BEEPER_DISARMING,        		8		// Beep when disarming the board
+BEEPER_ARMING,          		16    	// Beep when arming the board
+BEEPER_ARMING_GPS_FIX, 			32    	// Beep a special tone when arming the board and GPS has fix
+BEEPER_BAT_CRIT_LOW,       		64		// Longer warning beeps when battery is critically low (repeats)
+BEEPER_BAT_LOW,            		128     // Warning beeps when battery is getting low (repeats)
+BEEPER_GPS_STATUS,				256
+BEEPER_RX_SET,              	512		// Beeps when aux channel is set for beep or beep sequence how many satellites has found if GPS enabled
+BEEPER_DISARM_REPEAT,       	1024	// Beeps sounded while stick held in disarm position
+BEEPER_ACC_CALIBRATION,     	2048	// ACC inflight calibration completed confirmation
+BEEPER_ACC_CALIBRATION_FAIL,	4096	// ACC inflight calibration failed
+BEEPER_READY_BEEP,          	8192	// Ring a tone when GPS is locked and ready
+BEEPER_MULTI_BEEPS,         	16384	// Internal value used by 'beeperConfirmationBeeps()'.
+BEEPER_ARMED,               	32768	// Warning beeps when board is armed (repeats until board is disarmed or throttle is increased)
+*/

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -522,6 +522,8 @@ const clivalue_t valueTable[] = {
     { "magzero_x",                  VAR_INT16  | MASTER_VALUE, &masterConfig.magZero.raw[X], -32768, 32767 },
     { "magzero_y",                  VAR_INT16  | MASTER_VALUE, &masterConfig.magZero.raw[Y], -32768, 32767 },
     { "magzero_z",                  VAR_INT16  | MASTER_VALUE, &masterConfig.magZero.raw[Z], -32768, 32767 },
+
+    { "beeper_off_flags",           VAR_UINT32  | MASTER_VALUE, &masterConfig.beeper_off.flags, BEEPER_OFF_FLAGS_MIN, BEEPER_OFF_FLAGS_MAX },
 };
 
 #define VALUE_COUNT (sizeof(valueTable) / sizeof(clivalue_t))

--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -45,6 +45,7 @@
 #include "rx/rx.h"
 #include "rx/msp.h"
 
+#include "io/beeper.h"
 #include "io/escservo.h"
 #include "io/rc_controls.h"
 #include "io/gps.h"

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -51,6 +51,7 @@
 
 #include "rx/rx.h"
 
+#include "io/beeper.h"
 #include "io/serial.h"
 #include "io/flashfs.h"
 #include "io/gps.h"

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -30,6 +30,7 @@
 #include "rx/rx.h"
 #include "rx/msp.h"
 
+#include "io/beeper.h"
 #include "io/escservo.h"
 #include "io/rc_controls.h"
 #include "io/gps.h"


### PR DESCRIPTION
Users (issues #1271, #1098 and forums) asked for being able to make the beeper silent at desired times and conditions. This PR is a proposal for a simple and easy solution.

I introduced a CLI parameter (*beeper_off_flags*) with which one can selectively turn off the buzzer for any combination of the 15 (to date) beeping conditions. This only affects the buzzer sound and not the visual signal delivered by the led on board so that the alarms remain visible.

Default value for *beeper_off_flags* is 0 : the beeper is always active.
Maximum value is 65535 : the beeper is turned off for the whole conditions.
Values affected to each beeping case are listed below. So the *beeper_off_flags* parameter results in the sum of any combination where silence is desired.

As the *beeper_off_flags* parameter is coded on 32 bits, there is plenty space for other beeping conditions.

BEEPER_GYRO_CALIBRATED,		**1**
BEEPER_RX_LOST_LANDING, 		**2**	Beeps SOS when armed and TX is turned off or signal lost (autolanding/autodisarm)
BEEPER_RX_LOST,			**4**	Beeps when TX is turned off or signal lost (repeat until TX is okay)
BEEPER_DISARMING,			**8**	Beep when disarming the board
BEEPER_ARMING,			**16**	Beep when arming the board
BEEPER_ARMING_GPS_FIX,		**32**	Beep a special tone when arming the board and GPS has fix
BEEPER_BAT_CRIT_LOW, 		**64**	Longer warning beeps when battery is critically low (repeats)
BEEPER_BAT_LOW, 			**128**	Warning beeps when battery is getting low (repeats)
BEEPER_GPS_STATUS, 			**256**
BEEPER_RX_SET, 			**512**	Beeps when aux channel is set for beep or beep sequence how many satellites has found if GPS enabled
BEEPER_DISARM_REPEAT, 		**1024**	Beeps sounded while stick held in disarm position
BEEPER_ACC_CALIBRATION,		**2048**	ACC inflight calibration completed confirmation
BEEPER_ACC_CALIBRATION_FAIL	**4096**	ACC inflight calibration failed
BEEPER_READY_BEEP,			**8192**	Ring a tone when GPS is locked and ready
BEEPER_MULTI_BEEPS, 			**16384**	Internal value used by 'beeperConfirmationBeeps()'
BEEPER_ARMED, 			**32768**	Warning beeps when board is armed (repeats until board is disarmed or throttle is increased)

