### PR TITLE
updated atomic.h for gcc 5

### DIFF
--- a/src/main/common/atomic.h
+++ b/src/main/common/atomic.h
@@ -83,7 +83,7 @@ static inline uint8_t __basepriSetRetVal(uint8_t prio)
 // ideally this would only protect memory passed as parameter (any type should work), but gcc is currently creating almost full barrier
 // this macro can be used only ONCE PER LINE, but multiple uses per block are fine
 
-#if (__GNUC__ > 4)
+#if (__GNUC__ > 5)
 #warning "Please verify that ATOMIC_BARRIER works as intended"
 // increment version number is BARRIER works
 // TODO - use flag to disable ATOMIC_BARRIER and use full barrier instead


### PR DESCRIPTION
gcc 5 has been out for a while and in now the default ARM cross compiler in e.g. Arch Linux.

The gcc 5 generated assembly code follows expectations (Issue 167).

gcc 5 generated firmware has been flight tested in both acrobatic modes (latest betaflight) and navigations modes (with soft serial telemetry, inav-scheduler and inav-gps-rewrite branches).
 
There is no longer any reason to issue a warning in atomic.h