### PR TITLE
Added support for MS5607 barometer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -298,7 +298,7 @@ NAZE_SRC	 = startup_stm32f10x_md_gcc.S \
 		   drivers/adc.c \
 		   drivers/adc_stm32f10x.c \
 		   drivers/barometer_bmp085.c \
-		   drivers/barometer_ms5611.c \
+		   drivers/barometer_ms56xx.c \
 		   drivers/bus_spi.c \
 		   drivers/bus_i2c_stm32f10x.c \
 		   drivers/compass_hmc5883l.c \
@@ -339,7 +339,7 @@ EUSTM32F103RC_SRC	 = startup_stm32f10x_hd_gcc.S \
 		   drivers/adc.c \
 		   drivers/adc_stm32f10x.c \
 		   drivers/barometer_bmp085.c \
-		   drivers/barometer_ms5611.c \
+		   drivers/barometer_ms56xx.c \
 		   drivers/bus_i2c_stm32f10x.c \
 		   drivers/bus_spi.c \
 		   drivers/compass_ak8975.c \
@@ -433,7 +433,7 @@ CC3D_SRC	 = \
 		   drivers/adc.c \
 		   drivers/adc_stm32f10x.c \
 		   drivers/barometer_bmp085.c \
-		   drivers/barometer_ms5611.c \
+		   drivers/barometer_ms56xx.c \
 		   drivers/bus_spi.c \
 		   drivers/bus_i2c_stm32f10x.c \
 		   drivers/compass_hmc5883l.c \
@@ -502,7 +502,7 @@ STM32F3DISCOVERY_SRC	 = \
 		   drivers/accgyro_mpu3050.c \
 		   drivers/accgyro_mpu6050.c \
 		   drivers/accgyro_l3g4200d.c \
-		   drivers/barometer_ms5611.c \
+		   drivers/barometer_ms56xx.c \
 		   drivers/compass_ak8975.c \
 		   $(HIGHEND_SRC) \
 		   $(COMMON_SRC)
@@ -516,7 +516,7 @@ COLIBRI_RACE_SRC        = \
 		   $(STM32F30x_COMMON_SRC) \
 		   drivers/display_ug2864hsweg01.c \
 		   drivers/accgyro_spi_mpu6500.c \
-		   drivers/barometer_ms5611.c \
+		   drivers/barometer_ms56xx.c \
 		   drivers/compass_ak8975.c \
 		   drivers/compass_hmc5883l.c \
 		   drivers/serial_usb_vcp.c \
@@ -528,7 +528,7 @@ SPARKY_SRC	 = \
 		   $(STM32F30x_COMMON_SRC) \
 		   drivers/display_ug2864hsweg01.c \
 		   drivers/accgyro_mpu6050.c \
-		   drivers/barometer_ms5611.c \
+		   drivers/barometer_ms56xx.c \
 		   drivers/compass_ak8975.c \
 		   drivers/serial_usb_vcp.c \
 		   $(HIGHEND_SRC) \
@@ -540,7 +540,7 @@ ALIENWIIF3_SRC	 = $(SPARKY_SRC)
 SPRACINGF3_SRC	 = \
 		   $(STM32F30x_COMMON_SRC) \
 		   drivers/accgyro_mpu6050.c \
-		   drivers/barometer_ms5611.c \
+		   drivers/barometer_ms56xx.c \
 		   drivers/compass_ak8975.c \
 		   drivers/compass_hmc5883l.c \
 		   drivers/display_ug2864hsweg01.h \

--- a/src/main/drivers/barometer_ms56xx.c
+++ b/src/main/drivers/barometer_ms56xx.c
@@ -21,6 +21,7 @@
 #include <platform.h>
 
 #include "barometer.h"
+#include "sensors/barometer.h" // for baroSensor_e enum
 
 #include "gpio.h"
 #include "system.h"
@@ -28,8 +29,8 @@
 
 #include "build_config.h"
 
-// MS5611, Standard address 0x77
-#define MS5611_ADDR                 0x77
+// MS5611 and MS5607, Standard address 0x77
+#define MS56XX_ADDR             0x77
 
 #define CMD_RESET               0x1E // ADC reset command
 #define CMD_ADC_READ            0x00 // ADC read command
@@ -44,22 +45,23 @@
 #define CMD_PROM_RD             0xA0 // Prom read command
 #define PROM_NB                 8
 
-static void ms5611_reset(void);
-static uint16_t ms5611_prom(int8_t coef_num);
-STATIC_UNIT_TESTED int8_t ms5611_crc(uint16_t *prom);
-static uint32_t ms5611_read_adc(void);
-static void ms5611_start_ut(void);
-static void ms5611_get_ut(void);
-static void ms5611_start_up(void);
-static void ms5611_get_up(void);
+static void ms56xx_reset(void);
+static uint16_t ms56xx_prom(int8_t coef_num);
+STATIC_UNIT_TESTED int8_t ms56xx_crc(uint16_t *prom);
+static uint32_t ms56xx_read_adc(void);
+static void ms56xx_start_ut(void);
+static void ms56xx_get_ut(void);
+static void ms56xx_start_up(void);
+static void ms56xx_get_up(void);
 STATIC_UNIT_TESTED void ms5611_calculate(int32_t *pressure, int32_t *temperature);
+STATIC_UNIT_TESTED void ms5607_calculate(int32_t *pressure, int32_t *temperature);
 
-STATIC_UNIT_TESTED uint32_t ms5611_ut;  // static result of temperature measurement
-STATIC_UNIT_TESTED uint32_t ms5611_up;  // static result of pressure measurement
-STATIC_UNIT_TESTED uint16_t ms5611_c[PROM_NB];  // on-chip ROM
-static uint8_t ms5611_osr = CMD_ADC_4096;
+STATIC_UNIT_TESTED uint32_t ms56xx_ut;  // static result of temperature measurement
+STATIC_UNIT_TESTED uint32_t ms56xx_up;  // static result of pressure measurement
+STATIC_UNIT_TESTED uint16_t ms56xx_c[PROM_NB];  // on-chip ROM
+static uint8_t ms56xx_osr = CMD_ADC_4096;
 
-bool ms5611Detect(baro_t *baro)
+bool ms56xxDetect(baro_t *baro, baroSensor_e type)
 {
     bool ack = false;
     uint8_t sig;
@@ -67,44 +69,48 @@ bool ms5611Detect(baro_t *baro)
 
     delay(10); // No idea how long the chip takes to power-up, but let's make it 10ms
 
-    ack = i2cRead(MS5611_ADDR, CMD_PROM_RD, 1, &sig);
+    ack = i2cRead(MS56XX_ADDR, CMD_PROM_RD, 1, &sig);
     if (!ack)
         return false;
 
-    ms5611_reset();
+    ms56xx_reset();
     // read all coefficients
     for (i = 0; i < PROM_NB; i++)
-        ms5611_c[i] = ms5611_prom(i);
+        ms56xx_c[i] = ms56xx_prom(i);
     // check crc, bail out if wrong - we are probably talking to BMP085 w/o XCLR line!
-    if (ms5611_crc(ms5611_c) != 0)
+    if (ms56xx_crc(ms56xx_c) != 0)
         return false;
 
     // TODO prom + CRC
     baro->ut_delay = 10000;
     baro->up_delay = 10000;
-    baro->start_ut = ms5611_start_ut;
-    baro->get_ut = ms5611_get_ut;
-    baro->start_up = ms5611_start_up;
-    baro->get_up = ms5611_get_up;
-    baro->calculate = ms5611_calculate;
+    baro->start_ut = ms56xx_start_ut;
+    baro->get_ut = ms56xx_get_ut;
+    baro->start_up = ms56xx_start_up;
+    baro->get_up = ms56xx_get_up;
+    if (type == BARO_MS5607) {
+        baro->calculate = ms5607_calculate;
+    } else { // default to MS5611
+        baro->calculate = ms5611_calculate;
+    }
 
     return true;
 }
 
-static void ms5611_reset(void)
+static void ms56xx_reset(void)
 {
-    i2cWrite(MS5611_ADDR, CMD_RESET, 1);
+    i2cWrite(MS56XX_ADDR, CMD_RESET, 1);
     delayMicroseconds(2800);
 }
 
-static uint16_t ms5611_prom(int8_t coef_num)
+static uint16_t ms56xx_prom(int8_t coef_num)
 {
     uint8_t rxbuf[2] = { 0, 0 };
-    i2cRead(MS5611_ADDR, CMD_PROM_RD + coef_num * 2, 2, rxbuf); // send PROM READ command
+    i2cRead(MS56XX_ADDR, CMD_PROM_RD + coef_num * 2, 2, rxbuf); // send PROM READ command
     return rxbuf[0] << 8 | rxbuf[1];
 }
 
-STATIC_UNIT_TESTED int8_t ms5611_crc(uint16_t *prom)
+STATIC_UNIT_TESTED int8_t ms56xx_crc(uint16_t *prom)
 {
     int32_t i, j;
     uint32_t res = 0;
@@ -134,31 +140,31 @@ STATIC_UNIT_TESTED int8_t ms5611_crc(uint16_t *prom)
     return -1;
 }
 
-static uint32_t ms5611_read_adc(void)
+static uint32_t ms56xx_read_adc(void)
 {
     uint8_t rxbuf[3];
-    i2cRead(MS5611_ADDR, CMD_ADC_READ, 3, rxbuf); // read ADC
+    i2cRead(MS56XX_ADDR, CMD_ADC_READ, 3, rxbuf); // read ADC
     return (rxbuf[0] << 16) | (rxbuf[1] << 8) | rxbuf[2];
 }
 
-static void ms5611_start_ut(void)
+static void ms56xx_start_ut(void)
 {
-    i2cWrite(MS5611_ADDR, CMD_ADC_CONV + CMD_ADC_D2 + ms5611_osr, 1); // D2 (temperature) conversion start!
+    i2cWrite(MS56XX_ADDR, CMD_ADC_CONV + CMD_ADC_D2 + ms56xx_osr, 1); // D2 (temperature) conversion start!
 }
 
-static void ms5611_get_ut(void)
+static void ms56xx_get_ut(void)
 {
-    ms5611_ut = ms5611_read_adc();
+    ms56xx_ut = ms56xx_read_adc();
 }
 
-static void ms5611_start_up(void)
+static void ms56xx_start_up(void)
 {
-    i2cWrite(MS5611_ADDR, CMD_ADC_CONV + CMD_ADC_D1 + ms5611_osr, 1); // D1 (pressure) conversion start!
+    i2cWrite(MS56XX_ADDR, CMD_ADC_CONV + CMD_ADC_D1 + ms56xx_osr, 1); // D1 (pressure) conversion start!
 }
 
-static void ms5611_get_up(void)
+static void ms56xx_get_up(void)
 {
-    ms5611_up = ms5611_read_adc();
+    ms56xx_up = ms56xx_read_adc();
 }
 
 STATIC_UNIT_TESTED void ms5611_calculate(int32_t *pressure, int32_t *temperature)
@@ -166,10 +172,10 @@ STATIC_UNIT_TESTED void ms5611_calculate(int32_t *pressure, int32_t *temperature
     uint32_t press;
     int64_t temp;
     int64_t delt;
-    int64_t dT = (int64_t)ms5611_ut - ((uint64_t)ms5611_c[5] * 256);
-    int64_t off = ((int64_t)ms5611_c[2] << 16) + (((int64_t)ms5611_c[4] * dT) >> 7);
-    int64_t sens = ((int64_t)ms5611_c[1] << 15) + (((int64_t)ms5611_c[3] * dT) >> 8);
-    temp = 2000 + ((dT * (int64_t)ms5611_c[6]) >> 23);
+    int64_t dT = (int64_t)ms56xx_ut - ((uint64_t)ms56xx_c[5] << 8);
+    int64_t off = ((int64_t)ms56xx_c[2] << 16) + (((int64_t)ms56xx_c[4] * dT) >> 7);
+    int64_t sens = ((int64_t)ms56xx_c[1] << 15) + (((int64_t)ms56xx_c[3] * dT) >> 8);
+    temp = 2000 + ((dT * (int64_t)ms56xx_c[6]) >> 23);
 
     if (temp < 2000) { // temperature lower than 20degC
         delt = temp - 2000;
@@ -182,10 +188,40 @@ STATIC_UNIT_TESTED void ms5611_calculate(int32_t *pressure, int32_t *temperature
             off -= 7 * delt;
             sens -= (11 * delt) >> 1;
         }
-    temp -= ((dT * dT) >> 31);
+        temp -= ((dT * dT) >> 31);
     }
-    press = ((((int64_t)ms5611_up * sens) >> 21) - off) >> 15;
+    press = ((((int64_t)ms56xx_up * sens) >> 21) - off) >> 15;
 
+    if (pressure)
+        *pressure = press;
+    if (temperature)
+        *temperature = temp;
+}
+
+STATIC_UNIT_TESTED void ms5607_calculate(int32_t *pressure, int32_t *temperature)
+{
+    uint32_t press;
+    int64_t temp;
+    int64_t delt;
+    int64_t dT = (int64_t)ms56xx_ut - ((uint64_t)ms56xx_c[5] << 8);
+    int64_t off = ((int64_t)ms56xx_c[2] << 17) + (((int64_t)ms56xx_c[4] * dT) >> 6);
+    int64_t sens = ((int64_t)ms56xx_c[1] << 16) + (((int64_t)ms56xx_c[3] * dT) >> 7);
+    temp = 2000 + ((dT * (int64_t)ms56xx_c[6]) >> 23);
+
+    if (temp < 2000) { // temperature lower than 20degC
+        delt = temp - 2000;
+        delt = delt * delt;
+        off -= (61 * delt) >> 4;
+        sens -= 2 * delt;
+        if (temp < -1500) { // temperature lower than -15degC
+            delt = temp + 1500;
+            delt = delt * delt;
+            off -= 15 * delt;
+            sens -= 8 * delt;
+        }
+        temp -= ((dT * dT) >> 31);
+    }
+    press = ((((int64_t)ms56xx_up * sens) >> 21) - off) >> 15;
 
     if (pressure)
         *pressure = press;

--- a/src/main/drivers/barometer_ms56xx.h
+++ b/src/main/drivers/barometer_ms56xx.h
@@ -17,4 +17,6 @@
 
 #pragma once
 
-bool ms5611Detect(baro_t *baro);
+#include "sensors/barometer.h" // for baroSensor_e enum
+
+bool ms56xxDetect(baro_t *baro, baroSensor_e type);

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -192,7 +192,7 @@ static const char * const sensorTypeNames[] = {
 static const char * const sensorHardwareNames[4][11] = {
     { "", "None", "MPU6050", "L3G4200D", "MPU3050", "L3GD20", "MPU6000", "MPU6500", "FAKE", NULL },
     { "", "None", "ADXL345", "MPU6050", "MMA845x", "BMA280", "LSM303DLHC", "MPU6000", "MPU6500", "FAKE", NULL },
-    { "", "None", "BMP085", "MS5611", NULL },
+    { "", "None", "BMP085", "MS5611", "MS5607", NULL },
     { "", "None", "HMC5883", "AK8975", NULL }
 };
 #endif

--- a/src/main/sensors/barometer.h
+++ b/src/main/sensors/barometer.h
@@ -21,11 +21,12 @@ typedef enum {
     BARO_DEFAULT = 0,
     BARO_NONE = 1,
     BARO_BMP085 = 2,
-    BARO_MS5611 = 3
+    BARO_MS5611 = 3,
+    BARO_MS5607 = 4
 } baroSensor_e;
 
 #define BARO_SAMPLE_COUNT_MAX   48
-#define BARO_MAX BARO_MS5611
+#define BARO_MAX BARO_MS5607
 
 typedef struct barometerConfig_s {
     uint8_t baro_sample_count;              // size of baro filter array

--- a/src/main/sensors/initialisation.c
+++ b/src/main/sensors/initialisation.c
@@ -42,7 +42,7 @@
 
 #include "drivers/barometer.h"
 #include "drivers/barometer_bmp085.h"
-#include "drivers/barometer_ms5611.h"
+#include "drivers/barometer_ms56xx.h"
 
 #include "drivers/compass.h"
 #include "drivers/compass_hmc5883l.h"
@@ -447,7 +447,7 @@ static void detectBaro(baroSensor_e baroHardwareToUse)
 
         case BARO_MS5611:
 #ifdef USE_BARO_MS5611
-            if (ms5611Detect(&baro)) {
+            if (ms56xxDetect(&baro, BARO_MS5611)) {
                 baroHardware = BARO_MS5611;
                 break;
             }
@@ -457,6 +457,13 @@ static void detectBaro(baroSensor_e baroHardwareToUse)
 #ifdef USE_BARO_BMP085
             if (bmp085Detect(bmp085Config, &baro)) {
                 baroHardware = BARO_BMP085;
+                break;
+            }
+#endif
+        case BARO_MS5607:
+#ifdef USE_BARO_MS5607
+            if (ms56xxDetect(&baro, BARO_MS5607)) {
+                baroHardware = BARO_MS5607;
                 break;
             }
 #endif

--- a/src/main/target/NAZE/target.h
+++ b/src/main/target/NAZE/target.h
@@ -106,6 +106,7 @@
 
 #define BARO
 #define USE_BARO_MS5611
+#define USE_BARO_MS5607
 #define USE_BARO_BMP085
 
 #define MAG

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -466,25 +466,25 @@ $(OBJECT_DIR)/rx_ranges_unittest : \
 
 	$(CXX) $(CXX_FLAGS) $^ -o $(OBJECT_DIR)/$@
 
-$(OBJECT_DIR)/drivers/barometer_ms5611.o : \
-    $(USER_DIR)/drivers/barometer_ms5611.c \
-    $(USER_DIR)/drivers/barometer_ms5611.h \
+$(OBJECT_DIR)/drivers/barometer_ms56xx.o : \
+    $(USER_DIR)/drivers/barometer_ms56xx.c \
+    $(USER_DIR)/drivers/barometer_ms56xx.h \
     $(GTEST_HEADERS)
 
 	@mkdir -p $(dir $@)
-	$(CC) $(C_FLAGS) $(TEST_CFLAGS) -c $(USER_DIR)/drivers/barometer_ms5611.c -o $@
+	$(CC) $(C_FLAGS) $(TEST_CFLAGS) -c $(USER_DIR)/drivers/barometer_ms56xx.c -o $@
 
-$(OBJECT_DIR)/baro_ms5611_unittest.o : \
-	$(TEST_DIR)/baro_ms5611_unittest.cc \
-	$(USER_DIR)/drivers/barometer_ms5611.h \
+$(OBJECT_DIR)/baro_ms56xx_unittest.o : \
+	$(TEST_DIR)/baro_ms56xx_unittest.cc \
+	$(USER_DIR)/drivers/barometer_ms56xx.h \
 	$(GTEST_HEADERS)
 
 	@mkdir -p $(dir $@)
-	$(CXX) $(CXX_FLAGS) $(TEST_CFLAGS) -c $(TEST_DIR)/baro_ms5611_unittest.cc -o $@
+	$(CXX) $(CXX_FLAGS) $(TEST_CFLAGS) -c $(TEST_DIR)/baro_ms56xx_unittest.cc -o $@
 
-$(OBJECT_DIR)/baro_ms5611_unittest : \
-	$(OBJECT_DIR)/drivers/barometer_ms5611.o \
-	$(OBJECT_DIR)/baro_ms5611_unittest.o \
+$(OBJECT_DIR)/baro_ms56xx_unittest : \
+	$(OBJECT_DIR)/drivers/barometer_ms56xx.o \
+	$(OBJECT_DIR)/baro_ms56xx_unittest.o \
 	$(OBJECT_DIR)/gtest_main.a
 
 	$(CXX) $(CXX_FLAGS) $^ -o $(OBJECT_DIR)/$@

--- a/src/test/unit/baro_ms56xx_unittest.cc
+++ b/src/test/unit/baro_ms56xx_unittest.cc
@@ -18,12 +18,12 @@
 
 extern "C" {
 
-int8_t ms5611_crc(uint16_t *prom);
+int8_t ms56xx_crc(uint16_t *prom);
 void ms5611_calculate(int32_t *pressure, int32_t *temperature);
 
-extern uint16_t ms5611_c[8];
-extern uint32_t ms5611_up;
-extern uint32_t ms5611_ut;
+extern uint16_t ms56xx_c[8];
+extern uint32_t ms56xx_up;
+extern uint32_t ms56xx_ut;
 
 }
 
@@ -36,10 +36,10 @@ TEST(baroMS5611Test, TestValidMs5611Crc)
 {
 
     // given
-    uint16_t ms5611_prom[] = {0x3132,0x3334,0x3536,0x3738,0x3940,0x4142,0x4344,0x450B};
+    uint16_t ms56xx_prom[] = {0x3132,0x3334,0x3536,0x3738,0x3940,0x4142,0x4344,0x450B};
 
     // when
-    int8_t result = ms5611_crc(ms5611_prom);
+    int8_t result = ms56xx_crc(ms56xx_prom);
 
     // then
     EXPECT_EQ(0, result);
@@ -50,10 +50,10 @@ TEST(baroMS5611Test, TestInvalidMs5611Crc)
 {
 
     // given
-    uint16_t ms5611_prom[] = {0x3132,0x3334,0x3536,0x3738,0x3940,0x4142,0x4344,0x4500};
+    uint16_t ms56xx_prom[] = {0x3132,0x3334,0x3536,0x3738,0x3940,0x4142,0x4344,0x4500};
 
     // when
-    int8_t result = ms5611_crc(ms5611_prom);
+    int8_t result = ms56xx_crc(ms56xx_prom);
 
     // then
     EXPECT_EQ(-1, result);
@@ -64,10 +64,10 @@ TEST(baroMS5611Test, TestMs5611AllZeroProm)
 {
 
     // given
-    uint16_t ms5611_prom[] = {0x0000,0x0000,0x0000,0x0000,0x0000,0x0000,0x0000,0x0000};
+    uint16_t ms56xx_prom[] = {0x0000,0x0000,0x0000,0x0000,0x0000,0x0000,0x0000,0x0000};
 
     // when
-    int8_t result = ms5611_crc(ms5611_prom);
+    int8_t result = ms56xx_crc(ms56xx_prom);
 
     // then
     EXPECT_EQ(-1, result);
@@ -78,10 +78,10 @@ TEST(baroMS5611Test, TestMs5611AllOnesProm)
 {
 
     // given
-    uint16_t ms5611_prom[] = {0xFFFF,0xFFFF,0xFFFF,0xFFFF,0xFFFF,0xFFFF,0xFFFF,0xFFFF};
+    uint16_t ms56xx_prom[] = {0xFFFF,0xFFFF,0xFFFF,0xFFFF,0xFFFF,0xFFFF,0xFFFF,0xFFFF};
 
     // when
-    int8_t result = ms5611_crc(ms5611_prom);
+    int8_t result = ms56xx_crc(ms56xx_prom);
 
     // then
     EXPECT_EQ(-1, result);
@@ -93,11 +93,11 @@ TEST(baroMS5611Test, TestMs5611CalculatePressureGT20Deg)
 
     // given
     int32_t pressure, temperature;
-    uint16_t ms5611_c_test[] = {0x0000, 40127, 36924, 23317, 23282, 33464, 28312, 0x0000}; // calibration data from MS5611 datasheet 
-    memcpy(&ms5611_c, &ms5611_c_test, sizeof(ms5611_c_test));
+    uint16_t ms56xx_c_test[] = {0x0000, 40127, 36924, 23317, 23282, 33464, 28312, 0x0000}; // calibration data from MS5611 datasheet 
+    memcpy(&ms56xx_c, &ms56xx_c_test, sizeof(ms56xx_c_test));
 
-    ms5611_up = 9085466; // Digital pressure value from MS5611 datasheet
-    ms5611_ut = 8569150; // Digital temperature value from MS5611 datasheet
+    ms56xx_up = 9085466; // Digital pressure value from MS5611 datasheet
+    ms56xx_ut = 8569150; // Digital temperature value from MS5611 datasheet
 
     // when
     ms5611_calculate(&pressure, &temperature);
@@ -113,11 +113,11 @@ TEST(baroMS5611Test, TestMs5611CalculatePressureLT20Deg)
 
     // given
     int32_t pressure, temperature;
-    uint16_t ms5611_c_test[] = {0x0000, 40127, 36924, 23317, 23282, 33464, 28312, 0x0000}; // calibration data from MS5611 datasheet 
-    memcpy(&ms5611_c, &ms5611_c_test, sizeof(ms5611_c_test));
+    uint16_t ms56xx_c_test[] = {0x0000, 40127, 36924, 23317, 23282, 33464, 28312, 0x0000}; // calibration data from MS5611 datasheet 
+    memcpy(&ms56xx_c, &ms56xx_c_test, sizeof(ms56xx_c_test));
 
-    ms5611_up = 9085466; // Digital pressure value from MS5611 datasheet
-    ms5611_ut = 8069150; // Digital temperature value
+    ms56xx_up = 9085466; // Digital pressure value from MS5611 datasheet
+    ms56xx_ut = 8069150; // Digital temperature value
 
     // when
     ms5611_calculate(&pressure, &temperature);
@@ -133,11 +133,11 @@ TEST(baroMS5611Test, TestMs5611CalculatePressureLTMinus15Deg)
 
     // given
     int32_t pressure, temperature;
-    uint16_t ms5611_c_test[] = {0x0000, 40127, 36924, 23317, 23282, 33464, 28312, 0x0000}; // calibration data from MS5611 datasheet 
-    memcpy(&ms5611_c, &ms5611_c_test, sizeof(ms5611_c_test));
+    uint16_t ms56xx_c_test[] = {0x0000, 40127, 36924, 23317, 23282, 33464, 28312, 0x0000}; // calibration data from MS5611 datasheet 
+    memcpy(&ms56xx_c, &ms56xx_c_test, sizeof(ms56xx_c_test));
 
-    ms5611_up = 9085466; // Digital pressure value from MS5611 datasheet
-    ms5611_ut = 7369150; // Digital temperature value
+    ms56xx_up = 9085466; // Digital pressure value from MS5611 datasheet
+    ms56xx_ut = 7369150; // Digital temperature value
 
     // when
     ms5611_calculate(&pressure, &temperature);


### PR DESCRIPTION
This change adds support for the MS5607 barometer. I have modified and renamed the existing MS5611 drivers to work with both the MS5611 and the MS5607. Both barometers are essentially the same with the only differences being the scaling factors and the second order factors used when calculating temperature compensated pressure due to the lower resolution of the MS5607 vs the MS5611.

I see that with the recent commit 26f89b7, the barometer type is not configurable. I have added the MS5607 as yet another configurable barometer type. I added another parameter to the ms56xxDetect() function to tell it which barometer calculation function pointer to use, assuming barometer detection was successful.

This relates to Issue #512
