### PR TITLE
SBUS frame loss as RSSI

### DIFF
--- a/docs/Rssi.md
+++ b/docs/Rssi.md
@@ -2,11 +2,12 @@
 
 RSSI is a measurement of signal strength and is very handy so you know when your aircraft isw going out of range or if it is suffering RF interference.
 
-Some receivers have RSSI outputs.  3 types are supported.
+Some receivers have RSSI outputs.  4 types are supported.
 
 1. RSSI via PPM channel
 1. RSSI via Parallel PWM channel
 1. RSSI via ADC with PPM RC that has an RSSI output - aka RSSI ADC
+1. Frame loss from S.BUS receivers converted to RSSI
 
 ## RSSI via PPM
 
@@ -42,3 +43,8 @@ Under CLI :
 FrSky D4R-II and X8R supported.
 
 The feature can not be used when RX_PARALLEL_PWM is enabled.
+
+## RSSI from S.BUS frame loss
+
+When no RSSI channel is configured, RSSI ADC is not activated and S.BUS protocol is used, the frame loss will be converted to RSSI without any further configuration.
+

--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -419,7 +419,7 @@ static bool testBlackboxConditionUncached(FlightLogFieldCondition condition)
 #endif
 
         case FLIGHT_LOG_FIELD_CONDITION_RSSI:
-            return masterConfig.rxConfig.rssi_channel > 0 || feature(FEATURE_RSSI_ADC);
+            return masterConfig.rxConfig.rssi_channel > 0 || feature(FEATURE_RSSI_ADC) || (feature(FEATURE_RX_SERIAL) && masterConfig.rxConfig.serialrx_provider == 2);
 
         case FLIGHT_LOG_FIELD_CONDITION_NOT_LOGGING_EVERY_FRAME:
             return masterConfig.blackbox_rate_num < masterConfig.blackbox_rate_denom;

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -555,6 +555,19 @@ void parseRcChannels(const char *input, rxConfig_t *rxConfig)
     }
 }
 
+void updateRSSISbus(uint32_t currentTime)
+{
+    static uint32_t rssiUpdateAt = 0;
+
+    if ((int32_t)(currentTime - rssiUpdateAt) < 0) {
+        return;
+    }
+    rssiUpdateAt = currentTime + DELAY_5_HZ;
+
+    uint16_t currentRssiPct = fetchSbusFrameLossPctAndResetCounters();
+    rssi = (uint16_t)constrain(currentRssiPct, 0, 100) * 1023 / 100;
+}
+
 void updateRSSIPWM(void)
 {
     int16_t pwmRssi = 0;
@@ -614,6 +627,8 @@ void updateRSSI(uint32_t currentTime)
         updateRSSIPWM();
     } else if (feature(FEATURE_RSSI_ADC)) {
         updateRSSIADC(currentTime);
+    } else if (feature(FEATURE_RX_SERIAL) && rxConfig->serialrx_provider == 2) {
+         updateRSSISbus(currentTime);
     }
 }
 

--- a/src/main/rx/sbus.h
+++ b/src/main/rx/sbus.h
@@ -18,3 +18,4 @@
 #pragma once
 
 uint8_t sbusFrameStatus(void);
+uint16_t fetchSbusFrameLossPctAndResetCounters(void);

--- a/src/test/unit/rx_ranges_unittest.cc
+++ b/src/test/unit/rx_ranges_unittest.cc
@@ -180,5 +180,9 @@ void failsafeOnValidDataFailed(void)
 {
 }
 
+void fetchSbusFrameLossPctAndResetCounters(void)
+{
+}
+
 }
 

--- a/src/test/unit/rx_rx_unittest.cc
+++ b/src/test/unit/rx_rx_unittest.cc
@@ -188,4 +188,9 @@ extern "C" {
     void rxMspInit(rxConfig_t *, rxRuntimeConfig_t *, rcReadRawDataPtr *) {}
 
     void rxPwmInit(rxRuntimeConfig_t *, rcReadRawDataPtr *) {}
+
+    void fetchSbusFrameLossPctAndResetCounters(void)
+    {
+    }
+
 }


### PR DESCRIPTION
When no other RSSI is configured and SBUS is used, this calculates frame loss percentage as RSSI.
