### PR TITLE
selecting beeper mode with CLI command

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -551,6 +551,8 @@ static void resetConf(void)
     masterConfig.blackbox_rate_denom = 1;
 #endif
 
+    masterConfig.beeper_mode = 1;    // 1 = mode normal ; 0 = inverted
+
     // alternative defaults settings for COLIBRI RACE targets
 #if defined(COLIBRI_RACE)
     masterConfig.looptime = 1000;

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -70,10 +70,6 @@
 #include "config/config_profile.h"
 #include "config/config_master.h"
 
-#ifdef NAZE
-#include "hardware_revision.h"
-#endif
-
 #define BRUSHED_MOTORS_PWM_RATE 16000
 #define BRUSHLESS_MOTORS_PWM_RATE 400
 
@@ -556,15 +552,7 @@ static void resetConf(void)
 #endif
 
 #ifdef BEEPER
-#ifdef BEEPER_INVERTED
-    masterConfig.beeper_mode = 1;    // normal operation for NPN transistor (PP output)
-#else
-    masterConfig.beeper_mode = 0;    // normal operation for PNP transistor (OD output)
-#endif
-#ifdef NAZE
-    if (hardwareRevision >= NAZE32_REV5)
-        masterConfig.beeper_mode = 1;
-#endif
+    masterConfig.beeper_output_inversion = false;    // normal beeping
 #endif
 
     // alternative defaults settings for COLIBRI RACE targets

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -70,6 +70,10 @@
 #include "config/config_profile.h"
 #include "config/config_master.h"
 
+#ifdef NAZE
+#include "hardware_revision.h"
+#endif
+
 #define BRUSHED_MOTORS_PWM_RATE 16000
 #define BRUSHLESS_MOTORS_PWM_RATE 400
 

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -551,7 +551,17 @@ static void resetConf(void)
     masterConfig.blackbox_rate_denom = 1;
 #endif
 
-    masterConfig.beeper_mode = 1;    // 1 = mode normal ; 0 = inverted
+#ifdef BEEPER
+#ifdef BEEPER_INVERTED
+    masterConfig.beeper_mode = 1;    // normal operation for NPN transistor (PP output)
+#else
+    masterConfig.beeper_mode = 0;    // normal operation for PNP transistor (OD output)
+#endif
+#ifdef NAZE
+    if (hardwareRevision >= NAZE32_REV5)
+        masterConfig.beeper_mode = 1;
+#endif
+#endif
 
     // alternative defaults settings for COLIBRI RACE targets
 #if defined(COLIBRI_RACE)

--- a/src/main/config/config_master.h
+++ b/src/main/config/config_master.h
@@ -99,6 +99,8 @@ typedef struct master_t {
     uint8_t blackbox_device;
 #endif
 
+    uint8_t beeper_mode;    // 1 = mode normal ; 0 = inverted
+
     uint8_t magic_ef;                       // magic number, should be 0xEF
     uint8_t chk;                            // XOR checksum
 } master_t;

--- a/src/main/config/config_master.h
+++ b/src/main/config/config_master.h
@@ -99,7 +99,7 @@ typedef struct master_t {
     uint8_t blackbox_device;
 #endif
 
-    uint8_t beeper_mode;    // 1 = mode normal ; 0 = inverted
+    uint8_t beeper_mode;
 
     uint8_t magic_ef;                       // magic number, should be 0xEF
     uint8_t chk;                            // XOR checksum

--- a/src/main/config/config_master.h
+++ b/src/main/config/config_master.h
@@ -99,7 +99,9 @@ typedef struct master_t {
     uint8_t blackbox_device;
 #endif
 
-    uint8_t beeper_mode;
+#ifdef BEEPER
+    bool beeper_output_inversion;
+#endif
 
     uint8_t magic_ef;                       // magic number, should be 0xEF
     uint8_t chk;                            // XOR checksum

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -545,7 +545,9 @@ const clivalue_t valueTable[] = {
     { "magzero_y",                  VAR_INT16  | MASTER_VALUE, &masterConfig.magZero.raw[Y], -32768, 32767 },
     { "magzero_z",                  VAR_INT16  | MASTER_VALUE, &masterConfig.magZero.raw[Z], -32768, 32767 },
 
+#ifdef BEEPER
     { "beeper_mode",                VAR_UINT8  | MASTER_VALUE, &masterConfig.beeper_mode, 0, 1 },
+#endif
 };
 
 #define VALUE_COUNT (sizeof(valueTable) / sizeof(clivalue_t))

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -546,7 +546,7 @@ const clivalue_t valueTable[] = {
     { "magzero_z",                  VAR_INT16  | MASTER_VALUE, &masterConfig.magZero.raw[Z], -32768, 32767 },
 
 #ifdef BEEPER
-    { "beeper_mode",                VAR_UINT8  | MASTER_VALUE, &masterConfig.beeper_mode, 0, 1 },
+    { "beeper_output_inversion",    VAR_UINT8  | MASTER_VALUE, &masterConfig.beeper_output_inversion, 0, 1 },
 #endif
 };
 

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -544,6 +544,8 @@ const clivalue_t valueTable[] = {
     { "magzero_x",                  VAR_INT16  | MASTER_VALUE, &masterConfig.magZero.raw[X], -32768, 32767 },
     { "magzero_y",                  VAR_INT16  | MASTER_VALUE, &masterConfig.magZero.raw[Y], -32768, 32767 },
     { "magzero_z",                  VAR_INT16  | MASTER_VALUE, &masterConfig.magZero.raw[Z], -32768, 32767 },
+
+    { "beeper_mode",                VAR_UINT8  | MASTER_VALUE, &masterConfig.beeper_mode, 0, 1 },
 };
 
 #define VALUE_COUNT (sizeof(valueTable) / sizeof(clivalue_t))

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -278,19 +278,25 @@ void init(void)
         .gpioPeripheral = BEEP_PERIPHERAL,
         .gpioPin = BEEP_PIN,
         .gpioPort = BEEP_GPIO,
-        .isInverted = masterConfig.beeper_mode,
 #ifdef BEEPER_INVERTED
         .gpioMode = Mode_Out_PP,
+        .isInverted = true,
 #else
         .gpioMode = Mode_Out_OD,
+        .isInverted = false,
 #endif
     };
 #ifdef NAZE
     if (hardwareRevision >= NAZE32_REV5) {
         // naze rev4 and below used opendrain to PNP for buzzer. Rev5 and above use PP to NPN.
         beeperConfig.gpioMode = Mode_Out_PP;
+        beeperConfig.isInverted = true;
     }
 #endif
+
+    if (masterConfig.beeper_output_inversion){
+    	beeperConfig.isInverted = !beeperConfig.isInverted;
+    }
 
     beeperInit(&beeperConfig);
 #endif

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -278,19 +278,17 @@ void init(void)
         .gpioPeripheral = BEEP_PERIPHERAL,
         .gpioPin = BEEP_PIN,
         .gpioPort = BEEP_GPIO,
+        .isInverted = masterConfig.beeper_mode,
 #ifdef BEEPER_INVERTED
         .gpioMode = Mode_Out_PP,
-        .isInverted = masterConfig.beeper_mode
 #else
         .gpioMode = Mode_Out_OD,
-        .isInverted = false
 #endif
     };
 #ifdef NAZE
     if (hardwareRevision >= NAZE32_REV5) {
         // naze rev4 and below used opendrain to PNP for buzzer. Rev5 and above use PP to NPN.
         beeperConfig.gpioMode = Mode_Out_PP;
-        beeperConfig.isInverted = masterConfig.beeper_mode;
     }
 #endif
 

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -280,7 +280,7 @@ void init(void)
         .gpioPort = BEEP_GPIO,
 #ifdef BEEPER_INVERTED
         .gpioMode = Mode_Out_PP,
-        .isInverted = true
+        .isInverted = masterConfig.beeper_mode
 #else
         .gpioMode = Mode_Out_OD,
         .isInverted = false
@@ -290,7 +290,7 @@ void init(void)
     if (hardwareRevision >= NAZE32_REV5) {
         // naze rev4 and below used opendrain to PNP for buzzer. Rev5 and above use PP to NPN.
         beeperConfig.gpioMode = Mode_Out_PP;
-        beeperConfig.isInverted = true;
+        beeperConfig.isInverted = masterConfig.beeper_mode;
     }
 #endif
 


### PR DESCRIPTION
This proposal is related to issue #1099.

A CLI parameter (*beeper_mode*) is added to allow beeper in normal way (*set beeper_mode = 1*) or inverted (*set beeper_mode = 0*).

Also related to PR #1309 where *beeper_off_flags* should be set to 0 in inverted mode to be turned off.