### PR TITLE
Added support to use an external interface with smart port telemetry

### DIFF
--- a/docs/Telemetry.md
+++ b/docs/Telemetry.md
@@ -104,3 +104,8 @@ For Smartport on F3 based boards, enable the telemetry inversion setting.
 ```
 set telemetry_inversion = 1
 ```
+If your controller has a STM32F1 and you don't want to mod your receiver, you can try to build this interface: https://github.com/sguarin/sguarin/wiki
+And put the following setting.
+```
+set telemetry_smart_port_2wire = 1
+```

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -376,6 +376,7 @@ const clivalue_t valueTable[] = {
 
     { "telemetry_switch",           VAR_UINT8  | MASTER_VALUE,  &masterConfig.telemetryConfig.telemetry_switch, 0, 1 },
     { "telemetry_inversion",        VAR_UINT8  | MASTER_VALUE,  &masterConfig.telemetryConfig.telemetry_inversion, 0, 1 },
+    { "telemetry_smart_port_2wire", VAR_UINT8  | MASTER_VALUE,  &masterConfig.telemetryConfig.telemetry_smart_port_2wire, 0, 1 },
     { "frsky_default_lattitude",    VAR_FLOAT  | MASTER_VALUE,  &masterConfig.telemetryConfig.gpsNoFixLatitude, -90.0, 90.0 },
     { "frsky_default_longitude",    VAR_FLOAT  | MASTER_VALUE,  &masterConfig.telemetryConfig.gpsNoFixLongitude, -180.0, 180.0 },
     { "frsky_coordinates_format",   VAR_UINT8  | MASTER_VALUE,  &masterConfig.telemetryConfig.frsky_coordinate_format, 0, FRSKY_FORMAT_NMEA },

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -229,11 +229,7 @@ void configureSmartPortTelemetryPort(void)
         return;
     }
 
-    portOptions = SERIAL_NOT_INVERTED | SERIAL_BIDIR;
-
-    if (telemetryConfig->telemetry_smart_port_2wire) {
-        portOptions &= SERIAL_UNIDIR;
-    }
+    portOptions = SERIAL_NOT_INVERTED | (telemetryConfig->telemetry_smart_port_2wire ? SERIAL_UNIDIR : SERIAL_BIDIR);
 
     if (telemetryConfig->telemetry_inversion) {
         portOptions |= SERIAL_INVERTED;

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -229,7 +229,11 @@ void configureSmartPortTelemetryPort(void)
         return;
     }
 
-    portOptions = SERIAL_BIDIR;
+    portOptions = SERIAL_NOT_INVERTED | SERIAL_BIDIR;
+
+    if (telemetryConfig->telemetry_smart_port_2wire) {
+        portOptions &= SERIAL_UNIDIR;
+    }
 
     if (telemetryConfig->telemetry_inversion) {
         portOptions |= SERIAL_INVERTED;

--- a/src/main/telemetry/telemetry.h
+++ b/src/main/telemetry/telemetry.h
@@ -39,6 +39,7 @@ typedef enum {
 typedef struct telemetryConfig_s {
     uint8_t telemetry_switch;               // Use aux channel to change serial output & baudrate( MSP / Telemetry ). It disables automatic switching to Telemetry when armed.
     uint8_t telemetry_inversion;            // also shared with smartport inversion
+    uint8_t telemetry_smart_port_2wire;     // Use RX/TX interface to talk to smart port
     float gpsNoFixLatitude;   
     float gpsNoFixLongitude;  
     frskyGpsCoordFormat_e frsky_coordinate_format;   


### PR DESCRIPTION
Configure the UART in a normal way to use an external adapter between FC and Receiver.
Adapters:
https://github.com/sguarin/sguarin/wiki
or
http://www.multiwii.com/forum/viewtopic.php?f=8&t=4507
