### PR TITLE
Expand FIR coefficients for faster looptimes

### DIFF
--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -43,15 +43,18 @@ float filterApplyPt1(float input, filterStatePt1_t *filter, uint8_t f_cut, float
  *  450-sized, 920kv, 9.4x4.3 props, 3S : 4622rpm = 77Hz
  *  250-sized, 2300kv, 5x4.5 props, 4S : 14139rpm = 235Hz
  */
-static int8_t gyroFIRCoeff_1000[3][9] = { { 0, 0, 12, 23, 40, 51, 52, 40, 38 },    // looptime=1000; group delay 2.5ms; -0.5db = 32Hz ; -1db = 45Hz; -5db = 97Hz; -10db = 132Hz
-                                          { 18, 30, 42, 46, 40, 34, 22, 8, 8},     // looptime=1000; group delay 3ms;   -0.5db = 18Hz ; -1db = 33Hz; -5db = 81Hz; -10db = 113Hz
-                                          { 18, 12, 28, 40, 44, 40, 32, 22, 20} }; // looptime=1000; group delay 4ms;   -0.5db = 23Hz ; -1db = 35Hz; -5db = 75Hz; -10db = 103Hz
-static int8_t gyroFIRCoeff_2000[3][9] = { { 0, 0, 0, 6, 24, 58, 82, 64, 20 },      // looptime=2000, group delay 4ms;   -0.5db = 21Hz ; -1db = 31Hz; -5db = 71Hz; -10db = 99Hz
-                                          { 0, 0, 14, 22, 46, 60, 56, 40, 24},     // looptime=2000, group delay 5ms;   -0.5db = 20Hz ; -1db = 26Hz; -5db = 52Hz; -10db = 71Hz
-                                          { 14, 12, 26, 38, 44, 42, 34, 24, 20} }; // looptime=2000, group delay 7ms;   -0.5db = 11Hz ; -1db = 18Hz; -5db = 38Hz; -10db = 52Hz
-static int8_t gyroFIRCoeff_3000[3][9] = { { 0, 0, 0, 0, 4, 36, 88, 88, 44 },       // looptime=3000, group delay 4.5ms; -0.5db = 18Hz ; -1db = 26Hz; -5db = 57Hz; -10db = 78Hz
-                                          { 0, 0, 0, 14, 32, 64, 72, 54, 28},      // looptime=3000, group delay 6.5ms; -0.5db = 16Hz ; -1db = 21Hz; -5db = 42Hz; -10db = 57Hz
-                                          { 0, 6, 10, 28, 44, 54, 54, 38, 22} };   // looptime=3000, group delay 9ms;   -0.5db = 10Hz ; -1db = 13Hz; -5db = 32Hz; -10db = 45Hz
+static int8_t gyroFIRCoeff_500[3][FILTER_TAPS] = { { 0, 18, 14, 16, 20, 22, 24, 25, 25, 24, 20, 18, 12, 18 },  // TODO - NEEDS TABLE
+                                                  { 23, 12, 16, 18, 20, 20, 23, 20, 22, 18, 16, 14, 12, 22 },  //
+                                                  { 36, 12, 14, 14, 16, 16, 18, 18, 18, 16, 16, 14, 12, 36 } };//
+static int8_t gyroFIRCoeff_1000[3][FILTER_TAPS] = { { 0, 0, 0, 0, 0, 0, 0, 12, 23, 40, 51, 52, 40, 38 }, // looptime=1000; group delay 2.5ms; -0.5db = 32Hz ; -1db = 45Hz; -5db = 97Hz; -10db = 132Hz
+                                                  { 0, 0, 0, 0, 0, 18, 30, 42, 46, 40, 34, 22, 8, 8},    // looptime=1000; group delay 3ms;   -0.5db = 18Hz ; -1db = 33Hz; -5db = 81Hz; -10db = 113Hz
+                                                  { 0, 0, 0, 0, 0, 18, 12, 28, 40, 44, 40, 32, 22, 20} };// looptime=1000; group delay 4ms;   -0.5db = 23Hz ; -1db = 35Hz; -5db = 75Hz; -10db = 103Hz
+static int8_t gyroFIRCoeff_2000[3][FILTER_TAPS] = { { 0, 0, 0, 0, 0, 0, 0, 0, 6, 24, 58, 82, 64, 20 },   // looptime=2000, group delay 4ms;   -0.5db = 21Hz ; -1db = 31Hz; -5db = 71Hz; -10db = 99Hz
+                                                  { 0, 0, 0, 0, 0, 0, 0, 14, 22, 46, 60, 56, 40, 24},    // looptime=2000, group delay 5ms;   -0.5db = 20Hz ; -1db = 26Hz; -5db = 52Hz; -10db = 71Hz
+                                                  { 0, 0, 0, 0, 0, 14, 12, 26, 38, 44, 42, 34, 24, 20} };// looptime=2000, group delay 7ms;   -0.5db = 11Hz ; -1db = 18Hz; -5db = 38Hz; -10db = 52Hz
+static int8_t gyroFIRCoeff_3000[3][FILTER_TAPS] = { { 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 36, 88, 88, 44 },    // looptime=3000, group delay 4.5ms; -0.5db = 18Hz ; -1db = 26Hz; -5db = 57Hz; -10db = 78Hz
+                                                  { 0, 0, 0, 0, 0, 0, 0, 0, 14, 32, 64, 72, 54, 28},     // looptime=3000, group delay 6.5ms; -0.5db = 16Hz ; -1db = 21Hz; -5db = 42Hz; -10db = 57Hz
+                                                  { 0, 0, 0, 0, 0, 0, 6, 10, 28, 44, 54, 54, 38, 22} };  // looptime=3000, group delay 9ms;   -0.5db = 10Hz ; -1db = 13Hz; -5db = 32Hz; -10db = 45Hz
 
 int8_t * filterGetFIRCoefficientsTable(uint8_t filter_level, uint16_t targetLooptime)
 {
@@ -61,7 +64,12 @@ int8_t * filterGetFIRCoefficientsTable(uint8_t filter_level, uint16_t targetLoop
 
     int firIndex = constrain(filter_level, 1, 3) - 1;
 
-    // For looptimes faster than 1499 (and looptime=0) use filter for 1kHz looptime
+    // For looptimes faster than  700 use filter for 2kHz looptime
+    if (targetLooptime < 700) {
+        return gyroFIRCoeff_500[firIndex];
+    }
+
+    // For looptimes faster than 1499 use filter for 1kHz looptime
     if (targetLooptime < 1500) {
         return gyroFIRCoeff_1000[firIndex];
     }
@@ -77,19 +85,19 @@ int8_t * filterGetFIRCoefficientsTable(uint8_t filter_level, uint16_t targetLoop
 
 // 9 Tap FIR filter as described here:
 // Thanks to Qcopter & BorisB & DigitalEntity
-void filterApply9TapFIR(int16_t data[3], int16_t state[3][9], int8_t coeff[9])
+void filterApplyFIR(int16_t data[3], int16_t state[3][FILTER_TAPS], int8_t coeff[FILTER_TAPS])
 {
     int32_t FIRsum;
     int axis, i;
 
     for (axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
         FIRsum = 0;
-        for (i = 0; i <= 7; i++) {
+        for (i = 0; i <= FILTER_TAPS-2; i++) {
             state[axis][i] = state[axis][i + 1];
             FIRsum += state[axis][i] * (int16_t)coeff[i];
         }
-        state[axis][8] = data[axis];
-        FIRsum += state[axis][8] * coeff[8];
+        state[axis][FILTER_TAPS-1] = data[axis];
+        FIRsum += state[axis][FILTER_TAPS-1] * coeff[FILTER_TAPS-1];
         data[axis] = FIRsum / 256;
     }
 }

--- a/src/main/common/filter.h
+++ b/src/main/common/filter.h
@@ -15,6 +15,8 @@
  * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#define FILTER_TAPS 14
+
 typedef struct filterStatePt1_s {
 	float state;
 	float RC;
@@ -23,4 +25,4 @@ typedef struct filterStatePt1_s {
 
 float filterApplyPt1(float input, filterStatePt1_t *filter, uint8_t f_cut, float dt);
 int8_t * filterGetFIRCoefficientsTable(uint8_t filter_level, uint16_t targetLooptime);
-void filterApply9TapFIR(int16_t data[3], int16_t state[3][9], int8_t coeff[9]);
+void filterApplyFIR(int16_t data[3], int16_t state[3][FILTER_TAPS], int8_t coeff[FILTER_TAPS]);

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -39,7 +39,7 @@ int16_t gyroZero[FLIGHT_DYNAMICS_INDEX_COUNT] = { 0, 0, 0 };
 
 static gyroConfig_t *gyroConfig;
 static int8_t * gyroFIRTable = 0L;
-static int16_t gyroFIRState[3][9];
+static int16_t gyroFIRState[3][FILTER_TAPS];
 
 gyro_t gyro;                      // gyro access functions
 sensor_align_e gyroAlign = 0;
@@ -126,7 +126,7 @@ void gyroUpdate(void)
     }
 
     if (gyroFIRTable) {
-        filterApply9TapFIR(gyroADC, gyroFIRState, gyroFIRTable);
+        filterApplyFIR(gyroADC, gyroFIRState, gyroFIRTable);
     }
 
     alignSensors(gyroADC, gyroADC, gyroAlign);


### PR DESCRIPTION
@digitalentity 
Since gyro sync got merged. What do you think of this? It's for those who like faster looptimes with higher gyro refresh rates.

Maybe some more tables to put in there?


The 2khz filter coeffiecients work well. The HIGH filter may not be enough, but we may consider removing 3 level filtering and stick to 2 level filtering.