### PR TITLE
Enabled G-Tune for RMRC Dodo target

### DIFF
--- a/src/main/target/RMDO/target.h
+++ b/src/main/target/RMDO/target.h
@@ -152,6 +152,7 @@
 #define WS2811_IRQ                      DMA1_Channel2_IRQn
 
 #define GPS
+#define GTUNE
 #define BLACKBOX
 #define TELEMETRY
 #define SERIAL_RX


### PR DESCRIPTION
Enable G-Tune for the RMRC Dodo target as done for the NAZE recently.