### PR TITLE
System - Preset TX of all USARTS on init

### DIFF
--- a/src/main/drivers/system.c
+++ b/src/main/drivers/system.c
@@ -164,9 +164,46 @@ void systemInit(void)
     digitalHi(GPIOA, gpio.pin);
     gpioInit(GPIOA, &gpio);
 
+    // Set TX of USART2 and USART3 to input with pull-up to prevent floating TX outputs.
+    gpio.mode = Mode_IPU;
+
+#ifdef USE_USART2
+    gpio.pin = Pin_2;
+    gpioInit(GPIOA, &gpio);
+#endif
+
+#ifdef USE_USART3
+    gpio.pin = USART3_TX_PIN;
+    gpioInit(USART3_GPIO, &gpio);
+#endif
+
     // Turn off JTAG port 'cause we're using the GPIO for leds
 #define AFIO_MAPR_SWJ_CFG_NO_JTAG_SW            (0x2 << 24)
     AFIO->MAPR |= AFIO_MAPR_SWJ_CFG_NO_JTAG_SW;
+#endif
+
+#ifdef STM32F303
+    // Set TX for USART1, USART2 and USART3 to input with pull-up to prevent floating TX outputs.
+    gpio_config_t gpio;
+
+    gpio.mode = Mode_IPU;
+    gpio.speed = Speed_2MHz;
+
+#ifdef USE_USART1
+    gpio.pin = UART1_TX_PIN;
+    gpioInit(UART1_GPIO, &gpio);
+#endif
+
+#ifdef USE_USART2
+    gpio.pin = UART2_TX_PIN;
+    gpioInit(UART2_GPIO, &gpio);
+#endif
+
+#ifdef USE_USART3
+    gpio.pin = UART3_TX_PIN;
+    gpioInit(UART3_GPIO, &gpio);
+#endif
+
 #endif
 
     // Init cycle counter

--- a/src/main/target/CHEBUZZF3/target.h
+++ b/src/main/target/CHEBUZZF3/target.h
@@ -73,6 +73,20 @@
 #define USE_USART2
 #define SERIAL_PORT_COUNT 3
 
+#define UART1_TX_PIN        GPIO_Pin_9  // PA9
+#define UART1_RX_PIN        GPIO_Pin_10 // PA10
+#define UART1_GPIO          GPIOA
+#define UART1_GPIO_AF       GPIO_AF_7
+#define UART1_TX_PINSOURCE  GPIO_PinSource9
+#define UART1_RX_PINSOURCE  GPIO_PinSource10
+
+#define UART2_TX_PIN        GPIO_Pin_5 // PD5
+#define UART2_RX_PIN        GPIO_Pin_6 // PD6
+#define UART2_GPIO          GPIOD
+#define UART2_GPIO_AF       GPIO_AF_7
+#define UART2_TX_PINSOURCE  GPIO_PinSource5
+#define UART2_RX_PINSOURCE  GPIO_PinSource6
+
 #define USE_I2C
 #define I2C_DEVICE (I2CDEV_1)
 

--- a/src/main/target/NAZE32PRO/target.h
+++ b/src/main/target/NAZE32PRO/target.h
@@ -37,6 +37,20 @@
 #define USE_USART2
 #define SERIAL_PORT_COUNT 3
 
+#define UART1_TX_PIN        GPIO_Pin_9  // PA9
+#define UART1_RX_PIN        GPIO_Pin_10 // PA10
+#define UART1_GPIO          GPIOA
+#define UART1_GPIO_AF       GPIO_AF_7
+#define UART1_TX_PINSOURCE  GPIO_PinSource9
+#define UART1_RX_PINSOURCE  GPIO_PinSource10
+
+#define UART2_TX_PIN        GPIO_Pin_5 // PD5
+#define UART2_RX_PIN        GPIO_Pin_6 // PD6
+#define UART2_GPIO          GPIOD
+#define UART2_GPIO_AF       GPIO_AF_7
+#define UART2_TX_PINSOURCE  GPIO_PinSource5
+#define UART2_RX_PINSOURCE  GPIO_PinSource6
+
 #define USE_I2C
 #define I2C_DEVICE (I2CDEV_1)
 

--- a/src/main/target/STM32F3DISCOVERY/target.h
+++ b/src/main/target/STM32F3DISCOVERY/target.h
@@ -64,6 +64,20 @@
 #define USE_USART2
 #define SERIAL_PORT_COUNT 3
 
+#define UART1_TX_PIN        GPIO_Pin_9  // PA9
+#define UART1_RX_PIN        GPIO_Pin_10 // PA10
+#define UART1_GPIO          GPIOA
+#define UART1_GPIO_AF       GPIO_AF_7
+#define UART1_TX_PINSOURCE  GPIO_PinSource9
+#define UART1_RX_PINSOURCE  GPIO_PinSource10
+
+#define UART2_TX_PIN        GPIO_Pin_5 // PD5
+#define UART2_RX_PIN        GPIO_Pin_6 // PD6
+#define UART2_GPIO          GPIOD
+#define UART2_GPIO_AF       GPIO_AF_7
+#define UART2_TX_PINSOURCE  GPIO_PinSource5
+#define UART2_RX_PINSOURCE  GPIO_PinSource6
+
 #define USE_I2C
 #define I2C_DEVICE (I2CDEV_1)
 


### PR DESCRIPTION
Applied IPU mode where possible.

This is to prevent floating TX lines on startup.
Should cover the period before the device is initialized for first use.
Blackbox was suffering from this and produced a lot of garbage files,
while the LEDs blinked erratically (before first arm/disarm cycle).
OSD's and other serial devices may be affected too.

Tested on Naze and Sparky boards.