### PR TITLE
fix for LED strip initialization invalid memory write

### DIFF
--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -382,6 +382,10 @@ void updateLedCount(void)
     ledCount = 0;
     ledsInRingCount = 0;
 
+    if( ledConfigs == 0 ){
+        return;
+    }
+
     for (ledIndex = 0; ledIndex < MAX_LED_STRIP_LENGTH; ledIndex++) {
 
         ledConfig = &ledConfigs[ledIndex];


### PR DESCRIPTION
I've noticed that function "updateLedCount" can be executed when global variable "ledConfigs" is zero, which results writing to memory at 0x0.
The call stack when this happens is:

0 updateLedCount ledstrip.c 389
1 reevalulateLedConfig ledstrip.c 403
2 applyDefaultLedStripConfig ledstrip.c 1031
3 resetConf config.c 545
4 resetEEPROM config.c 992
5 ensureEEPROMContainsValidData config.c 987
6 init main.c 154
7 main main.c 528

Looks like the function "applyDefaultLedStripConfig" reevaluates global LED config before it's initialized.

(Sorry for duplicate issue. Someone (me) didn't read docs about separate branch for pull requests)