### PR TITLE
LLIGHTS support added on NAZE boards

### DIFF
--- a/docs/Board - Naze32.md
+++ b/docs/Board - Naze32.md
@@ -42,6 +42,11 @@ When SOFTSERIAL is enabled, LED_STRIP and CURRENT_METER are unavailable, but two
 | 9   | 7          | SOFTSERIAL2 RX |                                  |
 | 10  | 8          | SOFTSERIAL2 TX |                                  |
 
+Some boards have two additional GPIO pads connected internally to PB5 and PA15 pins. 
+The PA15 pin is driven by the LLIGHTS "mode" (positive logic - is high when the mode is on). 
+This allows to remotely switch the Landing Lights (or whatever else appliance). 
+Note that LEDs shall not be directly connected to this pin. Use N-MOSFET open-drain or equivalent circuit.
+
 ## Recovery
 
 ### Board

--- a/docs/Modes.md
+++ b/docs/Modes.md
@@ -20,7 +20,7 @@ auxillary receiver channels and other events such as failsafe detection.
 | 13      | 12     | BEEPERON   | Enable beeping - useful for locating a crashed aircraft              |
 | 14      | 13     | LEDMAX     |                                                                      |
 | 15      | 14     | LEDLOW     |                                                                      |
-| 16      | 15     | LLIGHTS    |                                                                      |
+| 16      | 15     | LLIGHTS    | Enable landing lights (extra GPIO binary output)                     |
 | 17      | 16     | CALIB      |                                                                      |
 | 18      | 17     | GOV        |                                                                      |
 | 19      | 18     | OSD        | Enable/Disable On-Screen-Display (OSD)                               |

--- a/src/main/drivers/light_led.h
+++ b/src/main/drivers/light_led.h
@@ -64,4 +64,15 @@
 #define LED2_ON                  do {} while(0)
 #endif
 
+
+#ifdef USE_LLIGHTS
+#define LLIGHTS_OFF             digitalLo(LLIGHTS_GPIO, LLIGHTS_PIN)
+#define LLIGHTS_ON              digitalHi(LLIGHTS_GPIO, LLIGHTS_PIN)
+#else
+#define LLIGHTS_OFF             do {} while(0)
+#define LLIGHTS_ON              do {} while(0)
+#endif
+
+
 void ledInit(void);
+void updateLlights(void);

--- a/src/main/drivers/light_led_stm32f10x.c
+++ b/src/main/drivers/light_led_stm32f10x.c
@@ -26,12 +26,14 @@
 #include "system.h"
 #include "gpio.h"
 
+#include "io/rc_controls.h"
+
 #include "light_led.h"
 
 
 void ledInit(void)
 {
-#if defined(LED0) || defined(LED1) || defined(LED2)
+#if defined(LED0) || defined(LED1) || defined(LED2) || defined(USE_LLIGHTS)
     uint32_t i;
 
     struct {
@@ -56,6 +58,12 @@ void ledInit(void)
             .cfg = { LED2_PIN, Mode_Out_PP, Speed_2MHz }
         }
 #endif
+#ifdef USE_LLIGHTS
+        {
+            .gpio = LLIGHTS_GPIO,
+            .cfg = { LLIGHTS_PIN, Mode_Out_PP, Speed_2MHz }
+        }
+#endif
     };
 
     uint8_t gpio_count = ARRAYLEN(gpio_setup);
@@ -69,10 +77,14 @@ void ledInit(void)
 #ifdef LED2
     RCC_APB2PeriphClockCmd(LED2_PERIPHERAL, ENABLE);
 #endif
+#ifdef USE_LLIGHTS
+    RCC_APB2PeriphClockCmd(LLIGHTS_PERIPHERAL, ENABLE);
+#endif
 
     LED0_OFF;
     LED1_OFF;
     LED2_OFF;
+    LLIGHTS_OFF;
 
     for (i = 0; i < gpio_count; i++) {
         gpioInit(gpio_setup[i].gpio, &gpio_setup[i].cfg);
@@ -81,3 +93,14 @@ void ledInit(void)
 #endif
 }
 
+#ifdef USE_LLIGHTS
+void updateLlights(void)
+{
+	if (IS_RC_MODE_ACTIVE(BOXLLIGHTS)) {
+		LLIGHTS_ON;
+	}
+	else {
+		LLIGHTS_OFF;
+	}
+}
+#endif

--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -673,6 +673,10 @@ void mspInit(serialConfig_t *serialConfig)
     }
 #endif
 
+#ifdef USE_LLIGHTS
+    activeBoxIds[activeBoxIdCount++] = BOXLLIGHTS;
+#endif
+
     if (feature(FEATURE_INFLIGHT_ACC_CAL))
         activeBoxIds[activeBoxIdCount++] = BOXCALIB;
 

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -855,4 +855,8 @@ void loop(void)
         updateLedStrip();
     }
 #endif
+
+#ifdef USE_LLIGHTS
+    updateLlights();
+#endif
 }

--- a/src/main/target/NAZE/target.h
+++ b/src/main/target/NAZE/target.h
@@ -29,6 +29,11 @@
 #define LED1_PIN    Pin_4 // PB4 (LED)
 #define LED1_PERIPHERAL RCC_APB2Periph_GPIOB
 
+#define USE_LLIGHTS
+#define LLIGHTS_GPIO   GPIOA
+#define LLIGHTS_PIN    Pin_15 // PA15 (general purpose GPIO pad)
+#define LLIGHTS_PERIPHERAL RCC_APB2Periph_GPIOA
+
 #define BEEP_GPIO   GPIOA
 #define BEEP_PIN    Pin_12 // PA12 (Beeper)
 #define BEEP_PERIPHERAL RCC_APB2Periph_GPIOA


### PR DESCRIPTION
This uses one of unused GPIO pads present on the NAZE boards.
