### PR TITLE
Allow USART1 to be used for SERIAL_RX

### DIFF
--- a/src/main/drivers/serial_uart_stm32f10x.c
+++ b/src/main/drivers/serial_uart_stm32f10x.c
@@ -49,7 +49,7 @@ static uartPort_t uartPort3;
 #endif
 
 // Using RX DMA disables the use of receive callbacks
-#define USE_USART1_RX_DMA
+//#define USE_USART1_RX_DMA
 
 #if defined(CC3D) // FIXME move board specific code to target.h files.
 #undef USE_USART1_RX_DMA

--- a/src/main/drivers/serial_uart_stm32f30x.c
+++ b/src/main/drivers/serial_uart_stm32f30x.c
@@ -38,7 +38,7 @@
 #include "serial_uart_impl.h"
 
 // Using RX DMA disables the use of receive callbacks
-#define USE_USART1_RX_DMA
+//#define USE_USART1_RX_DMA
 //#define USE_USART2_RX_DMA
 //#define USE_USART2_TX_DMA
 //#define USE_USART3_RX_DMA


### PR DESCRIPTION
Hello,

Been asking on IRC why this is set. Absolutely nothing ever defines 'USE_USART*_RX_DMA', having this enabled by default breaks functionality of using USART1 for serial RX.