### PR TITLE
Fix for Waiting for data (in configurator) problem on F1 targets

### DIFF
--- a/src/main/drivers/system.c
+++ b/src/main/drivers/system.c
@@ -151,11 +151,19 @@ void systemInit(void)
     cachedRccCsrValue = RCC->CSR;
     RCC_ClearFlag();
 
-
     enableGPIOPowerUsageAndNoiseReductions();
 
-
 #ifdef STM32F10X
+    // Set USART1 TX (PA9) to output and high state to prevent a rs232 break condition on reset.
+    // See issue https://github.com/cleanflight/cleanflight/issues/1433
+    gpio_config_t gpio;
+
+    gpio.mode = Mode_Out_PP;
+    gpio.speed = Speed_2MHz;
+    gpio.pin = Pin_9;
+    digitalHi(GPIOA, gpio.pin);
+    gpioInit(GPIOA, &gpio);
+
     // Turn off JTAG port 'cause we're using the GPIO for leds
 #define AFIO_MAPR_SWJ_CFG_NO_JTAG_SW            (0x2 << 24)
     AFIO->MAPR |= AFIO_MAPR_SWJ_CFG_NO_JTAG_SW;

--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -1823,10 +1823,7 @@ void mspProcess(void)
         }
 
         if (isRebootScheduled) {
-            // pause a little while to allow response to be sent
-            while (!isSerialTransmitBufferEmpty(candidatePort->port)) {
-                delay(50);
-            }
+            waitForSerialPortToFinishTransmitting(candidatePort->port);
             stopMotors();
             handleOneshotFeatureChangeOnRestart();
             systemReset();


### PR DESCRIPTION
Solves https://github.com/cleanflight/cleanflight/issues/1433 (see also https://github.com/cleanflight/cleanflight-configurator/issues/261)

Fixes the `Waiting for Data` problem in configurator when:

- Clicking on `Save and Reboot` button
- Clicking on `Flash Firmware`  button

When the system reboots after programming the new firmware it still
needs a connect/disconnect cycle to work normal. This cannot be solved
since the bootloader is a fixed program in ROM.

Fix is for F1 targets and only tested on naze boards.