### PR TITLE
Fix for changing PID's for users with Inflight Adjustments

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -128,7 +128,7 @@ static uint32_t activeFeaturesLatch = 0;
 static uint8_t currentControlRateProfileIndex = 0;
 controlRateConfig_t *currentControlRateProfile;
 
-static const uint8_t EEPROM_CONF_VERSION = 105;
+static const uint8_t EEPROM_CONF_VERSION = 106;
 
 static void resetAccelerometerTrims(flightDynamicsTrims_t *accelerometerTrims)
 {
@@ -413,7 +413,7 @@ static void resetConf(void)
 
     for (i = 0; i < MAX_SUPPORTED_RC_CHANNEL_COUNT; i++) {
         rxFailsafeChannelConfiguration_t *channelFailsafeConfiguration = &masterConfig.rxConfig.failsafe_channel_configurations[i];
-        channelFailsafeConfiguration->mode = (i < NON_AUX_CHANNEL_COUNT) ? RX_FAILSAFE_MODE_AUTO : RX_FAILSAFE_MODE_HOLD;
+        channelFailsafeConfiguration->mode = RX_FAILSAFE_MODE_AUTO;
         channelFailsafeConfiguration->step = (i == THROTTLE) ? masterConfig.rxConfig.rx_min_usec : CHANNEL_VALUE_TO_RXFAIL_STEP(masterConfig.rxConfig.midrc);
     }
 

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -368,16 +368,13 @@ static uint16_t getRxfailValue(uint8_t channel)
     switch(channelFailsafeConfiguration->mode) {
         case RX_FAILSAFE_MODE_AUTO:
             switch (channel) {
-                case ROLL:
-                case PITCH:
-                case YAW:
-                    return rxConfig->midrc;
-
                 case THROTTLE:
                     if (feature(FEATURE_3D))
                         return rxConfig->midrc;
                     else
                         return rxConfig->rx_min_usec;
+                default:
+                    return rxConfig->midrc;
             }
             /* no break */
 


### PR DESCRIPTION
Users who upgraded from 1.9 and have inflight adjustments configured now
experience changed PID's. Sometimes even to dangerous and unflyable
situation. Sometimes rx boots slower than the FC

This is because AUX channels go low and usually thats where they change
things.

IMO the new failsafe behaviour for AUX should be midrc default like
before!

@hydra @ProDrone 
This should be merged quickly before 1.10 releases.