### PR TITLE
Servo angle for tilting, part 2

### DIFF
--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -705,7 +705,7 @@ int16_t getMix(uint8_t rule_index)
         case INPUT_STABILIZED_ROLL:
         case INPUT_STABILIZED_PITCH:
         case INPUT_STABILIZED_YAW:
-            //WARINING: this list of case works only if the order in rcData index enum is the same of inputSource_e
+            //WARNING: this list of case works only if the order in rcData index enum is the same of inputSource_e
             if (FLIGHT_MODE(PASSTHRU_MODE)) {
                 responseRange = rcCommand[input_from - INPUT_STABILIZED_ROLL];
             } else {
@@ -729,7 +729,7 @@ int16_t getMix(uint8_t rule_index)
         case INPUT_RC_AUX2:
         case INPUT_RC_AUX3:
         case INPUT_RC_AUX4:
-            //WARINING: this list of case works only if the order in rcData index enum is the same of inputSource_e
+            //WARNING: this list of case works only if the order in rcData index enum is the same of inputSource_e
             responseRange = rcData[input_from - INPUT_RC_ROLL] - rxConfig->midrc;
             break;
 
@@ -784,84 +784,6 @@ STATIC_UNIT_TESTED void servoMixer(void)
         servo[i] += determineServoMiddleOrForwardFromChannel(i);
     }
 }
-/*
-STATIC_UNIT_TESTED void servoMixer(void)
-{
-    int16_t input[INPUT_SOURCE_COUNT]; // Range [-500:+500]
-    static int16_t currentOutput[MAX_SERVO_RULES];
-    uint8_t i;
-
-    if (FLIGHT_MODE(PASSTHRU_MODE)) {
-        // Direct passthru from RX
-        input[INPUT_STABILIZED_ROLL] = rcCommand[ROLL];
-        input[INPUT_STABILIZED_PITCH] = rcCommand[PITCH];
-        input[INPUT_STABILIZED_YAW] = rcCommand[YAW];
-    } else {
-        // Assisted modes (gyro only or gyro+acc according to AUX configuration in Gui
-        input[INPUT_STABILIZED_ROLL] = axisPID[ROLL];
-        input[INPUT_STABILIZED_PITCH] = axisPID[PITCH];
-        input[INPUT_STABILIZED_YAW] = axisPID[YAW];
-
-        // Reverse yaw servo when inverted in 3D mode
-        if (feature(FEATURE_3D) && (rcData[THROTTLE] < rxConfig->midrc)) {
-            input[INPUT_STABILIZED_YAW] *= -1;
-        }
-    }
-
-    input[INPUT_GIMBAL_PITCH] = scaleRange(inclination.values.pitchDeciDegrees, -1800, 1800, -500, +500);
-    input[INPUT_GIMBAL_ROLL] = scaleRange(inclination.values.rollDeciDegrees, -1800, 1800, -500, +500);
-
-    input[INPUT_STABILIZED_THROTTLE] = motor[0] - 1000 - 500;  // Since it derives from rcCommand or mincommand and must be [-500:+500]
-
-    // center the RC input value around the RC middle value
-    // by subtracting the RC middle value from the RC input value, we get:
-    // data - middle = input
-    // 2000 - 1500 = +500
-    // 1500 - 1500 = 0
-    // 1000 - 1500 = -500
-    input[INPUT_RC_ROLL]     = rcData[ROLL]     - rxConfig->midrc;
-    input[INPUT_RC_PITCH]    = rcData[PITCH]    - rxConfig->midrc;
-    input[INPUT_RC_YAW]      = rcData[YAW]      - rxConfig->midrc;
-    input[INPUT_RC_THROTTLE] = rcData[THROTTLE] - rxConfig->midrc;
-    input[INPUT_RC_AUX1]     = rcData[AUX1]     - rxConfig->midrc;
-    input[INPUT_RC_AUX2]     = rcData[AUX2]     - rxConfig->midrc;
-    input[INPUT_RC_AUX3]     = rcData[AUX3]     - rxConfig->midrc;
-    input[INPUT_RC_AUX4]     = rcData[AUX4]     - rxConfig->midrc;
-
-    for (i = 0; i < MAX_SUPPORTED_SERVOS; i++)
-        servo[i] = 0;
-
-    // mix servos according to rules
-    for (i = 0; i < servoRuleCount; i++) {
-        // consider rule if no box assigned or box is active
-        if (currentServoMixer[i].box == 0 || IS_RC_MODE_ACTIVE(BOXSERVO1 + currentServoMixer[i].box - 1)) {
-            uint8_t target = currentServoMixer[i].targetChannel;
-            uint8_t from = currentServoMixer[i].inputSource;
-            uint16_t servo_width = servoConf[target].max - servoConf[target].min;
-            int16_t min = currentServoMixer[i].min * servo_width / 100 - servo_width / 2;
-            int16_t max = currentServoMixer[i].max * servo_width / 100 - servo_width / 2;
-
-            if (currentServoMixer[i].speed == 0)
-                currentOutput[i] = input[from];
-            else {
-                if (currentOutput[i] < input[from])
-                    currentOutput[i] = constrain(currentOutput[i] + currentServoMixer[i].speed, currentOutput[i], input[from]);
-                else if (currentOutput[i] > input[from])
-                    currentOutput[i] = constrain(currentOutput[i] - currentServoMixer[i].speed, input[from], currentOutput[i]);
-            }
-
-            servo[target] += servoDirection(target, from) * constrain(((int32_t)currentOutput[i] * currentServoMixer[i].rate) / 100, min, max);
-        } else {
-            currentOutput[i] = 0;
-        }
-    }
-
-    for (i = 0; i < MAX_SUPPORTED_SERVOS; i++) {
-        servo[i] = ((int32_t)servoConf[i].rate * servo[i]) / 100L;
-        servo[i] += determineServoMiddleOrForwardFromChannel(i);
-    }
-}
-*/
 #endif
 
 void mixTable(void)

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -666,14 +666,14 @@ static int16_t decidegreeToServoPulse(uint8_t servo_index, int16_t angle_deci_de
     // normalize angle to range -180 to 180 (degree)
     while (angle_deci_degree > 1800)
         angle_deci_degree -= 3600;
-    while (angle_deci_degree < -1800)
+    while (angle_deci_degree < -1799) //prevent an angle to be -1800, it will be 1800
         angle_deci_degree += 3600;
 
     //remap input value (RX limit) to output value (Servo limit), also take into account eventual non-linearity of the two half range
     if (angle_deci_degree > 0) {
-        angle_deci_degree = scaleRange(angle_deci_degree, 0, servoConf[servo_index].angleAtMax * 10, 0, servoConf[servo_index].max);
+        angle_deci_degree = scaleRange(angle_deci_degree, 0, servoConf[servo_index].angleAtMax * 10, servoConf[servo_index].middle, servoConf[servo_index].max);
     } else {
-        angle_deci_degree = scaleRange(angle_deci_degree, 0, servoConf[servo_index].angleAtMin * 10, 0, servoConf[servo_index].min);
+        angle_deci_degree = scaleRange(angle_deci_degree, 0, -servoConf[servo_index].angleAtMin * 10, servoConf[servo_index].middle, servoConf[servo_index].min);
     }
 
     return angle_deci_degree;
@@ -687,7 +687,7 @@ int16_t getMix(uint8_t rule_index)
     uint8_t servo_index = currentServoMixer[rule_index].targetChannel;
 
     // consider rule only if no box assigned or box is active
-    if (!currentServoMixer[rule_index].box == 0 && !IS_RC_MODE_ACTIVE(BOXSERVO1 + currentServoMixer[rule_index].box - 1)) {
+    if (currentServoMixer[rule_index].box != 0 && !IS_RC_MODE_ACTIVE(BOXSERVO1 + currentServoMixer[rule_index].box - 1)) {
         currentOutput[servo_index] = 0;
         return rxConfig->midrc;
     }


### PR DESCRIPTION
While adding support to use real angle to servo i had to change a bit the servoMixer, so I decided to move a bit thing around, fix a couple of bug and optimize a bit
- Fixed to use full range of the servo instead of limiting to [-500:500](needed for 180° servo's)
- Fixed to scale correctly the full range of the servo instead of cutting to [min:max](needed if we want artificially limit servo PWM to smaller range than [-500:500], used when rate is < abs%28100%%29)
- Support to use angle to PWM function, with INPUT_GIMBAL_PITCH and INPUT_GIMBAL_ROLL as an example. To prevent the scale of the range applied above to mess up with our fine-tuned PWM, just set needScale to false
- calculate only used input and once for every rule: because if we use angle to PWM, the output PWM depend from the target servo. Anyway as no mixer reuse the same input two time, it is an optimization, and also make possible to (next point):
- got rid of the "input" array
- rate %, if used with fine mode, will act as a soft limitation over the full range instead of scaling the final output (of course scaling the output was making the precise angle to PWM fail)

hope you will enjoy that code as much as i had to write it :)

part of #925 
