### PR TITLE
BMP280 barometer support with unittests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -298,6 +298,7 @@ NAZE_SRC	 = startup_stm32f10x_md_gcc.S \
 		   drivers/adc.c \
 		   drivers/adc_stm32f10x.c \
 		   drivers/barometer_bmp085.c \
+		   drivers/barometer_bmp280.c \
 		   drivers/barometer_ms5611.c \
 		   drivers/bus_spi.c \
 		   drivers/bus_i2c_stm32f10x.c \
@@ -339,6 +340,7 @@ EUSTM32F103RC_SRC	 = startup_stm32f10x_hd_gcc.S \
 		   drivers/adc.c \
 		   drivers/adc_stm32f10x.c \
 		   drivers/barometer_bmp085.c \
+		   drivers/barometer_bmp280.c \
 		   drivers/barometer_ms5611.c \
 		   drivers/bus_i2c_stm32f10x.c \
 		   drivers/bus_spi.c \
@@ -373,6 +375,7 @@ OLIMEXINO_SRC	 = startup_stm32f10x_md_gcc.S \
 		   drivers/adc.c \
 		   drivers/adc_stm32f10x.c \
 		   drivers/barometer_bmp085.c \
+		   drivers/barometer_bmp280.c \
 		   drivers/bus_i2c_stm32f10x.c \
 		   drivers/bus_spi.c \
 		   drivers/compass_hmc5883l.c \
@@ -433,6 +436,7 @@ CC3D_SRC	 = \
 		   drivers/adc.c \
 		   drivers/adc_stm32f10x.c \
 		   drivers/barometer_bmp085.c \
+		   drivers/barometer_bmp280.c \
 		   drivers/barometer_ms5611.c \
 		   drivers/bus_spi.c \
 		   drivers/bus_i2c_stm32f10x.c \
@@ -503,6 +507,7 @@ STM32F3DISCOVERY_SRC	 = \
 		   drivers/accgyro_mpu6050.c \
 		   drivers/accgyro_l3g4200d.c \
 		   drivers/barometer_ms5611.c \
+		   drivers/barometer_bmp280.c \
 		   drivers/compass_ak8975.c \
 		   $(HIGHEND_SRC) \
 		   $(COMMON_SRC)
@@ -529,6 +534,7 @@ SPARKY_SRC	 = \
 		   drivers/display_ug2864hsweg01.c \
 		   drivers/accgyro_mpu6050.c \
 		   drivers/barometer_ms5611.c \
+		   drivers/barometer_bmp280.c \
 		   drivers/compass_ak8975.c \
 		   drivers/serial_usb_vcp.c \
 		   $(HIGHEND_SRC) \
@@ -541,6 +547,7 @@ SPRACINGF3_SRC	 = \
 		   $(STM32F30x_COMMON_SRC) \
 		   drivers/accgyro_mpu6050.c \
 		   drivers/barometer_ms5611.c \
+		   drivers/barometer_bmp280.c \
 		   drivers/compass_ak8975.c \
 		   drivers/compass_hmc5883l.c \
 		   drivers/display_ug2864hsweg01.h \

--- a/src/main/drivers/barometer_bmp280.c
+++ b/src/main/drivers/barometer_bmp280.c
@@ -1,0 +1,212 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <platform.h>
+
+#include "build_config.h"
+
+#include "barometer.h"
+
+#include "system.h"
+#include "bus_i2c.h"
+
+#include "barometer_bmp280.h"
+
+#ifdef BARO
+
+// BMP280, address 0x76
+
+#define BMP280_I2C_ADDR                      (0x76)
+#define BMP280_DEFAULT_CHIP_ID               (0x58)
+
+#define BMP280_CHIP_ID_REG                   (0xD0)  /* Chip ID Register */
+#define BMP280_RST_REG                       (0xE0)  /* Softreset Register */
+#define BMP280_STAT_REG                      (0xF3)  /* Status Register */
+#define BMP280_CTRL_MEAS_REG                 (0xF4)  /* Ctrl Measure Register */
+#define BMP280_CONFIG_REG                    (0xF5)  /* Configuration Register */
+#define BMP280_PRESSURE_MSB_REG              (0xF7)  /* Pressure MSB Register */
+#define BMP280_PRESSURE_LSB_REG              (0xF8)  /* Pressure LSB Register */
+#define BMP280_PRESSURE_XLSB_REG             (0xF9)  /* Pressure XLSB Register */
+#define BMP280_TEMPERATURE_MSB_REG           (0xFA)  /* Temperature MSB Reg */
+#define BMP280_TEMPERATURE_LSB_REG           (0xFB)  /* Temperature LSB Reg */
+#define BMP280_TEMPERATURE_XLSB_REG          (0xFC)  /* Temperature XLSB Reg */
+#define BMP280_FORCED_MODE                   (0x01)
+
+#define BMP280_TEMPERATURE_CALIB_DIG_T1_LSB_REG             (0x88)
+#define BMP280_PRESSURE_TEMPERATURE_CALIB_DATA_LENGTH       (24)
+#define BMP280_DATA_FRAME_SIZE               (6)
+
+#define BMP280_OVERSAMP_SKIPPED          (0x00)
+#define BMP280_OVERSAMP_1X               (0x01)
+#define BMP280_OVERSAMP_2X               (0x02)
+#define BMP280_OVERSAMP_4X               (0x03)
+#define BMP280_OVERSAMP_8X               (0x04)
+#define BMP280_OVERSAMP_16X              (0x05)
+
+// configure pressure and temperature oversampling, forced sampling mode
+#define BMP280_PRESSURE_OSR              (BMP280_OVERSAMP_8X)
+#define BMP280_TEMPERATURE_OSR           (BMP280_OVERSAMP_1X)
+#define BMP280_MODE                      (BMP280_PRESSURE_OSR << 2 | BMP280_TEMPERATURE_OSR << 5 | BMP280_FORCED_MODE)
+
+#define T_INIT_MAX                       (20)
+// 20/16 = 1.25 ms
+#define T_MEASURE_PER_OSRS_MAX           (37)
+// 37/16 = 2.3125 ms
+#define T_SETUP_PRESSURE_MAX             (10)
+// 10/16 = 0.625 ms
+
+typedef struct bmp280_calib_param_t {
+    uint16_t dig_T1; /* calibration T1 data */
+    int16_t dig_T2; /* calibration T2 data */
+    int16_t dig_T3; /* calibration T3 data */
+    uint16_t dig_P1; /* calibration P1 data */
+    int16_t dig_P2; /* calibration P2 data */
+    int16_t dig_P3; /* calibration P3 data */
+    int16_t dig_P4; /* calibration P4 data */
+    int16_t dig_P5; /* calibration P5 data */
+    int16_t dig_P6; /* calibration P6 data */
+    int16_t dig_P7; /* calibration P7 data */
+    int16_t dig_P8; /* calibration P8 data */
+    int16_t dig_P9; /* calibration P9 data */
+    int32_t t_fine; /* calibration t_fine data */
+} bmp280_calib_param_t;
+
+static uint8_t bmp280_chip_id = 0;
+static bool bmp280InitDone = false;
+static bmp280_calib_param_t bmp280_cal;
+// uncompensated pressure and temperature
+static int32_t bmp280_up = 0;
+static int32_t bmp280_ut = 0;
+
+static void bmp280_start_ut(void);
+static void bmp280_get_ut(void);
+static void bmp280_start_up(void);
+static void bmp280_get_up(void);
+static void bmp280_calculate(int32_t *pressure, int32_t *temperature);
+
+bool bmp280Detect(baro_t *baro)
+{
+    if (bmp280InitDone)
+        return true;
+
+    delay(20);
+
+    i2cRead(BMP280_I2C_ADDR, BMP280_CHIP_ID_REG, 1, &bmp280_chip_id);  /* read Chip Id */
+    if (bmp280_chip_id != BMP280_DEFAULT_CHIP_ID)
+        return false;
+
+    // read calibration
+    i2cRead(BMP280_I2C_ADDR, BMP280_TEMPERATURE_CALIB_DIG_T1_LSB_REG, 24, (uint8_t *)&bmp280_cal);
+    // set oversampling + power mode (forced), and start sampling
+    i2cWrite(BMP280_I2C_ADDR, BMP280_CTRL_MEAS_REG, BMP280_MODE);
+
+    bmp280InitDone = true;
+
+    // these are dummy as temperature is measured as part of pressure
+    baro->ut_delay = 0;
+    baro->get_ut = bmp280_get_ut;
+    baro->start_ut = bmp280_start_ut;
+
+    // only _up part is executed, and gets both temperature and pressure
+    baro->up_delay = ((T_INIT_MAX + T_MEASURE_PER_OSRS_MAX * (((1 << BMP280_TEMPERATURE_OSR) >> 1) + ((1 << BMP280_PRESSURE_OSR) >> 1)) + (BMP280_PRESSURE_OSR ? T_SETUP_PRESSURE_MAX : 0) + 15) / 16) * 1000;
+    baro->start_up = bmp280_start_up;
+    baro->get_up = bmp280_get_up;
+    baro->calculate = bmp280_calculate;
+
+    return true;
+}
+
+static void bmp280_start_ut(void)
+{
+    // dummy
+}
+
+static void bmp280_get_ut(void)
+{
+    // dummy
+}
+
+static void bmp280_start_up(void)
+{
+    // start measurement
+    // set oversampling + power mode (forced), and start sampling
+    i2cWrite(BMP280_I2C_ADDR, BMP280_CTRL_MEAS_REG, BMP280_MODE);
+}
+
+static void bmp280_get_up(void)
+{
+    uint8_t data[BMP280_DATA_FRAME_SIZE];
+
+    // read data from sensor
+    i2cRead(BMP280_I2C_ADDR, BMP280_PRESSURE_MSB_REG, BMP280_DATA_FRAME_SIZE, data);
+    bmp280_up = (int32_t)((((uint32_t)(data[0])) << 12) | (((uint32_t)(data[1])) << 4) | ((uint32_t)data[2] >> 4));
+    bmp280_ut = (int32_t)((((uint32_t)(data[3])) << 12) | (((uint32_t)(data[4])) << 4) | ((uint32_t)data[5] >> 4));
+}
+
+// Returns temperature in DegC, float precision. Output value of “51.23” equals 51.23 DegC.
+// t_fine carries fine temperature as global value
+float bmp280_compensate_T(int32_t adc_T)
+{
+    float var1, var2, T;
+
+    var1 = (((float)adc_T) / 16384.0f - ((float)bmp280_cal.dig_T1) / 1024.0f) * ((float)bmp280_cal.dig_T2);
+    var2 = ((((float)adc_T) / 131072.0f - ((float)bmp280_cal.dig_T1) / 8192.0f) * (((float)adc_T) / 131072.0f - ((float)bmp280_cal.dig_T1) / 8192.0f)) * ((float)bmp280_cal.dig_T3);
+    bmp280_cal.t_fine = (int32_t)(var1 + var2);
+    T = (var1 + var2) / 5120.0f;
+
+    return T;
+}
+
+// Returns pressure in Pa as float. Output value of “96386.2” equals 96386.2 Pa = 963.862 hPa
+float bmp280_compensate_P(int32_t adc_P)
+{
+    float var1, var2, p;
+    var1 = ((float)bmp280_cal.t_fine / 2.0f) - 64000.0f;
+    var2 = var1 * var1 * ((float)bmp280_cal.dig_P6) / 32768.0f;
+    var2 = var2 + var1 * ((float)bmp280_cal.dig_P5) * 2.0f;
+    var2 = (var2 / 4.0f) + (((float)bmp280_cal.dig_P4) * 65536.0f);
+    var1 = (((float)bmp280_cal.dig_P3) * var1 * var1 / 524288.0f + ((float)bmp280_cal.dig_P2) * var1) / 524288.0f;
+    var1 = (1.0f + var1 / 32768.0f) * ((float)bmp280_cal.dig_P1);
+    if (var1 == 0.0f)
+        return 0.0f; // avoid exception caused by division by zero
+
+    p = 1048576.0f - (float)adc_P;
+    p = (p - (var2 / 4096.0f)) * 6250.0f / var1;
+    var1 = ((float)bmp280_cal.dig_P9) * p * p / 2147483648.0f;
+    var2 = p * ((float)bmp280_cal.dig_P8) / 32768.0f;
+    p = p + (var1 + var2 + ((float)bmp280_cal.dig_P7)) / 16.0f;
+
+    return p;
+}
+
+static void bmp280_calculate(int32_t *pressure, int32_t *temperature)
+{
+    // calculate
+    float t, p;
+    t = bmp280_compensate_T(bmp280_ut);
+    p = bmp280_compensate_P(bmp280_up);
+
+    if (pressure)
+        *pressure = (int32_t)p;
+    if (temperature)
+        *temperature = (int32_t)t * 100;
+}
+
+#endif

--- a/src/main/drivers/barometer_bmp280.c
+++ b/src/main/drivers/barometer_bmp280.c
@@ -206,7 +206,7 @@ STATIC_UNIT_TESTED void bmp280_calculate(int32_t *pressure, int32_t *temperature
     if (pressure)
         *pressure = (int32_t)p;
     if (temperature)
-        *temperature = (int32_t)t * 100;
+        *temperature = (int32_t)(t * 100);
 }
 
 #endif

--- a/src/main/drivers/barometer_bmp280.c
+++ b/src/main/drivers/barometer_bmp280.c
@@ -90,16 +90,16 @@ typedef struct bmp280_calib_param_t {
 
 static uint8_t bmp280_chip_id = 0;
 static bool bmp280InitDone = false;
-static bmp280_calib_param_t bmp280_cal;
+STATIC_UNIT_TESTED bmp280_calib_param_t bmp280_cal;
 // uncompensated pressure and temperature
-static int32_t bmp280_up = 0;
-static int32_t bmp280_ut = 0;
+STATIC_UNIT_TESTED int32_t bmp280_up = 0;
+STATIC_UNIT_TESTED int32_t bmp280_ut = 0;
 
 static void bmp280_start_ut(void);
 static void bmp280_get_ut(void);
 static void bmp280_start_up(void);
 static void bmp280_get_up(void);
-static void bmp280_calculate(int32_t *pressure, int32_t *temperature);
+STATIC_UNIT_TESTED void bmp280_calculate(int32_t *pressure, int32_t *temperature);
 
 bool bmp280Detect(baro_t *baro)
 {
@@ -160,9 +160,9 @@ static void bmp280_get_up(void)
     bmp280_ut = (int32_t)((((uint32_t)(data[3])) << 12) | (((uint32_t)(data[4])) << 4) | ((uint32_t)data[5] >> 4));
 }
 
-// Returns temperature in DegC, float precision. Output value of “51.23” equals 51.23 DegC.
+// Returns temperature in DegC, float precision. Output value of "51.23" equals 51.23 DegC.
 // t_fine carries fine temperature as global value
-float bmp280_compensate_T(int32_t adc_T)
+static float bmp280_compensate_T(int32_t adc_T)
 {
     float var1, var2, T;
 
@@ -174,8 +174,8 @@ float bmp280_compensate_T(int32_t adc_T)
     return T;
 }
 
-// Returns pressure in Pa as float. Output value of “96386.2” equals 96386.2 Pa = 963.862 hPa
-float bmp280_compensate_P(int32_t adc_P)
+// Returns pressure in Pa as float. Output value of "96386.2" equals 96386.2 Pa = 963.862 hPa
+static float bmp280_compensate_P(int32_t adc_P)
 {
     float var1, var2, p;
     var1 = ((float)bmp280_cal.t_fine / 2.0f) - 64000.0f;
@@ -196,7 +196,7 @@ float bmp280_compensate_P(int32_t adc_P)
     return p;
 }
 
-static void bmp280_calculate(int32_t *pressure, int32_t *temperature)
+STATIC_UNIT_TESTED void bmp280_calculate(int32_t *pressure, int32_t *temperature)
 {
     // calculate
     float t, p;

--- a/src/main/drivers/barometer_bmp280.c
+++ b/src/main/drivers/barometer_bmp280.c
@@ -160,53 +160,53 @@ static void bmp280_get_up(void)
     bmp280_ut = (int32_t)((((uint32_t)(data[3])) << 12) | (((uint32_t)(data[4])) << 4) | ((uint32_t)data[5] >> 4));
 }
 
-// Returns temperature in DegC, float precision. Output value of "51.23" equals 51.23 DegC.
+// Returns temperature in DegC, resolution is 0.01 DegC. Output value of "5123" equals 51.23 DegC
 // t_fine carries fine temperature as global value
-static float bmp280_compensate_T(int32_t adc_T)
+static int32_t bmp280_compensate_T(int32_t adc_T)
 {
-    float var1, var2, T;
+    int32_t var1, var2, T;
 
-    var1 = (((float)adc_T) / 16384.0f - ((float)bmp280_cal.dig_T1) / 1024.0f) * ((float)bmp280_cal.dig_T2);
-    var2 = ((((float)adc_T) / 131072.0f - ((float)bmp280_cal.dig_T1) / 8192.0f) * (((float)adc_T) / 131072.0f - ((float)bmp280_cal.dig_T1) / 8192.0f)) * ((float)bmp280_cal.dig_T3);
-    bmp280_cal.t_fine = (int32_t)(var1 + var2);
-    T = (var1 + var2) / 5120.0f;
+    var1 = ((((adc_T >> 3) - ((int32_t)bmp280_cal.dig_T1 << 1))) * ((int32_t)bmp280_cal.dig_T2)) >> 11;
+    var2  = (((((adc_T >> 4) - ((int32_t)bmp280_cal.dig_T1)) * ((adc_T >> 4) - ((int32_t)bmp280_cal.dig_T1))) >> 12) * ((int32_t)bmp280_cal.dig_T3)) >> 14;
+    bmp280_cal.t_fine = var1 + var2;
+    T = (bmp280_cal.t_fine * 5 + 128) >> 8;
 
     return T;
 }
 
-// Returns pressure in Pa as float. Output value of "96386.2" equals 96386.2 Pa = 963.862 hPa
-static float bmp280_compensate_P(int32_t adc_P)
+// Returns pressure in Pa as unsigned 32 bit integer in Q24.8 format (24 integer bits and 8 fractional bits).
+// Output value of "24674867" represents 24674867/256 = 96386.2 Pa = 963.862 hPa
+static uint32_t bmp280_compensate_P(int32_t adc_P)
 {
-    float var1, var2, p;
-    var1 = ((float)bmp280_cal.t_fine / 2.0f) - 64000.0f;
-    var2 = var1 * var1 * ((float)bmp280_cal.dig_P6) / 32768.0f;
-    var2 = var2 + var1 * ((float)bmp280_cal.dig_P5) * 2.0f;
-    var2 = (var2 / 4.0f) + (((float)bmp280_cal.dig_P4) * 65536.0f);
-    var1 = (((float)bmp280_cal.dig_P3) * var1 * var1 / 524288.0f + ((float)bmp280_cal.dig_P2) * var1) / 524288.0f;
-    var1 = (1.0f + var1 / 32768.0f) * ((float)bmp280_cal.dig_P1);
-    if (var1 == 0.0f)
-        return 0.0f; // avoid exception caused by division by zero
-
-    p = 1048576.0f - (float)adc_P;
-    p = (p - (var2 / 4096.0f)) * 6250.0f / var1;
-    var1 = ((float)bmp280_cal.dig_P9) * p * p / 2147483648.0f;
-    var2 = p * ((float)bmp280_cal.dig_P8) / 32768.0f;
-    p = p + (var1 + var2 + ((float)bmp280_cal.dig_P7)) / 16.0f;
-
-    return p;
+    int64_t var1, var2, p;
+    var1 = ((int64_t)bmp280_cal.t_fine) - 128000;
+    var2 = var1 * var1 * (int64_t)bmp280_cal.dig_P6;
+    var2 = var2 + ((var1*(int64_t)bmp280_cal.dig_P5) << 17);
+    var2 = var2 + (((int64_t)bmp280_cal.dig_P4) << 35);
+    var1 = ((var1 * var1 * (int64_t)bmp280_cal.dig_P3) >> 8) + ((var1 * (int64_t)bmp280_cal.dig_P2) << 12);
+    var1 = (((((int64_t)1) << 47) + var1)) * ((int64_t)bmp280_cal.dig_P1) >> 33;
+    if (var1 == 0)
+        return 0;
+    p = 1048576 - adc_P;
+    p = (((p << 31) - var2) * 3125) / var1;
+    var1 = (((int64_t)bmp280_cal.dig_P9) * (p >> 13) * (p >> 13)) >> 25;
+    var2 = (((int64_t)bmp280_cal.dig_P8) * p) >> 19;
+    p = ((p + var1 + var2) >> 8) + (((int64_t)bmp280_cal.dig_P7) << 4);
+    return (uint32_t)p;
 }
 
 STATIC_UNIT_TESTED void bmp280_calculate(int32_t *pressure, int32_t *temperature)
 {
     // calculate
-    float t, p;
+    int32_t t;
+    uint32_t p;
     t = bmp280_compensate_T(bmp280_ut);
     p = bmp280_compensate_P(bmp280_up);
 
     if (pressure)
-        *pressure = (int32_t)p;
+        *pressure = (int32_t)(p / 256);
     if (temperature)
-        *temperature = (int32_t)(t * 100);
+        *temperature = t;
 }
 
 #endif

--- a/src/main/drivers/barometer_bmp280.h
+++ b/src/main/drivers/barometer_bmp280.h
@@ -1,0 +1,21 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+bool bmp280Detect(baro_t *baro);
+

--- a/src/main/sensors/barometer.h
+++ b/src/main/sensors/barometer.h
@@ -21,7 +21,8 @@ typedef enum {
     BARO_DEFAULT = 0,
     BARO_NONE = 1,
     BARO_BMP085 = 2,
-    BARO_MS5611 = 3
+    BARO_MS5611 = 3,
+    BARO_BMP280 = 4
 } baroSensor_e;
 
 #define BARO_SAMPLE_COUNT_MAX   48

--- a/src/main/sensors/initialisation.c
+++ b/src/main/sensors/initialisation.c
@@ -42,6 +42,7 @@
 
 #include "drivers/barometer.h"
 #include "drivers/barometer_bmp085.h"
+#include "drivers/barometer_bmp280.h"
 #include "drivers/barometer_ms5611.h"
 
 #include "drivers/compass.h"
@@ -457,6 +458,14 @@ static void detectBaro(baroSensor_e baroHardwareToUse)
 #ifdef USE_BARO_BMP085
             if (bmp085Detect(bmp085Config, &baro)) {
                 baroHardware = BARO_BMP085;
+                break;
+            }
+#endif
+	    ; // fallthough
+        case BARO_BMP280:
+#ifdef USE_BARO_BMP280
+            if (bmp280Detect(&baro)) {
+                baroHardware = BARO_BMP280;
                 break;
             }
 #endif

--- a/src/main/target/CC3D/target.h
+++ b/src/main/target/CC3D/target.h
@@ -58,6 +58,7 @@
 #define BARO
 #define USE_BARO_MS5611
 #define USE_BARO_BMP085
+#define USE_BARO_BMP280
 
 // External I2C MAG
 #define MAG

--- a/src/main/target/CHEBUZZF3/target.h
+++ b/src/main/target/CHEBUZZF3/target.h
@@ -58,6 +58,7 @@
 
 #define BARO
 #define USE_BARO_MS5611
+#define USE_BARO_BMP280
 
 #define MAG
 #define USE_MAG_AK8975

--- a/src/main/target/EUSTM32F103RC/target.h
+++ b/src/main/target/EUSTM32F103RC/target.h
@@ -65,6 +65,7 @@
 #define BARO
 #define USE_BARO_MS5611
 #define USE_BARO_BMP085
+#define USE_BARO_BMP280
 
 #define MAG
 #define USE_MAG_HMC5883

--- a/src/main/target/NAZE/target.h
+++ b/src/main/target/NAZE/target.h
@@ -107,6 +107,7 @@
 #define BARO
 #define USE_BARO_MS5611
 #define USE_BARO_BMP085
+#define USE_BARO_BMP280
 
 #define MAG
 #define USE_MAG_HMC5883

--- a/src/main/target/OLIMEXINO/target.h
+++ b/src/main/target/OLIMEXINO/target.h
@@ -59,6 +59,7 @@
 #define BARO
 //#define USE_BARO_MS5611
 #define USE_BARO_BMP085
+#define USE_BARO_BMP280
 
 #define MAG
 #define USE_MAG_HMC5883

--- a/src/main/target/PORT103R/target.h
+++ b/src/main/target/PORT103R/target.h
@@ -88,6 +88,7 @@
 #define BARO
 #define USE_BARO_MS5611
 #define USE_BARO_BMP085
+#define USE_BARO_BMP280
 
 #define MAG
 #define USE_MAG_HMC5883

--- a/src/main/target/SPARKY/target.h
+++ b/src/main/target/SPARKY/target.h
@@ -41,6 +41,7 @@
 
 #define BARO
 #define USE_BARO_MS5611
+#define USE_BARO_BMP280
 
 #define MAG
 #define USE_MAG_AK8975

--- a/src/main/target/SPRACINGF3/target.h
+++ b/src/main/target/SPRACINGF3/target.h
@@ -49,6 +49,7 @@
 
 #define BARO
 #define USE_BARO_MS5611
+#define USE_BARO_BMP280
 
 #define MAG
 #define USE_MAG_AK8975

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -512,6 +512,29 @@ $(OBJECT_DIR)/baro_bmp085_unittest : \
 
 	$(CXX) $(CXX_FLAGS) $^ -o $(OBJECT_DIR)/$@
 
+$(OBJECT_DIR)/drivers/barometer_bmp280.o : \
+    $(USER_DIR)/drivers/barometer_bmp280.c \
+    $(USER_DIR)/drivers/barometer_bmp280.h \
+    $(GTEST_HEADERS)
+
+	@mkdir -p $(dir $@)
+	$(CC) $(C_FLAGS) $(TEST_CFLAGS) -c $(USER_DIR)/drivers/barometer_bmp280.c -o $@
+
+$(OBJECT_DIR)/baro_bmp280_unittest.o : \
+	$(TEST_DIR)/baro_bmp280_unittest.cc \
+	$(USER_DIR)/drivers/barometer_bmp280.h \
+	$(GTEST_HEADERS)
+
+	@mkdir -p $(dir $@)
+	$(CXX) $(CXX_FLAGS) $(TEST_CFLAGS) -c $(TEST_DIR)/baro_bmp280_unittest.cc -o $@
+
+$(OBJECT_DIR)/baro_bmp280_unittest : \
+	$(OBJECT_DIR)/drivers/barometer_bmp280.o \
+	$(OBJECT_DIR)/baro_bmp280_unittest.o \
+	$(OBJECT_DIR)/gtest_main.a
+
+	$(CXX) $(CXX_FLAGS) $^ -o $(OBJECT_DIR)/$@
+
 $(OBJECT_DIR)/sensors/boardalignment.o : \
 	$(USER_DIR)/sensors/boardalignment.c \
 	$(USER_DIR)/sensors/boardalignment.h \

--- a/src/test/unit/baro_bmp280_unittest.cc
+++ b/src/test/unit/baro_bmp280_unittest.cc
@@ -73,7 +73,7 @@ TEST(baroBmp280Test, TestBmp280Calculate)
 
     // then
     EXPECT_EQ(100653, pressure); // 100653 Pa
-    EXPECT_EQ(2500, temperature); // 25.00 degC (data sheet says 25.08)
+    EXPECT_EQ(2508, temperature); // 25.08 degC
 
 }
 
@@ -104,7 +104,7 @@ TEST(baroBmp280Test, TestBmp280CalculateHighP)
 
     // then
     EXPECT_EQ(135382, pressure); // 135385 Pa
-    EXPECT_EQ(2500, temperature); // 25.00 degC (data sheet says 25.08)
+    EXPECT_EQ(2508, temperature); // 25.08 degC
 
 }
 
@@ -135,7 +135,7 @@ TEST(baroBmp280Test, TestBmp280CalculateZeroP)
 
     // then
     EXPECT_EQ(0, pressure); // P1=0 trips pressure to 0 Pa, avoiding division by zero
-    EXPECT_EQ(2500, temperature); // 25.00 degC (data sheet says 25.08)
+    EXPECT_EQ(2508, temperature); // 25.08 degC
 
 }
 

--- a/src/test/unit/baro_bmp280_unittest.cc
+++ b/src/test/unit/baro_bmp280_unittest.cc
@@ -1,0 +1,154 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <stdint.h>
+
+extern "C" {
+
+    void bmp280_calculate(int32_t *pressure, int32_t *temperature);
+    extern uint32_t bmp280_up;
+    extern uint32_t bmp280_ut;
+
+typedef struct bmp280_calib_param_t {
+    uint16_t dig_T1; /* calibration T1 data */
+    int16_t dig_T2; /* calibration T2 data */
+    int16_t dig_T3; /* calibration T3 data */
+    uint16_t dig_P1; /* calibration P1 data */
+    int16_t dig_P2; /* calibration P2 data */
+    int16_t dig_P3; /* calibration P3 data */
+    int16_t dig_P4; /* calibration P4 data */
+    int16_t dig_P5; /* calibration P5 data */
+    int16_t dig_P6; /* calibration P6 data */
+    int16_t dig_P7; /* calibration P7 data */
+    int16_t dig_P8; /* calibration P8 data */
+    int16_t dig_P9; /* calibration P9 data */
+    int32_t t_fine; /* calibration t_fine data */
+} bmp280_calib_param_t;
+
+    bmp280_calib_param_t bmp280_cal;
+}
+
+
+#include "unittest_macros.h"
+#include "gtest/gtest.h"
+
+
+TEST(baroBmp280Test, TestBmp280Calculate)
+{
+
+    // given
+    int32_t pressure, temperature;
+    bmp280_up = 415148; // Digital pressure value
+    bmp280_ut = 519888; // Digital temperature value
+
+    // and
+    bmp280_cal.dig_T1 = 27504;
+    bmp280_cal.dig_T2 = 26435;
+    bmp280_cal.dig_T3 = -1000;
+    bmp280_cal.dig_P1 = 36477;
+    bmp280_cal.dig_P2 = -10685;
+    bmp280_cal.dig_P3 = 3024;
+    bmp280_cal.dig_P4 = 2855;
+    bmp280_cal.dig_P5 = 140;
+    bmp280_cal.dig_P6 = -7;
+    bmp280_cal.dig_P7 = 15500;
+    bmp280_cal.dig_P8 = -14600;
+    bmp280_cal.dig_P9 = 6000;
+
+    // when
+    bmp280_calculate(&pressure, &temperature);
+
+    // then
+    EXPECT_EQ(100653, pressure); // 100653 Pa
+    EXPECT_EQ(2500, temperature); // 25.00 degC (data sheet says 25.08)
+
+}
+
+TEST(baroBmp280Test, TestBmp280CalculateHighP)
+{
+
+    // given
+    int32_t pressure, temperature;
+    bmp280_up = 215148; // Digital pressure value
+    bmp280_ut = 519888; // Digital temperature value
+
+    // and
+    bmp280_cal.dig_T1 = 27504;
+    bmp280_cal.dig_T2 = 26435;
+    bmp280_cal.dig_T3 = -1000;
+    bmp280_cal.dig_P1 = 36477;
+    bmp280_cal.dig_P2 = -10685;
+    bmp280_cal.dig_P3 = 3024;
+    bmp280_cal.dig_P4 = 2855;
+    bmp280_cal.dig_P5 = 140;
+    bmp280_cal.dig_P6 = -7;
+    bmp280_cal.dig_P7 = 15500;
+    bmp280_cal.dig_P8 = -14600;
+    bmp280_cal.dig_P9 = 6000;
+
+    // when
+    bmp280_calculate(&pressure, &temperature);
+
+    // then
+    EXPECT_EQ(135382, pressure); // 135385 Pa
+    EXPECT_EQ(2500, temperature); // 25.00 degC (data sheet says 25.08)
+
+}
+
+TEST(baroBmp280Test, TestBmp280CalculateZeroP)
+{
+
+    // given
+    int32_t pressure, temperature;
+    bmp280_up = 415148; // Digital pressure value
+    bmp280_ut = 519888; // Digital temperature value
+
+    // and
+    bmp280_cal.dig_T1 = 27504;
+    bmp280_cal.dig_T2 = 26435;
+    bmp280_cal.dig_T3 = -1000;
+    bmp280_cal.dig_P1 = 0;
+    bmp280_cal.dig_P2 = -10685;
+    bmp280_cal.dig_P3 = 3024;
+    bmp280_cal.dig_P4 = 2855;
+    bmp280_cal.dig_P5 = 140;
+    bmp280_cal.dig_P6 = -7;
+    bmp280_cal.dig_P7 = 15500;
+    bmp280_cal.dig_P8 = -14600;
+    bmp280_cal.dig_P9 = 6000;
+
+    // when
+    bmp280_calculate(&pressure, &temperature);
+
+    // then
+    EXPECT_EQ(0, pressure); // P1=0 trips pressure to 0 Pa, avoiding division by zero
+    EXPECT_EQ(2500, temperature); // 25.00 degC (data sheet says 25.08)
+
+}
+
+// STUBS
+
+extern "C" {
+
+    void delay(uint32_t) {}
+    bool i2cWrite(uint8_t, uint8_t, uint8_t) {
+        return 1;
+    }
+    bool i2cRead(uint8_t, uint8_t, uint8_t, uint8_t) {
+        return 1;
+    }
+
+}


### PR DESCRIPTION
This uses as a starting point the code from #975 (which is squashed into a single commit).

I have added unit tests to check the computation of the pressure and temperature against the reference values in the data sheet [1], fixing a casting bug along the way.

The last commit switches from the floating point to the fixed point algorithm for computing the temperature and pressure. Since we end up rounding to the nearest 0.01 C and 1 Pa, this is perfectly sufficient, letting us save the extra calculation (see data sheet section 3.11.1). I'm not sure if this is the best course of action, I'd be willing to drop this commit.

[1] http://ae-bst.resource.bosch.com/media/products/dokumente/bmp280/BST-BMP280-DS001-11.pdf

Closes #975