### PR TITLE
Correct use of sizeof(data_element) rather than sizeof(pointer)

### DIFF
--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -1017,7 +1017,7 @@ bool parseColor(uint8_t index, const char *colorConfig)
 
 void applyDefaultColors(hsvColor_t *colors, uint8_t colorCount)
 {
-    memset(colors, 0, colorCount * sizeof(colors));
+    memset(colors, 0, colorCount * sizeof(hsvColor_t));
     for (uint8_t colorIndex = 0; colorIndex < colorCount && colorIndex < (sizeof(defaultColors) / sizeof(defaultColors[0])); colorIndex++) {
         *colors++ = *defaultColors[colorIndex];
     }


### PR DESCRIPTION
Fixes Issue #1430 as reported by cppcheck.

No regressions with `make test`.
