### PR TITLE
Change from prevent arming when in cli mode to prevent cli when armed

### DIFF
--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -1605,7 +1605,6 @@ void cliEnter(serialPort_t *serialPort)
     setPrintfSerialPort(cliPort);
     cliPrint("\r\nEntering CLI Mode, type 'exit' to return, or 'help'\r\n");
     cliPrompt();
-    ENABLE_ARMING_FLAG(PREVENT_ARMING);
 }
 
 static void cliExit(char *cmdline)
@@ -2183,6 +2182,15 @@ static void cliVersion(char *cmdline)
 void cliProcess(void)
 {
     if (!cliPort) {
+        return;
+    }
+
+    // prevent any cli activity when ARMED
+    if (ARMING_FLAG(ARMED)) {
+        // flush the port.
+        while (serialRxBytesWaiting(cliPort)) {
+            serialRead(cliPort);
+        }
         return;
     }
 


### PR DESCRIPTION
While I agree with idea behind #1263 I think it should be done the other way round.

With the current implementation the only way to allow arming after entering CLI is to exit/reset this will loose any changes unless saved.

With this implementation the CLI is not processed when ARMED but then allows the CLI to continue once disarmed. 

This allows temp changes whilst PID tuning without having to save every time.