### PR TITLE
Enabling magnetometer/compass back in CJMCU target

### DIFF
--- a/src/main/target/CJMCU/target.h
+++ b/src/main/target/CJMCU/target.h
@@ -40,8 +40,8 @@
 #define GYRO
 #define USE_GYRO_MPU6050
 
-//#define MAG
-//#define USE_MAG_HMC5883
+#define MAG
+#define USE_MAG_HMC5883
 
 #define BRUSHED_MOTORS
 


### PR DESCRIPTION
This patch just enable magnetometer which was disabled (by error ?) for CJMCU board during merge of G-Tune branch to the master.