### PR TITLE
RX - Improved RX failsafe detection & handling

### DIFF
--- a/src/main/main.c
+++ b/src/main/main.c
@@ -112,7 +112,7 @@ void mixerInit(mixerMode_e mixerMode, motorMixer_t *customMotorMixers, servoMixe
 void mixerInit(mixerMode_e mixerMode, motorMixer_t *customMotorMixers);
 #endif
 void mixerUsePWMOutputConfiguration(pwmOutputConfiguration_t *pwmOutputConfiguration);
-void rxInit(rxConfig_t *rxConfig);
+void rxInit(rxConfig_t *rxConfig, modeActivationCondition_t *modeActivationConditions);
 void gpsInit(serialConfig_t *serialConfig, gpsConfig_t *initialGpsConfig);
 void navigationInit(gpsProfile_t *initialGpsProfile, pidProfile_t *pidProfile);
 void imuInit(void);
@@ -406,7 +406,7 @@ void init(void)
 
     failsafeInit(&masterConfig.rxConfig, masterConfig.flight3DConfig.deadband3d_throttle);
 
-    rxInit(&masterConfig.rxConfig);
+    rxInit(&masterConfig.rxConfig, currentProfile->modeActivationConditions);
 
 #ifdef GPS
     if (feature(FEATURE_GPS)) {

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -682,8 +682,8 @@ void filterRc(void){
 
     if (isRXDataNew) {
         for (int channel=0; channel < 4; channel++) {
-        	deltaRC[channel] = rcData[channel] -  (lastCommand[channel] - deltaRC[channel] * factor / rcInterpolationFactor);
-            lastCommand[channel] = rcData[channel];
+        	deltaRC[channel] = rcCommand[channel] -  (lastCommand[channel] - deltaRC[channel] * factor / rcInterpolationFactor);
+            lastCommand[channel] = rcCommand[channel];
         }
 
         isRXDataNew = false;
@@ -692,10 +692,10 @@ void filterRc(void){
         factor--;
     }
 
-    // Interpolate steps of rcData
+    // Interpolate steps of rcCommand
     if (factor > 0) {
         for (int channel=0; channel < 4; channel++) {
-            rcData[channel] = lastCommand[channel] - deltaRC[channel] * factor/rcInterpolationFactor;
+            rcCommand[channel] = lastCommand[channel] - deltaRC[channel] * factor/rcInterpolationFactor;
          }
     } else {
         factor = 0;
@@ -768,11 +768,12 @@ void loop(void)
             }
         }
 
+        annexCode();
+
         if (masterConfig.rxConfig.rcSmoothing) {
             filterRc();
         }
 
-        annexCode();
 #if defined(BARO) || defined(SONAR)
         haveProcessedAnnexCodeOnce = true;
 #endif

--- a/src/test/unit/rx_rx_unittest.cc
+++ b/src/test/unit/rx_rx_unittest.cc
@@ -24,10 +24,12 @@ extern "C" {
     #include "platform.h"
 
     #include "rx/rx.h"
+    #include "io/rc_controls.h"
+    #include "common/maths.h"
 
     uint32_t rcModeActivationMask;
 
-    void rxInit(rxConfig_t *rxConfig);
+    void rxInit(rxConfig_t *rxConfig, modeActivationCondition_t *modeActivationConditions);
     void rxResetFlightChannelStatus(void);
     bool rxHaveValidFlightChannels(void);
     bool isPulseValid(uint16_t pulseDuration);
@@ -54,16 +56,28 @@ TEST(RxTest, TestValidFlightChannels)
 
     // and
     rxConfig_t rxConfig;
+    modeActivationCondition_t modeActivationConditions[MAX_MODE_ACTIVATION_CONDITION_COUNT];
 
     memset(&rxConfig, 0, sizeof(rxConfig));
     rxConfig.rx_min_usec = 1000;
     rxConfig.rx_max_usec = 2000;
 
-    // when
-    rxInit(&rxConfig);
+    memset(&modeActivationConditions, 0, sizeof(modeActivationConditions));
+    modeActivationConditions[0].auxChannelIndex = 0;
+    modeActivationConditions[0].modeId = BOXARM;
+    modeActivationConditions[0].range.startStep = CHANNEL_VALUE_TO_STEP(CHANNEL_RANGE_MIN);
+    modeActivationConditions[0].range.endStep = CHANNEL_VALUE_TO_STEP(1600);
 
+    // when
+    rxInit(&rxConfig, modeActivationConditions);
+
+    // then (ARM channel should be positioned just 1 step above active range to init to OFF)
+    EXPECT_EQ(1625, rcData[modeActivationConditions[0].auxChannelIndex +  NON_AUX_CHANNEL_COUNT]);
+
+    // given
     rxResetFlightChannelStatus();
 
+    // and
     for (uint8_t channelIndex = 0; channelIndex < MAX_SUPPORTED_RC_CHANNEL_COUNT; channelIndex++) {
         bool validPulse = isPulseValid(1500);
         rxUpdateFlightChannelStatus(channelIndex, validPulse);
@@ -80,20 +94,29 @@ TEST(RxTest, TestInvalidFlightChannels)
 
     // and
     rxConfig_t rxConfig;
+    modeActivationCondition_t modeActivationConditions[MAX_MODE_ACTIVATION_CONDITION_COUNT];
 
     memset(&rxConfig, 0, sizeof(rxConfig));
     rxConfig.rx_min_usec = 1000;
     rxConfig.rx_max_usec = 2000;
+
+    memset(&modeActivationConditions, 0, sizeof(modeActivationConditions));
+    modeActivationConditions[0].auxChannelIndex = 0;
+    modeActivationConditions[0].modeId = BOXARM;
+    modeActivationConditions[0].range.startStep = CHANNEL_VALUE_TO_STEP(1400);
+    modeActivationConditions[0].range.endStep = CHANNEL_VALUE_TO_STEP(CHANNEL_RANGE_MAX);
 
     // and
     uint16_t channelPulses[MAX_SUPPORTED_RC_CHANNEL_COUNT];
     memset(&channelPulses, 1500, sizeof(channelPulses));
 
     // and
-    rxInit(&rxConfig);
+    rxInit(&rxConfig, modeActivationConditions);
+
+    // then (ARM channel should be positioned just 1 step below active range to init to OFF)
+    EXPECT_EQ(1375, rcData[modeActivationConditions[0].auxChannelIndex +  NON_AUX_CHANNEL_COUNT]);
 
     // and
-
     for (uint8_t stickChannelIndex = 0; stickChannelIndex < STICK_CHANNEL_COUNT; stickChannelIndex++) {
 
         // given


### PR DESCRIPTION
Supersedes #1361
 
To solve problems as indicated here:
https://github.com/cleanflight/cleanflight/issues/1266#issuecomment-135640133

and here:
https://github.com/cleanflight/cleanflight/pull/1340

and here:
https://github.com/cleanflight/cleanflight/pull/1342

Tested on FrSKY X4RSB with latest CPPM firmware (non-EU version).
Firmware filename: X4R-X4RSB_cppm_non-EU_150630

In both SBUS and CPPM mode.

---
Added CLI variable `rxfail_delay` to rxfail detection

Used when out of range pulses from the receiver are detected.
Delay in deciseconds before rxfail values are applied (channel value is on HOLD until then).
Default 3 (range: 3 - 10).

This should prevent a too aggressive reaction to small dropouts.
