### PR TITLE
Added Vagrantfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 obj/
 patches/
 startup_stm32f10x_md_gcc.s
+.vagrant/
 
 # script-generated files
 docs/Manual.pdf

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,26 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure(2) do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "ubuntu/trusty64"
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  config.vm.provision "shell", inline: <<-SHELL
+    apt-get remove -y binutils-arm-none-eabi gcc-arm-none-eabi
+    add-apt-repository ppa:terry.guo/gcc-arm-embedded
+    apt-get update
+    apt-get install -y git gcc-arm-none-eabi=4.9.3.2015q3-1trusty1
+  SHELL
+end


### PR DESCRIPTION
I had some problems setting up a Cleanflight compatible Toolchain, as I'm already using gcc 5 and don't want to downgrade.

An quick solution is virtualizing the whole Toolchain, which is made very easy by tools like [Vagrant](https://www.vagrantup.com).

Using this `Vagrantfile`, the following is enough to get started with Cleanflight Development:

    vagrant up
    vagrant ssh
    cd /vagrant
    make -j8 TARGET=CC3D

The most recent Ubuntu Trusty 64bit Image is used and the installation happens according to the `docs/development/Building in Ubuntu.md` document.