### PR TITLE
MSP_SET_RXFAIL_CONFIG changed to allow more future RX channels

### DIFF
--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -1633,16 +1633,12 @@ static bool processInCommand(void)
         break;
 
     case MSP_SET_RXFAIL_CONFIG:
-        {
-            uint8_t channelCount = currentPort->dataSize / 3;
-            if (channelCount > MAX_SUPPORTED_RC_CHANNEL_COUNT) {
-                headSerialError(0);
-            } else {
-                for (i = 0; i < channelCount; i++) {
-                    masterConfig.rxConfig.failsafe_channel_configurations[i].mode = read8();
-                    masterConfig.rxConfig.failsafe_channel_configurations[i].step = CHANNEL_VALUE_TO_RXFAIL_STEP(read16());
-                }
-            }
+        i = read8();
+        if (i < MAX_SUPPORTED_RC_CHANNEL_COUNT) {
+            masterConfig.rxConfig.failsafe_channel_configurations[i].mode = read8();
+            masterConfig.rxConfig.failsafe_channel_configurations[i].step = CHANNEL_VALUE_TO_RXFAIL_STEP(read16());
+        } else {
+            headSerialError(0);
         }
         break;
 


### PR DESCRIPTION
@hydra This is the change you mentioned on IRC the other day:
~~~
[22:04] <hydra_> ProDrone: if we ever support more than 18 channels we will have a problem with this:
[22:04] <hydra_> #define MSP_SET_RXFAIL_CONFIG           78 //in message          Sets RXFAIL settings
[22:04] <hydra_> #define INBUF_SIZE 64
[22:05] <hydra_> 18 * 3 = 54
[22:05] <hydra_> just so you're aware.
[22:05] <hydra_> a different approach is taken for things like the LED_STRIP configuration, etc.
[22:06] <hydra_> an index is supplied with the data. and one message is set for each index that needs to be sent.
[22:07] <hydra_> in an alternative world the FC would then be sent up to 18 rxfail messages, each with an index and 3 extra bytes payload
[22:07] <hydra_> no worries.  might be worth doing this now before the next configurator and CF release
[22:07] <hydra_> see if you think it's worth it.
[22:08] <hydra_> it simplifies the FC code but complicates the configurator code, but a pattern is already set in the configurator so you can follow it.
[22:09] <hydra_> it's not complicated to do either.
[22:09] <hydra_> I'll merge the configurator changes now, since they will work with the current code.
[22:09] <hydra_> then you can give me a PR for both if you have time.
~~~

__NOTES:__
- This goes together with configurator pull request: https://github.com/cleanflight/cleanflight-configurator/pull/303
- I did NOT bump the API minor because this only changes a message introduced at 1.15 and is not yet used somewhere else.