### PR TITLE
Change I2C output type to OD

### DIFF
--- a/src/main/drivers/bus_i2c_stm32f30x.c
+++ b/src/main/drivers/bus_i2c_stm32f30x.c
@@ -101,7 +101,7 @@ void i2cInitPort(I2C_TypeDef *I2Cx)
 
         GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AF;
         GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
-        GPIO_InitStructure.GPIO_OType = GPIO_OType_PP;
+        GPIO_InitStructure.GPIO_OType = GPIO_OType_OD;
         GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_NOPULL;
 
         GPIO_InitStructure.GPIO_Pin = I2C1_SCL_PIN;
@@ -142,7 +142,7 @@ void i2cInitPort(I2C_TypeDef *I2Cx)
         // Init pins
         GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AF;
         GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
-        GPIO_InitStructure.GPIO_OType = GPIO_OType_PP;
+        GPIO_InitStructure.GPIO_OType = GPIO_OType_OD;
         GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_NOPULL;
 
         GPIO_InitStructure.GPIO_Pin = I2C2_SCL_PIN;


### PR DESCRIPTION
I2C OType should be set to OpenDrain (lib/main/STM32F30x_StdPeriph_Driver/src/stm32f30x_i2c.c#L31)

see #1471
This is not tested on actual hardware yet