### PR TITLE
blackbox OpenLog and serial_RX on same UART

### DIFF
--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -92,7 +92,7 @@ baudRate_e lookupBaudRateIndex(uint32_t baudRate)
     return BAUD_AUTO;
 }
 
-static serialPortUsage_t *findSerialPortUsageByIdentifier(serialPortIdentifier_e identifier)
+serialPortUsage_t *findSerialPortUsageByIdentifier(serialPortIdentifier_e identifier)
 {
     uint8_t index;
     for (index = 0; index < SERIAL_PORT_COUNT; index++) {
@@ -200,7 +200,8 @@ bool isSerialConfigValid(serialConfig_t *serialConfigToCheck)
     for (index = 0; index < SERIAL_PORT_COUNT; index++) {
         serialPortConfig_t *portConfig = &serialConfigToCheck->portConfigs[index];
 
-        if (portConfig->functionMask & FUNCTION_MSP) {
+        if ((portConfig->functionMask & FUNCTION_MSP)
+    		    || (portConfig->functionMask & (FUNCTION_RX_SERIAL + FUNCTION_BLACKBOX))) {
             mspPortCount++;
         }
 
@@ -211,11 +212,13 @@ bool isSerialConfigValid(serialConfig_t *serialConfigToCheck)
                 return false;
             }
 
-            if (!(portConfig->functionMask & FUNCTION_MSP)) {
+            if ((!(portConfig->functionMask & FUNCTION_MSP)
+            		&& !(portConfig->functionMask & (FUNCTION_RX_SERIAL + FUNCTION_BLACKBOX)))) {
                 return false;
             }
 
-            if (!(portConfig->functionMask & ALL_FUNCTIONS_SHARABLE_WITH_MSP)) {
+            if (!(portConfig->functionMask & ALL_FUNCTIONS_SHARABLE_WITH_MSP)
+                && !(portConfig->functionMask & ALL_FUNCTIONS_SHARABLE_WITH_BLACKBOX)){
                 // some other bit must have been set.
                 return false;
             }

--- a/src/main/io/serial.h
+++ b/src/main/io/serial.h
@@ -63,6 +63,9 @@ typedef enum {
 
 extern const serialPortIdentifier_e serialPortIdentifiers[SERIAL_PORT_COUNT];
 
+#define ALL_FUNCTIONS_SHARABLE_WITH_BLACKBOX (FUNCTION_RX_SERIAL)
+#define ALL_FUNCTIONS_SHARABLE_WITH_RX_SERIAL (FUNCTION_BLACKBOX)
+
 //
 // runtime
 //
@@ -74,6 +77,7 @@ typedef struct serialPortUsage_s {
 
 serialPort_t *findSharedSerialPort(uint16_t functionMask, serialPortFunction_e sharedWithFunction);
 serialPort_t *findNextSharedSerialPort(uint16_t functionMask, serialPortFunction_e sharedWithFunction);
+serialPortUsage_t *findSerialPortUsageByIdentifier(serialPortIdentifier_e identifier);
 
 //
 // configuration
@@ -107,7 +111,6 @@ serialPortConfig_t *findNextSerialPortConfig(serialPortFunction_e function);
 
 portSharing_e determinePortSharing(serialPortConfig_t *portConfig, serialPortFunction_e function);
 bool isSerialPortShared(serialPortConfig_t *portConfig, uint16_t functionMask, serialPortFunction_e sharedWithFunction);
-
 
 
 //

--- a/src/main/rx/spektrum.c
+++ b/src/main/rx/spektrum.c
@@ -87,7 +87,19 @@ bool spektrumInit(rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig, rcRe
         return false;
     }
 
-    serialPort_t *spektrumPort = openSerialPort(portConfig->identifier, FUNCTION_RX_SERIAL, spektrumDataReceive, SPEKTRUM_BAUDRATE, MODE_RX, SERIAL_NOT_INVERTED);
+    portMode_t serialPortMode;
+    portSharing_e serialPortSharing = determinePortSharing(portConfig, FUNCTION_RX_SERIAL);
+    if (serialPortSharing == PORTSHARING_SHARED){
+    	if (portConfig->functionMask & ALL_FUNCTIONS_SHARABLE_WITH_RX_SERIAL)
+            serialPortMode = MODE_RXTX;
+    	else
+    		return false;
+    	}
+    else {
+        serialPortMode = MODE_RX;
+    }
+
+    serialPort_t *spektrumPort = openSerialPort(portConfig->identifier, FUNCTION_RX_SERIAL, spektrumDataReceive, SPEKTRUM_BAUDRATE, serialPortMode, SERIAL_NOT_INVERTED);
 
     return spektrumPort != NULL;
 }

--- a/src/main/rx/xbus.c
+++ b/src/main/rx/xbus.c
@@ -114,16 +114,27 @@ bool xBusInit(rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig, rcReadRa
             break;
     }
 
-    if (callback) {
+    if (callback)
         *callback = xBusReadRawRC;
-    }
 
     serialPortConfig_t *portConfig = findSerialPortConfig(FUNCTION_RX_SERIAL);
     if (!portConfig) {
         return false;
     }
 
-    serialPort_t *xBusPort = openSerialPort(portConfig->identifier, FUNCTION_RX_SERIAL, xBusDataReceive, baudRate, MODE_RX, SERIAL_NOT_INVERTED);
+    portMode_t serialPortMode;
+    portSharing_e serialPortSharing = determinePortSharing(portConfig, FUNCTION_RX_SERIAL);
+    if (serialPortSharing == PORTSHARING_SHARED){
+    	if (portConfig->functionMask & ALL_FUNCTIONS_SHARABLE_WITH_RX_SERIAL)
+            serialPortMode = MODE_RXTX;
+    	else
+    		return false;
+    	}
+    else {
+        serialPortMode = MODE_RX;
+    }
+
+    serialPort_t *xBusPort = openSerialPort(portConfig->identifier, FUNCTION_RX_SERIAL, xBusDataReceive, baudRate, serialPortMode, SERIAL_NOT_INVERTED);
 
     return xBusPort != NULL;
 }


### PR DESCRIPTION
Serial_RX receiver and blackbox OpenLog use RX and TX lines of UART respectively.
Up to now they cannot share the same UART which results in costly configuration.

This proposal allows connecting a serial RX and an OpenLog board on the same UART through full duplex operation. The RX and TX communications are here limited to 115200 bds (hardcoded serialRX baudrate).

I only tested the code with a sumD receiver and a 3500us looptime. Any testings for other receivers (spektrum, sbus, sumh and xbus) and looptime are of course welcome.

This mod has no incidence on recording data to the onboard flash memory chip.

Thanks for your comments.
