### PR TITLE
Possibility to ignore serialrx data on failsafe.

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -492,6 +492,7 @@ static void resetConf(void)
     masterConfig.failsafeConfig.failsafe_throttle = 1000;         // default throttle off.
     masterConfig.failsafeConfig.failsafe_kill_switch = 0;         // default failsafe switch action is identical to rc link loss
     masterConfig.failsafeConfig.failsafe_throttle_low_delay = 100; // default throttle low delay for "just disarm" on failsafe condition
+    masterConfig.failsafeConfig.failsafe_ignore_serialrx = 0;
 
 #ifdef USE_SERVOS
     // servos

--- a/src/main/flight/failsafe.c
+++ b/src/main/flight/failsafe.c
@@ -73,6 +73,11 @@ void useFailsafeConfig(failsafeConfig_t *failsafeConfigToUse)
     failsafeReset();
 }
 
+bool shouldIgnoreSerialRxOnFailsafe(void)
+{
+    return feature(FEATURE_FAILSAFE) && failsafeConfig->failsafe_ignore_serialrx == 1;
+}
+
 void failsafeInit(rxConfig_t *intialRxConfig, uint16_t deadband3d_throttle)
 {
     rxConfig = intialRxConfig;

--- a/src/main/flight/failsafe.h
+++ b/src/main/flight/failsafe.h
@@ -33,6 +33,7 @@ typedef struct failsafeConfig_s {
     uint16_t failsafe_throttle;             // Throttle level used for landing - specify value between 1000..2000 (pwm pulse width for slightly below hover). center throttle = 1500.
     uint8_t failsafe_kill_switch;           // failsafe switch action is 0: identical to rc link loss, 1: disarms instantly
     uint16_t failsafe_throttle_low_delay;   // Time throttle stick must have been below 'min_check' to "JustDisarm" instead of "full failsafe procedure".
+    uint8_t failsafe_ignore_serialrx;       // 1: When the serial rx indicates failsafe, ignore it's channels and use the configured ones, 0: Always read serial rx channels when available
 } failsafeConfig_t;
 
 typedef enum {
@@ -65,6 +66,8 @@ typedef struct failsafeState_s {
 } failsafeState_t;
 
 void useFailsafeConfig(failsafeConfig_t *failsafeConfigToUse);
+
+bool shouldIgnoreSerialRxOnFailsafe(void);
 
 void failsafeStartMonitoring(void);
 void failsafeUpdateState(void);

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -445,6 +445,7 @@ const clivalue_t valueTable[] = {
     { "failsafe_throttle",          VAR_UINT16 | MASTER_VALUE,  &masterConfig.failsafeConfig.failsafe_throttle, PWM_RANGE_MIN, PWM_RANGE_MAX },
     { "failsafe_kill_switch",       VAR_UINT8  | MASTER_VALUE,  &masterConfig.failsafeConfig.failsafe_kill_switch, 0, 1 },
     { "failsafe_throttle_low_delay",VAR_UINT16 | MASTER_VALUE,  &masterConfig.failsafeConfig.failsafe_throttle_low_delay, 0, 300 },
+    { "failsafe_ignore_serialrx",   VAR_UINT8  | MASTER_VALUE,  &masterConfig.failsafeConfig.failsafe_ignore_serialrx, 0, 1 },
 
     { "rx_min_usec",                VAR_UINT16 | MASTER_VALUE,  &masterConfig.rxConfig.rx_min_usec, PWM_PULSE_MIN, PWM_PULSE_MAX },
     { "rx_max_usec",                VAR_UINT16 | MASTER_VALUE,  &masterConfig.rxConfig.rx_max_usec, PWM_PULSE_MIN, PWM_PULSE_MAX },

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -441,10 +441,15 @@ static void detectAndApplySignalLossBehaviour(void)
     uint16_t sample;
     bool useValueFromRx = true;
     bool rxIsDataDriven = isRxDataDriven();
+    bool useRxFailValues = false;
 
     if (!rxSignalReceived) {
         if (rxIsDataDriven && rxDataReceived) {
-            // use the values from the RX
+            if (shouldIgnoreSerialRxOnFailsafe()) {
+                useRxFailValues = true;
+            } else {
+                // use the values from the RX
+            }
         } else {
             useValueFromRx = false;
         }
@@ -458,7 +463,7 @@ static void detectAndApplySignalLossBehaviour(void)
 
         bool validPulse = isPulseValid(sample);
 
-        if (!validPulse) {
+        if (!validPulse || useRxFailValues) {
             sample = getRxfailValue(channel);
         }
 

--- a/src/test/unit/rx_ranges_unittest.cc
+++ b/src/test/unit/rx_ranges_unittest.cc
@@ -180,5 +180,10 @@ void failsafeOnValidDataFailed(void)
 {
 }
 
+bool shouldIgnoreSerialRxOnFailsafe(void)
+{
+    return false;
+}
+
 }
 

--- a/src/test/unit/rx_rx_unittest.cc
+++ b/src/test/unit/rx_rx_unittest.cc
@@ -165,4 +165,10 @@ extern "C" {
     void rxMspInit(rxConfig_t *, rxRuntimeConfig_t *, rcReadRawDataPtr *) {}
 
     void rxPwmInit(rxRuntimeConfig_t *, rcReadRawDataPtr *) {}
+
+    bool shouldIgnoreSerialRxOnFailsafe(void)
+    {
+        return false;
+    }
+
 }


### PR DESCRIPTION
Since the beeper isn't on when a serialrx flags failsafe, I want to put this on a failsafe channel.
One of my quads' rx can only put failsafe on the throttle channel, which means I need to configure it internally in CF.
Only problem is that it always reads the rx channels when serialrx flags failsafe so the internal settings are ignored.
One solution is to add a config setting to enable possiblity to ignore the rx values.
