### PR TITLE
fix unused parameter warning in StdPeriph_Driver

### DIFF
--- a/lib/main/STM32F30x_StdPeriph_Driver/src/stm32f30x_adc.c
+++ b/lib/main/STM32F30x_StdPeriph_Driver/src/stm32f30x_adc.c
@@ -945,6 +945,10 @@ void ADC_AnalogWatchdog3SingleChannelConfig(ADC_TypeDef* ADCx, uint8_t ADC_Chann
   *   This parameter can be: ENABLE or DISABLE.
   * @retval None
   */
+#ifdef __GNUC__
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+#endif
 void ADC_TempSensorCmd(ADC_TypeDef* ADCx, FunctionalState NewState)
 {
   /* Check the parameters */
@@ -961,6 +965,9 @@ void ADC_TempSensorCmd(ADC_TypeDef* ADCx, FunctionalState NewState)
      ADC1_2->CCR &= ~(uint32_t)ADC12_CCR_TSEN;
    }
 }
+#ifdef __GNUC__
+# pragma GCC diagnostic pop
+#endif
 
 /**
   * @brief  Enables or disables the Vrefint channel.
@@ -1010,6 +1017,10 @@ void ADC_VrefintCmd(ADC_TypeDef* ADCx, FunctionalState NewState)
   *   This parameter can be: ENABLE or DISABLE.
   * @retval None
   */
+#ifdef __GNUC__
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+#endif
 void ADC_VbatCmd(ADC_TypeDef* ADCx, FunctionalState NewState)
 {
   /* Check the parameters */
@@ -1026,7 +1037,9 @@ void ADC_VbatCmd(ADC_TypeDef* ADCx, FunctionalState NewState)
      ADC1_2->CCR &= ~(uint32_t)ADC12_CCR_VBATEN;
    }
 }
-
+#ifdef __GNUC__
+# pragma GCC diagnostic pop
+#endif
 /**
   * @}
   */

--- a/lib/main/STM32F30x_StdPeriph_Driver/src/stm32f30x_hrtim.c
+++ b/lib/main/STM32F30x_StdPeriph_Driver/src/stm32f30x_hrtim.c
@@ -248,12 +248,19 @@ void HRTIM_SimpleBase_Init(HRTIM_TypeDef* HRTIMx, uint32_t TimerIdx, HRTIM_BaseI
   * @param  HRTIMx: pointer to HRTIMx peripheral 
   * @retval None
   */
+#ifdef __GNUC__
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+#endif
 void HRTIM_DeInit(HRTIM_TypeDef* HRTIMx)
 {
   /* Check the parameters */
     RCC_APB2PeriphResetCmd(RCC_APB2Periph_HRTIM1, ENABLE);
     RCC_APB2PeriphResetCmd(RCC_APB2Periph_HRTIM1, DISABLE);  
  }
+#ifdef __GNUC__
+# pragma GCC diagnostic pop
+#endif
 
 /**
   * @brief  Initializes the HRTIMx timer in basic output compare mode 
@@ -629,6 +636,10 @@ void HRTIM_SimplePWMStop(HRTIM_TypeDef * HRTIMx,
   *        units. It can be used directly and is active as soon as the timing 
   *        unit counter is enabled.
   */
+#ifdef __GNUC__
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+#endif
 void HRTIM_SimpleCaptureStart(HRTIM_TypeDef * HRTIMx,
                                               uint32_t TimerIdx,
                                               uint32_t CaptureChannel)
@@ -637,6 +648,9 @@ void HRTIM_SimpleCaptureStart(HRTIM_TypeDef * HRTIMx,
   __HRTIM_ENABLE(HRTIMx, TimerIdxToTimerId[TimerIdx]);
 
 }
+#ifdef __GNUC__
+# pragma GCC diagnostic pop
+#endif
 
 /**
   * @brief  Disables a basic capture on the designed capture unit 
@@ -3207,6 +3221,10 @@ uint32_t HRTIM_WaveformGetOutputLevel(HRTIM_TypeDef * HRTIMx,
   *                    @arg HRTIM_OUTPUT_TE2: Timer E - Output 2
   * @retval Output state
   */
+#ifdef __GNUC__
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+#endif
 uint32_t HRTIM_WaveformGetOutputState(HRTIM_TypeDef * HRTIMx,
                                           uint32_t TimerIdx,
                                           uint32_t Output)
@@ -3295,6 +3313,9 @@ uint32_t HRTIM_WaveformGetOutputState(HRTIM_TypeDef * HRTIMx,
   
   return(output_state);  
 }
+#ifdef __GNUC__
+# pragma GCC diagnostic pop
+#endif
 
 /**
   * @brief  Returns the level (active or inactive) of the designated output 

--- a/lib/main/STM32F30x_StdPeriph_Driver/src/stm32f30x_syscfg.c
+++ b/lib/main/STM32F30x_StdPeriph_Driver/src/stm32f30x_syscfg.c
@@ -467,6 +467,10 @@ void SYSCFG_SRAMWRPEnable(uint32_t SYSCFG_SRAMWRP)
   *     @arg SYSCFG_FLAG_PE: SRAM parity error flag.
   * @retval The new state of SYSCFG_Flag (SET or RESET).
   */
+#ifdef __GNUC__
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+#endif
 FlagStatus SYSCFG_GetFlagStatus(uint32_t SYSCFG_Flag)
 {
   FlagStatus bitstatus = RESET;
@@ -488,6 +492,9 @@ FlagStatus SYSCFG_GetFlagStatus(uint32_t SYSCFG_Flag)
   /* Return the SYSCFG_Flag status */
   return  bitstatus;
 }
+#ifdef __GNUC__
+# pragma GCC diagnostic pop
+#endif
 
 /**
   * @brief  Clears the selected SYSCFG flag.


### PR DESCRIPTION
Remove annoying warnings.
#pragma is used to minimize modification to StdPeriph_Driver source code - produced diff should be easy to handle