### PR TITLE
hack for cc3d MPU interrupts | proposition for a common CallbackHandler

### DIFF
--- a/src/main/drivers/accgyro_mpu.c
+++ b/src/main/drivers/accgyro_mpu.c
@@ -214,6 +214,33 @@ void MPU_DATA_READY_EXTI_Handler(void)
 #endif
 }
 
+    //// Hack for cc3d
+void EXTI3_IRQHandler(void)
+{
+    if (EXTI_GetITStatus(mpuIntExtiConfig->exti_line) == RESET) {
+        return;
+    }
+
+    EXTI_ClearITPendingBit(mpuIntExtiConfig->exti_line);
+
+    mpuDataReady = true;
+
+#ifdef DEBUG_MPU_DATA_READY_INTERRUPT
+    // Measure the delta in micro seconds between calls to the interrupt handler
+    static uint32_t lastCalledAt = 0;
+    static int32_t callDelta = 0;
+
+    uint32_t now = micros();
+    callDelta = now - lastCalledAt;
+
+    //UNUSED(callDelta);
+    debug[0] = callDelta;
+
+    lastCalledAt = now;
+#endif
+}
+    //// Hack for cc3d
+
 void configureMPUDataReadyInterruptHandling(void)
 {
 #ifdef USE_MPU_DATA_READY_SIGNAL
@@ -243,7 +270,9 @@ void configureMPUDataReadyInterruptHandling(void)
     }
 #endif
 
+#ifndef CC3D
     registerExti15_10_CallbackHandler(MPU_DATA_READY_EXTI_Handler);
+#endif
 
     EXTI_ClearITPendingBit(mpuIntExtiConfig->exti_line);
 

--- a/src/main/drivers/accgyro_spi_mpu6000.c
+++ b/src/main/drivers/accgyro_spi_mpu6000.c
@@ -126,6 +126,8 @@ void mpu6000SpiGyroInit(uint16_t lpf)
 
     mpu6000AccAndGyroInit();
 
+    mpuIntExtiInit();
+
     spiResetErrorCounter(MPU6000_SPI_INSTANCE);
 
     spiSetDivisor(MPU6000_SPI_INSTANCE, SPI_0_5625MHZ_CLOCK_DIVIDER);
@@ -145,6 +147,7 @@ void mpu6000SpiGyroInit(uint16_t lpf)
 
 void mpu6000SpiAccInit(void)
 {
+    mpuIntExtiInit();
     acc_1G = 512 * 8;
 }
 
@@ -234,6 +237,13 @@ static void mpu6000AccAndGyroInit(void) {
     delayMicroseconds(1);
 
     spiSetDivisor(MPU6000_SPI_INSTANCE, SPI_18MHZ_CLOCK_DIVIDER);  // 18 MHz SPI clock
+    delayMicroseconds(1);
+
+    #ifdef USE_MPU_DATA_READY_SIGNAL
+        // Set MPU Data Ready Signal
+        mpu6000WriteRegister(MPU6000_INT_ENABLE , MPU_RF_DATA_RDY_EN);
+        delayMicroseconds(1);
+    #endif
 
     mpuSpi6000InitDone = true;
 }

--- a/src/main/drivers/accgyro_spi_mpu6000.h
+++ b/src/main/drivers/accgyro_spi_mpu6000.h
@@ -44,6 +44,9 @@
 
 #define MPU6000_WHO_AM_I_CONST              (0x68)
 
+// RF = Register Flag
+#define MPU_RF_DATA_RDY_EN (1 << 0)
+
 bool mpu6000SpiDetect(void);
 
 bool mpu6000SpiAccDetect(acc_t *acc);


### PR DESCRIPTION
Hi
i re-implemented my cc3d gyro interrupt handling into the new more common accgyro_mpu file-system. It is mainly used in betaflight at the moment so i´m not sure if this is needed at the moment in the master branch. It is also still quite target specific because the interrupt handler that is available at the moment is only for interrupt on pins between 10 and 15 but cc3d is using EXTI3.

A better solution would be a more common CallbackHandler that can be used for different EXTIs so maybe someone can help out here.

