### PR TITLE
Fix RX_MSP oscillation, > 8 channel support

### DIFF
--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -1310,9 +1310,13 @@ static bool processInCommand(void)
             if (channelCount > MAX_SUPPORTED_RC_CHANNEL_COUNT) {
                 headSerialError(0);
             } else {
-                for (i = 0; i < channelCount; i++)
-                    rcData[i] = read16();
-                rxMspFrameRecieve();
+                uint16_t frame[MAX_SUPPORTED_RC_CHANNEL_COUNT];
+
+                for (i = 0; i < channelCount; i++) {
+                    frame[i] = read16();
+                }
+
+                rxMspFrameReceive(frame, channelCount);
             }
         }
         break;

--- a/src/main/rx/msp.c
+++ b/src/main/rx/msp.c
@@ -31,16 +31,26 @@
 #include "rx/rx.h"
 #include "rx/msp.h"
 
+static uint16_t mspFrame[MAX_SUPPORTED_RC_CHANNEL_COUNT];
 static bool rxMspFrameDone = false;
 
 static uint16_t rxMspReadRawRC(rxRuntimeConfig_t *rxRuntimeConfigPtr, uint8_t chan)
 {
     UNUSED(rxRuntimeConfigPtr);
-    return rcData[chan];
+    return mspFrame[chan];
 }
 
-void rxMspFrameRecieve(void)
+void rxMspFrameReceive(uint16_t *frame, int channelCount)
 {
+    for (int i = 0; i < channelCount; i++) {
+        mspFrame[i] = frame[i];
+    }
+
+    // Any channels not provided will be reset to zero
+    for (int i = channelCount; i < MAX_SUPPORTED_RC_CHANNEL_COUNT; i++) {
+        mspFrame[i] = 0;
+    }
+
     rxMspFrameDone = true;
 }
 
@@ -57,7 +67,7 @@ bool rxMspFrameComplete(void)
 void rxMspInit(rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig, rcReadRawDataPtr *callback)
 {
     UNUSED(rxConfig);
-    rxRuntimeConfig->channelCount = 8; // Limited to 8 channels due to MSP_SET_RAW_RC command.
+    rxRuntimeConfig->channelCount = MAX_SUPPORTED_RC_CHANNEL_COUNT;
     if (callback)
         *callback = rxMspReadRawRC;
 }

--- a/src/main/rx/msp.h
+++ b/src/main/rx/msp.h
@@ -18,4 +18,4 @@
 #pragma once
 
 bool rxMspFrameComplete(void);
-void rxMspFrameRecieve(void);
+void rxMspFrameReceive(uint16_t *frame, int channelCount);

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -83,6 +83,7 @@ int16_t rcData[MAX_SUPPORTED_RC_CHANNEL_COUNT];     // interval [1000;2000]
 
 #define DELAY_50_HZ (1000000 / 50)
 #define DELAY_10_HZ (1000000 / 10)
+#define DELAY_5_HZ (1000000 / 5)
 #define SKIP_RC_ON_SUSPEND_PERIOD 1500000           // 1.5 second period in usec (call frequency independent)
 #define SKIP_RC_SAMPLES_ON_RESUME  2                // flush 2 samples to drop wrong measurements (timing independent)
 
@@ -297,16 +298,18 @@ void updateRx(uint32_t currentTime)
         if (frameStatus & SERIAL_RX_FRAME_COMPLETE) {
             rxDataReceived = true;
             rxSignalReceived = (frameStatus & SERIAL_RX_FRAME_FAILSAFE) == 0;
+            needRxSignalBefore = currentTime + DELAY_10_HZ;
         }
     }
 #endif
 
     if (feature(FEATURE_RX_MSP)) {
         rxDataReceived = rxMspFrameComplete();
-    }
 
-    if (feature(FEATURE_RX_SERIAL | FEATURE_RX_MSP) && rxDataReceived) {
-        needRxSignalBefore = currentTime + DELAY_10_HZ;
+        if (rxDataReceived) {
+            rxSignalReceived = true;
+            needRxSignalBefore = currentTime + DELAY_5_HZ;
+        }
     }
 
     if (feature(FEATURE_RX_PPM)) {


### PR DESCRIPTION
The implementation of `MSP_SET_RAW_RC` wrote the read rc values directly into `rcData[]`. In rx.c's `readRxChannelsApplyRanges()`, these values were read from `rcData[]`, then channel mapping was applied to juggle the channels around, then the values were stored into `rcRaw[]`. In `detectAndApplySignalLossBehaviour()`, if these values were considered reasonable then they were copied back to `rcData[]`.

The issue is that if the channel mapping was not set to the identity map for MSP ("AERT1234"), and `readRxChannelsApplyRanges()` was called again before another `MSP_SET_RAW_RC` message arrived, it would read the `rcData[]` that it had already applied channel mapping to, and would apply channel mapping and channel scaling a second time. This caused channels to rapidly oscillate:

<img width="1343" alt="screen shot 2015-09-25 at 1 52 01 am" src="https://cloud.githubusercontent.com/assets/1921411/10075098/0e8f8272-6328-11e5-994e-2f16e460049b.png">

The fix is to have RX_MSP store its read values in its own private array instead of directly into `rcData[]` (which is supposed to be the finished product after all rx processing). Now there is no chance of a feedback loop.

I also fixed support for more than 8 channels in RX_MSP, and fixed that `rxSignalReceived` was never being set to true for RX_MSP.

Fixes #1333