### PR TITLE
Update buzzer.md with tone sequences

### DIFF
--- a/docs/Buzzer.md
+++ b/docs/Buzzer.md
@@ -18,23 +18,38 @@ There is a special arming tone used if a GPS fix has been attained, and there's 
 
 The CLI command `play_sound` is useful for demonstrating the buzzer tones. Repeatedly entering the command will play the various tones in turn. Entering the command with a numeric-index parameter will play the associated tone.
 
-Available buzzer tones include the following:
-
-    RX_LOST_LANDING       Beeps SOS when armed and TX is turned off or signal lost (autolanding/autodisarm)
-    RX_LOST               Beeps when TX is turned off or signal lost (repeat until TX is okay)
-    DISARMING             Beep when disarming the board
-    ARMING                Beep when arming the board
-    ARMING_GPS_FIX        Beep a special tone when arming the board and GPS has fix
-    BAT_CRIT_LOW          Longer warning beeps when battery is critically low (repeats)
-    BAT_LOW               Warning beeps when battery is getting low (repeats)
-    RX_SET                Beeps when aux channel is set for beep or beep sequence how many satellites has found if GPS enabled
-    DISARM_REPEAT         Beeps sounded while stick held in disarm position
-    ACC_CALIBRATION       ACC inflight calibration completed confirmation
-    ACC_CALIBRATION_FAIL  ACC inflight calibration failed
-    READY_BEEP            Ring a tone when GPS is locked and ready
-    ARMED                 Warning beeps when board is armed (repeats until board is disarmed or throttle is increased)
-
 Buzzer is enabled by default on platforms that have buzzer connections.
+
+## Tone sequences
+
+Buzzer tone sequences (square wave generation) are made so that : 1st, 3rd, 5th, .. are the delays how long the beeper is on and 2nd, 4th, 6th, .. are the delays how long beeper is off. Delays are in milliseconds/10 (i.e., 5 => 50ms).
+
+Sequences available in Cleanflight v1.10 are :
+
+    Gyro calibrated            20, 10, 20, 10, 20, 10
+    RX lost landing            beeps SOS
+    TX off or signal lost      50, 50	 (repeats until TX is okay)
+    Disarming the board        15, 5, 15, 5
+    Arming the board           30, 5, 5, 5
+    Arming and GPS has fix     5, 5, 15, 5, 5, 5, 15, 30
+    Battery is critically low  50, 2	(repeats)
+    Battery is getting low     25, 50	 (repeats) 
+    GPS status                 multi beeps	(sat count)
+    RX set                     short beep	(when aux channel is set for beep or beep sequence how many satellites has found if GPS enabled)
+    ACC inflight calibration completed    two short beeps
+    ACC inflight calibration failed       two longer beeps
+    GPS locked and copter ready           4, 5, 4, 5, 8, 5, 15, 5, 8, 5, 4, 5, 4, 5
+    Multi beeps                           variable # of beeps	(confirmation, GPS sat count, etc)
+    Stick held in disarm position         0, 100, 10	(after pause)
+    Board is armed                        0, 245, 10, 5	(after pause ; repeats until board is disarmed or throttle is increased)
+
+with
+
+    SOS morse code      10, 10, 10, 10, 10, 40, 40, 10, 40, 10, 40, 40, 10, 10, 10, 10, 10, 70
+    Short fast beep     10, 10
+    Two short beeps     5, 5, 5, 5
+    Two longer beeps    20, 15, 35, 5
+
 
 ## Types of buzzer supported
 

--- a/docs/Buzzer.md
+++ b/docs/Buzzer.md
@@ -16,7 +16,7 @@ Three beeps immediately after powering the board means that the gyroscope calibr
 
 There is a special arming tone used if a GPS fix has been attained, and there's a "ready" tone sounded after a GPS fix has been attained (only happens once).  The tone sounded via the TX-AUX-switch will count out the number of satellites (if GPS fix).
 
-The CLI command `play_sound` is useful for demonstrating the buzzer tones. Repeatedly entering the command will play the various tones in turn. Entering the command with a numeric-index parameter will play the associated tone.
+The CLI command `play_sound` is useful for demonstrating the buzzer tones. Repeatedly entering the command will play the various tones in turn. Entering the command with a numeric-index parameter (see below) will play the associated tone.
 
 Buzzer is enabled by default on platforms that have buzzer connections.
 
@@ -24,31 +24,24 @@ Buzzer is enabled by default on platforms that have buzzer connections.
 
 Buzzer tone sequences (square wave generation) are made so that : 1st, 3rd, 5th, .. are the delays how long the beeper is on and 2nd, 4th, 6th, .. are the delays how long beeper is off. Delays are in milliseconds/10 (i.e., 5 => 50ms).
 
-Sequences available in Cleanflight v1.10 are :
+Sequences available in Cleanflight v1.9 and above are :
 
-    Gyro calibrated            20, 10, 20, 10, 20, 10
-    RX lost landing            beeps SOS
-    TX off or signal lost      50, 50	 (repeats until TX is okay)
-    Disarming the board        15, 5, 15, 5
-    Arming the board           30, 5, 5, 5
-    Arming and GPS has fix     5, 5, 15, 5, 5, 5, 15, 30
-    Battery is critically low  50, 2	(repeats)
-    Battery is getting low     25, 50	 (repeats) 
-    GPS status                 multi beeps	(sat count)
-    RX set                     short beep	(when aux channel is set for beep or beep sequence how many satellites has found if GPS enabled)
-    ACC inflight calibration completed    two short beeps
-    ACC inflight calibration failed       two longer beeps
-    GPS locked and copter ready           4, 5, 4, 5, 8, 5, 15, 5, 8, 5, 4, 5, 4, 5
-    Multi beeps                           variable # of beeps	(confirmation, GPS sat count, etc)
-    Stick held in disarm position         0, 100, 10	(after pause)
-    Board is armed                        0, 245, 10, 5	(after pause ; repeats until board is disarmed or throttle is increased)
-
-with
-
-    SOS morse code      10, 10, 10, 10, 10, 40, 40, 10, 40, 10, 40, 40, 10, 10, 10, 10, 10, 70
-    Short fast beep     10, 10
-    Two short beeps     5, 5, 5, 5
-    Two longer beeps    20, 15, 35, 5
+    0    GYRO_CALIBRATED       20, 10, 20, 10, 20, 10	Gyro is calibrated
+    1    RX_LOST_LANDING       10, 10, 10, 10, 10, 40, 40, 10, 40, 10, 40, 40, 10, 10, 10, 10, 10, 70    SOS morse code
+    2    RX_LOST               50, 50		TX off or signal lost (repeats until TX is okay)
+    3    DISARMING             15, 5, 15, 5		Disarming the board
+    4    ARMING                30, 5, 5, 5		Arming the board
+    5    ARMING_GPS_FIX        5, 5, 15, 5, 5, 5, 15, 30	Arming and GPS has fix
+    6    BAT_CRIT_LOW          50, 2		Battery is critically low (repeats)
+    7    BAT_LOW               25, 50		Battery is getting low (repeats) 
+    8    NULL                  multi beeps		GPS status (sat count)
+    9    RX_SET                10, 10		RX is set (when aux channel is set for beep or beep sequence how many satellites has found if GPS enabled)
+    10   ACC_CALIBRATION       5, 5, 5, 5		ACC inflight calibration completed
+    11   ACC_CALIBRATION_FAIL  20, 15, 35, 5	ACC inflight calibration failed
+    12   READY_BEEP            4, 5, 4, 5, 8, 5, 15, 5, 8, 5, 4, 5, 4, 5	GPS locked and copter ready   
+    13   NULL                  multi beeps		Variable # of beeps (confirmation, GPS sat count, etc)
+    14   DISARM_REPEAT         0, 100, 10		Stick held in disarm position (after pause)
+    15   ARMED                 0, 245, 10, 5	Board is armed (after pause ; repeats until board is disarmed or throttle is increased)
 
 
 ## Types of buzzer supported
@@ -64,6 +57,7 @@ Examples of a known-working buzzers.
  * [5V Electromagnetic Active Buzzer Continuous Beep](http://www.banggood.com/10Pcs-5V-Electromagnetic-Active-Buzzer-Continuous-Beep-Continuously-p-943524.html)
  * [Radio Shack Model: 273-074 PC-BOARD 12VDC (3-16v) 70DB PIEZO BUZZER](http://www.radioshack.com/pc-board-12vdc-70db-piezo-buzzer/2730074.html#.VIAtpzHF_Si)
  * [MultiComp MCKPX-G1205A-3700 TRANSDUCER, THRU-HOLE, 4V, 30MA](http://uk.farnell.com/multicomp/mckpx-g1205a-3700/transducer-thru-hole-4v-30ma/dp/2135914?CMP=i-bf9f-00001000)
+ * [3-24V Piezo Electronic Tone Buzzer Alarm 95DB](http://www.banggood.com/3-24V-Piezo-Electronic-Tone-Buzzer-Alarm-95DB-Continuous-Sound-p-919348.html)
 
 ## Connections
 


### PR DESCRIPTION
Added description of tone sequences in document buzzer.md (issues #711 , #1096 , #1271).
As used in *io/beeper.c*.