### PR TITLE
Test code for PIDs

### DIFF
--- a/src/main/config/config_unittest.h
+++ b/src/main/config/config_unittest.h
@@ -1,0 +1,75 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+
+#ifdef SRC_MAIN_FLIGHT_PID_C_
+#ifdef UNIT_TEST
+
+float unittest_pidLuxFloat_lastError[3];
+float unittest_pidLuxFloat_delta1[3];
+float unittest_pidLuxFloat_delta2[3];
+float unittest_pidLuxFloat_PTerm[3];
+float unittest_pidLuxFloat_ITerm[3];
+float unittest_pidLuxFloat_DTerm[3];
+
+#define SET_PID_LUX_FLOAT_LOCALS(axis) \
+    { \
+        lastError[axis] = unittest_pidLuxFloat_lastError[axis]; \
+        delta1[axis] = unittest_pidLuxFloat_delta1[axis]; \
+        delta2[axis] = unittest_pidLuxFloat_delta2[axis]; \
+    }
+
+#define GET_PID_LUX_FLOAT_LOCALS(axis) \
+    { \
+        unittest_pidLuxFloat_lastError[axis] = lastError[axis]; \
+        unittest_pidLuxFloat_delta1[axis] = delta1[axis]; \
+        unittest_pidLuxFloat_delta2[axis] = delta2[axis]; \
+        unittest_pidLuxFloat_PTerm[axis] = PTerm; \
+        unittest_pidLuxFloat_ITerm[axis] = ITerm; \
+        unittest_pidLuxFloat_DTerm[axis] = DTerm; \
+    }
+
+int32_t unittest_pidMultiWiiRewrite_lastError[3];
+int32_t unittest_pidMultiWiiRewrite_PTerm[3];
+int32_t unittest_pidMultiWiiRewrite_ITerm[3];
+int32_t unittest_pidMultiWiiRewrite_DTerm[3];
+
+#define SET_PID_MULTI_WII_REWRITE_LOCALS(axis) \
+    { \
+    lastError[axis] = unittest_pidMultiWiiRewrite_lastError[axis]; \
+    }
+
+#define GET_PID_MULTI_WII_REWRITE_LOCALS(axis) \
+    { \
+        unittest_pidMultiWiiRewrite_lastError[axis] = lastError[axis]; \
+        unittest_pidMultiWiiRewrite_PTerm[axis] = PTerm; \
+        unittest_pidMultiWiiRewrite_ITerm[axis] = ITerm; \
+        unittest_pidMultiWiiRewrite_DTerm[axis] = DTerm; \
+    }
+
+#else
+
+#define SET_PID_LUX_FLOAT_LOCALS(axis) {}
+#define GET_PID_LUX_FLOAT_LOCALS(axis) {}
+#define SET_PID_MULTI_WII_REWRITE_LOCALS(axis) {}
+#define GET_PID_MULTI_WII_REWRITE_LOCALS(axis) {}
+
+#endif // UNIT_TEST
+#endif // SRC_MAIN_FLIGHT_PID_C_
+

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -182,7 +182,7 @@ static void pidLuxFloat(pidProfile_t *pidProfile, controlRateConfig_t *controlRa
         }
 
         // -----calculate I component.
-        errorGyroIf[axis] = constrainf(errorGyroIf[axis] + RateError * dT * pidProfile->I_f[axis] * 10, -250.0f, 250.0f);
+        errorGyroIf[axis] = constrainf(errorGyroIf[axis] + RateError * dT * pidProfile->I_f[axis] * 10, -PID_LUX_FLOAT_MAX_I, PID_LUX_FLOAT_MAX_I);
 
         // limit maximum integrator value to prevent WindUp - accumulating extreme values when system is saturated.
         // I coefficient (I8) moved before integration to make limiting independent from PID settings
@@ -212,10 +212,10 @@ static void pidLuxFloat(pidProfile_t *pidProfile, controlRateConfig_t *controlRa
             deltaSum = filterApplyPt1(deltaSum, &DTermState[axis], pidProfile->dterm_cut_hz, dT);
         }
 
-        DTerm = constrainf(deltaSum * pidProfile->D_f[axis] * PIDweight[axis] / 100, -300.0f, 300.0f);
+        DTerm = constrainf(deltaSum * pidProfile->D_f[axis] * PIDweight[axis] / 100, -PID_LUX_FLOAT_MAX_D, PID_LUX_FLOAT_MAX_D);
 
         // -----calculate total PID output
-        axisPID[axis] = constrain(lrintf(PTerm + ITerm + DTerm), -1000, 1000);
+        axisPID[axis] = constrain(lrintf(PTerm + ITerm + DTerm), -PID_LUX_FLOAT_MAX_PID, PID_LUX_FLOAT_MAX_PID);
 
 #ifdef GTUNE
         if (FLIGHT_MODE(GTUNE_MODE) && ARMING_FLAG(ARMED)) {

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -15,6 +15,8 @@
  * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#define SRC_MAIN_FLIGHT_PID_C_
+
 #include <stdbool.h>
 #include <stdint.h>
 #include <math.h>
@@ -45,6 +47,7 @@
 #include "flight/gtune.h"
 
 #include "config/runtime_config.h"
+#include "config/config_unittest.h"
 
 extern uint16_t cycleTime;
 extern uint8_t motorCount;
@@ -132,6 +135,7 @@ static void pidLuxFloat(pidProfile_t *pidProfile, controlRateConfig_t *controlRa
 
     // ----------PID controller----------
     for (axis = 0; axis < 3; axis++) {
+        SET_PID_LUX_FLOAT_LOCALS(axis);
         // -----Get the desired angle rate depending on flight mode
         uint8_t rate = controlRateConfig->rates[axis];
 
@@ -224,6 +228,7 @@ static void pidLuxFloat(pidProfile_t *pidProfile, controlRateConfig_t *controlRa
         axisPID_I[axis] = ITerm;
         axisPID_D[axis] = DTerm;
 #endif
+        GET_PID_LUX_FLOAT_LOCALS(axis);
     }
 }
 
@@ -397,6 +402,7 @@ static void pidMultiWiiRewrite(pidProfile_t *pidProfile, controlRateConfig_t *co
 
     // ----------PID controller----------
     for (axis = 0; axis < 3; axis++) {
+        SET_PID_MULTI_WII_REWRITE_LOCALS(axis);
         uint8_t rate = controlRateConfig->rates[axis];
 
         // -----Get the desired angle rate depending on flight mode
@@ -488,6 +494,7 @@ static void pidMultiWiiRewrite(pidProfile_t *pidProfile, controlRateConfig_t *co
         axisPID_I[axis] = ITerm;
         axisPID_D[axis] = DTerm;
 #endif
+    GET_PID_MULTI_WII_REWRITE_LOCALS(axis);
     }
 }
 

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -17,6 +17,10 @@
 
 #pragma once
 
+#define PID_LUX_FLOAT_MAX_I 250.0f
+#define PID_LUX_FLOAT_MAX_D 300.0f
+#define PID_LUX_FLOAT_MAX_PID 1000
+
 #define GYRO_I_MAX 256                      // Gyro I limiter
 #define YAW_P_LIMIT_MIN 100                 // Maximum value for yaw P limiter
 #define YAW_P_LIMIT_MAX 500                 // Maximum value for yaw P limiter

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -577,6 +577,31 @@ $(OBJECT_DIR)/sonar_unittest : \
 
 	$(CXX) $(CXX_FLAGS) $^ -o $(OBJECT_DIR)/$@
 
+$(OBJECT_DIR)/flight/pid.o : \
+	$(USER_DIR)/flight/pid.c \
+	$(USER_DIR)/flight/pid.h \
+	$(GTEST_HEADERS)
+
+	@mkdir -p $(dir $@)
+	$(CC) $(C_FLAGS) $(TEST_CFLAGS) -DBLACKBOX -c $(USER_DIR)/flight/pid.c -o $@
+
+$(OBJECT_DIR)/pid_unittest.o : \
+	$(TEST_DIR)/pid_unittest.cc \
+	$(USER_DIR)/flight/pid.h \
+	$(GTEST_HEADERS)
+
+	@mkdir -p $(dir $@)
+	$(CXX) $(CXX_FLAGS) $(TEST_CFLAGS) -c $(TEST_DIR)/pid_unittest.cc -o $@
+
+$(OBJECT_DIR)/pid_unittest : \
+	$(OBJECT_DIR)/common/maths.o \
+	$(OBJECT_DIR)/common/filter.o \
+	$(OBJECT_DIR)/flight/pid.o \
+	$(OBJECT_DIR)/pid_unittest.o \
+	$(OBJECT_DIR)/gtest_main.a
+
+	$(CXX) $(CXX_FLAGS) $^ -o $(OBJECT_DIR)/$@
+
 $(OBJECT_DIR)/sensors/boardalignment.o : \
 	$(USER_DIR)/sensors/boardalignment.c \
 	$(USER_DIR)/sensors/boardalignment.h \

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -251,8 +251,8 @@ TEST(PIDUnittest, TestPidLuxFloat)
     // run the PID controller. Check expected PID values
     // Note D value is multiplied by 1/3 because it is part of 3 point moving average, first two terms initially zero.
     float ITermRoll = calcLuxITerm(&pidProfile, FD_ROLL, rateErrorRoll);
-    float ITermPitch = calcLuxITerm(&pidProfile, FD_ROLL, rateErrorPitch);
-    float ITermYaw = calcLuxITerm(&pidProfile, FD_ROLL, rateErrorYaw);
+    float ITermPitch = calcLuxITerm(&pidProfile, FD_PITCH, rateErrorPitch);
+    float ITermYaw = calcLuxITerm(&pidProfile, FD_YAW, rateErrorYaw);
     pid_controller(&pidProfile, &controlRate, max_angle_inclination, &rollAndPitchTrims, &rxConfig);
     EXPECT_FLOAT_EQ(calcLuxPTerm(&pidProfile, FD_ROLL, rateErrorRoll), unittest_pidLuxFloat_PTerm[FD_ROLL]);
     EXPECT_FLOAT_EQ(ITermRoll, unittest_pidLuxFloat_ITerm[FD_ROLL]);
@@ -267,7 +267,7 @@ TEST(PIDUnittest, TestPidLuxFloat)
     // run the PID controller a second time.
     // Error rates unchanged, so expect P unchanged, I integrated and D multiplied by 1/3 (2 of 3 terms in moving average are zero)
     ITermRoll += calcLuxITerm(&pidProfile, FD_ROLL, rateErrorRoll);
-    ITermPitch += calcLuxITerm(&pidProfile, FD_ROLL, rateErrorPitch);
+    ITermPitch += calcLuxITerm(&pidProfile, FD_PITCH, rateErrorPitch);
     pid_controller(&pidProfile, &controlRate, max_angle_inclination, &rollAndPitchTrims, &rxConfig);
     EXPECT_FLOAT_EQ(calcLuxPTerm(&pidProfile, FD_ROLL, rateErrorRoll), unittest_pidLuxFloat_PTerm[FD_ROLL]);
     EXPECT_FLOAT_EQ(ITermRoll, unittest_pidLuxFloat_ITerm[FD_ROLL]);
@@ -279,7 +279,7 @@ TEST(PIDUnittest, TestPidLuxFloat)
     // run the PID controller a third time. Error rates unchanged, so expect P and D unchanged, I integrated
     // Error rates unchanged, so expect P unchanged, I integrated and D multiplied by 1/3 (2 of 3 terms in moving average are zero)
     ITermRoll += calcLuxITerm(&pidProfile, FD_ROLL, rateErrorRoll);
-    ITermPitch += calcLuxITerm(&pidProfile, FD_ROLL, rateErrorPitch);
+    ITermPitch += calcLuxITerm(&pidProfile, FD_PITCH, rateErrorPitch);
     pid_controller(&pidProfile, &controlRate, max_angle_inclination, &rollAndPitchTrims, &rxConfig);
     EXPECT_FLOAT_EQ(calcLuxPTerm(&pidProfile, FD_ROLL, rateErrorRoll), unittest_pidLuxFloat_PTerm[FD_ROLL]);
     EXPECT_FLOAT_EQ(ITermRoll, unittest_pidLuxFloat_ITerm[FD_ROLL]);
@@ -291,7 +291,7 @@ TEST(PIDUnittest, TestPidLuxFloat)
     // run the PID controller a fourth time.
     // Error rates unchanged, so expect P unchanged, I integrated and D zero, since all terms in moving average are now zero
     ITermRoll += calcLuxITerm(&pidProfile, FD_ROLL, rateErrorRoll);
-    ITermPitch += calcLuxITerm(&pidProfile, FD_ROLL, rateErrorPitch);
+    ITermPitch += calcLuxITerm(&pidProfile, FD_PITCH, rateErrorPitch);
     pid_controller(&pidProfile, &controlRate, max_angle_inclination, &rollAndPitchTrims, &rxConfig);
     EXPECT_FLOAT_EQ(calcLuxPTerm(&pidProfile, FD_ROLL, rateErrorRoll), unittest_pidLuxFloat_PTerm[FD_ROLL]);
     EXPECT_FLOAT_EQ(ITermRoll, unittest_pidLuxFloat_ITerm[FD_ROLL]);

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -1,0 +1,630 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+#include <math.h>
+
+extern "C" {
+    #include "build_config.h"
+    #include "debug.h"
+
+    #include "common/axis.h"
+    #include "common/maths.h"
+
+    #include "drivers/sensor.h"
+    #include "drivers/accgyro.h"
+    #include "sensors/sensors.h"
+    #include "sensors/acceleration.h"
+
+    #include "rx/rx.h"
+    #include "io/rc_controls.h"
+
+    #include "flight/pid.h"
+    #include "flight/imu.h"
+
+    #include "config/runtime_config.h"
+    #include "config/config_unittest.h"
+}
+
+#include "unittest_macros.h"
+#include "gtest/gtest.h"
+
+extern "C" {
+    void pidSetController(pidControllerType_e type);
+    typedef void (*pidControllerFuncPtr)(pidProfile_t *pidProfile, controlRateConfig_t *controlRateConfig,
+            uint16_t max_angle_inclination, rollAndPitchTrims_t *angleTrim, rxConfig_t *rxConfig);            // pid controller function prototype
+    extern pidControllerFuncPtr pid_controller;
+    extern uint8_t PIDweight[3];
+    float dT; // dT for pidLuxFloat
+    int32_t cycleTime; // cycleTime for pidMultiWiiRewrite
+    float unittest_pidLuxFloat_lastError[3];
+    float unittest_pidLuxFloat_PTerm[3];
+    float unittest_pidLuxFloat_ITerm[3];
+    float unittest_pidLuxFloat_DTerm[3];
+    float unittest_pidLuxFloat_delta1[3];
+    float unittest_pidLuxFloat_delta2[3];
+    int32_t unittest_pidMultiWiiRewrite_lastError[3];
+    int32_t unittest_pidMultiWiiRewrite_PTerm[3];
+    int32_t unittest_pidMultiWiiRewrite_ITerm[3];
+    int32_t unittest_pidMultiWiiRewrite_DTerm[3];
+}
+
+void resetPidProfile(pidProfile_t *pidProfile)
+{
+    pidProfile->pidController = 1;
+
+    pidProfile->P8[PIDROLL] = 40;
+    pidProfile->I8[PIDROLL] = 30;
+    pidProfile->D8[PIDROLL] = 23;
+    pidProfile->P8[PIDPITCH] = 40;
+    pidProfile->I8[PIDPITCH] = 30;
+    pidProfile->D8[PIDPITCH] = 23;
+    pidProfile->P8[PIDYAW] = 85;
+    pidProfile->I8[PIDYAW] = 45;
+    pidProfile->D8[PIDYAW] = 0;
+    pidProfile->P8[PIDALT] = 50;
+    pidProfile->I8[PIDALT] = 0;
+    pidProfile->D8[PIDALT] = 0;
+    pidProfile->P8[PIDPOS] = 15; // POSHOLD_P * 100;
+    pidProfile->I8[PIDPOS] = 0; // POSHOLD_I * 100;
+    pidProfile->D8[PIDPOS] = 0;
+    pidProfile->P8[PIDPOSR] = 34; // POSHOLD_RATE_P * 10;
+    pidProfile->I8[PIDPOSR] = 14; // POSHOLD_RATE_I * 100;
+    pidProfile->D8[PIDPOSR] = 53; // POSHOLD_RATE_D * 1000;
+    pidProfile->P8[PIDNAVR] = 25; // NAV_P * 10;
+    pidProfile->I8[PIDNAVR] = 33; // NAV_I * 100;
+    pidProfile->D8[PIDNAVR] = 83; // NAV_D * 1000;
+    pidProfile->P8[PIDLEVEL] = 90;
+    pidProfile->I8[PIDLEVEL] = 10;
+    pidProfile->D8[PIDLEVEL] = 100;
+    pidProfile->P8[PIDMAG] = 40;
+    pidProfile->P8[PIDVEL] = 120;
+    pidProfile->I8[PIDVEL] = 45;
+    pidProfile->D8[PIDVEL] = 1;
+
+    pidProfile->yaw_p_limit = YAW_P_LIMIT_MAX;
+    pidProfile->gyro_soft_lpf = 0;   // no filtering by default
+    pidProfile->yaw_pterm_cut_hz = 0;
+    pidProfile->dterm_cut_hz = 0;
+
+    pidProfile->P_f[FD_ROLL] = 1.4f;     // new PID with preliminary defaults test carefully
+    pidProfile->I_f[FD_ROLL] = 0.4f;
+    pidProfile->D_f[FD_ROLL] = 0.03f;
+    pidProfile->P_f[FD_PITCH] = 1.4f;
+    pidProfile->I_f[FD_PITCH] = 0.4f;
+    pidProfile->D_f[FD_PITCH] = 0.03f;
+    pidProfile->P_f[FD_YAW] = 3.5f;
+    pidProfile->I_f[FD_YAW] = 0.4f;
+    pidProfile->D_f[FD_YAW] = 0.01f;
+    pidProfile->A_level = 5.0f;
+    pidProfile->H_level = 3.0f;
+    pidProfile->H_sensitivity = 75;
+
+#ifdef GTUNE
+    pidProfile->gtune_lolimP[FD_ROLL] = 10;          // [0..200] Lower limit of ROLL P during G tune.
+    pidProfile->gtune_lolimP[FD_PITCH] = 10;         // [0..200] Lower limit of PITCH P during G tune.
+    pidProfile->gtune_lolimP[FD_YAW] = 10;           // [0..200] Lower limit of YAW P during G tune.
+    pidProfile->gtune_hilimP[FD_ROLL] = 100;         // [0..200] Higher limit of ROLL P during G tune. 0 Disables tuning for that axis.
+    pidProfile->gtune_hilimP[FD_PITCH] = 100;        // [0..200] Higher limit of PITCH P during G tune. 0 Disables tuning for that axis.
+    pidProfile->gtune_hilimP[FD_YAW] = 100;          // [0..200] Higher limit of YAW P during G tune. 0 Disables tuning for that axis.
+    pidProfile->gtune_pwr = 0;                    // [0..10] Strength of adjustment
+    pidProfile->gtune_settle_time = 450;          // [200..1000] Settle time in ms
+    pidProfile->gtune_average_cycles = 16;        // [8..128] Number of looptime cycles used for gyro average calculation
+#endif
+}
+
+void pidControllerInitLuxFloat(pidProfile_t *pidProfile, controlRateConfig_t *controlRate, uint16_t max_angle_inclination, rollAndPitchTrims_t *rollAndPitchTrims, rxConfig_t *rxConfig)
+{
+    UNUSED(max_angle_inclination);
+    UNUSED(rxConfig);
+
+    pidSetController(PID_CONTROLLER_LUX_FLOAT);
+    resetPidProfile(pidProfile);
+    resetRollAndPitchTrims(rollAndPitchTrims);
+    pidResetErrorAngle();
+    pidResetErrorGyro();
+    dT = 0.1f;
+    // set up the PIDWeights to 100%, so they are neutral in the tests
+    PIDweight[FD_ROLL] = 100;
+    PIDweight[FD_PITCH] = 100;
+    PIDweight[FD_YAW] = 100;
+    // set up the control rates for calculation of rate error
+    controlRate->rates[ROLL] = 80;
+    controlRate->rates[PITCH] = 80;
+    controlRate->rates[YAW] = 90;
+    // reset the pidLuxFloat static values
+    for (int ii = FD_ROLL; ii <= FD_YAW; ++ii) {
+        unittest_pidLuxFloat_lastError[ii] = 0.0f;
+        unittest_pidLuxFloat_delta1[ii] = 0.0f;
+        unittest_pidLuxFloat_delta2[ii] = 0.0f;
+    }
+}
+
+/*
+ * calculate the value of rcCommand[ROLL] required to give a desired rateError
+ */
+int16_t calcLuxRcCommandRoll(float rateError, const controlRateConfig_t *controlRate) {
+    return 50.0f * rateError / (controlRate->rates[ROLL] + 20);
+}
+
+/*
+ * calculate the angleRate as done in pidLuxFloat, used for cross checking
+ */
+float calcLuxAngleRateRoll(const controlRateConfig_t *controlRate) {
+    return ((controlRate->rates[ROLL] + 20) * rcCommand[ROLL]) / 50.0f;
+}
+
+/*
+ * calculate the value of rcCommand[PITCH] required to give a desired rateError
+ */
+int16_t calcLuxRcCommandPitch(float rateError, const controlRateConfig_t *controlRate) {
+    return 50.0f * rateError / (controlRate->rates[PITCH] + 20);
+}
+
+/*
+ * calculate the angleRate as done in pidLuxFloat, used for cross checking
+ */
+float calcLuxAngleRatePitch(const controlRateConfig_t *controlRate) {
+    return ((controlRate->rates[PITCH] + 20) * rcCommand[PITCH]) / 50.0f;
+}
+
+/*
+ * calculate the value of rcCommand[YAW] required to give a desired rateError
+ */
+int16_t calcLuxRcCommandYaw(float rateError, const controlRateConfig_t *controlRate) {
+    return 50.0f * rateError / (controlRate->rates[YAW] + 10);
+}
+
+/*
+ * calculate the angleRate as done in pidLuxFloat, used for cross checking
+ */
+float calcLuxAngleRateYaw(const controlRateConfig_t *controlRate) {
+    return ((controlRate->rates[YAW] + 10) * rcCommand[YAW]) / 50.0f;
+}
+
+float calcLuxPTerm(pidProfile_t *pidProfile, flight_dynamics_index_t axis, float rateError) {
+    return rateError * pidProfile->P_f[axis];
+}
+
+float calcLuxITerm(pidProfile_t *pidProfile, flight_dynamics_index_t axis, float rateError) {
+    return  rateError * pidProfile->I_f[axis] * dT * 10;
+}
+
+float calcLuxDTerm(pidProfile_t *pidProfile, flight_dynamics_index_t axis, float rateError) {
+    return rateError * pidProfile->D_f[axis] * 1.0f / dT;
+}
+
+TEST(PIDUnittest, TestPidLuxFloat)
+{
+    pidProfile_t pidProfile;
+    controlRateConfig_t controlRate;
+    const uint16_t max_angle_inclination = 500; // 50 degrees
+    rollAndPitchTrims_t rollAndPitchTrims;
+    rxConfig_t rxConfig;
+
+    pidControllerInitLuxFloat(&pidProfile, &controlRate, max_angle_inclination, &rollAndPitchTrims, &rxConfig);
+
+    // set up a rateError of zero on all axes
+    rcCommand[ROLL] = calcLuxRcCommandRoll(0, &controlRate);
+    rcCommand[PITCH] = calcLuxRcCommandPitch(0, &controlRate);
+    rcCommand[YAW] = calcLuxRcCommandYaw(0, &controlRate);
+    pid_controller(&pidProfile, &controlRate, max_angle_inclination, &rollAndPitchTrims, &rxConfig);
+    EXPECT_EQ(0, unittest_pidLuxFloat_PTerm[FD_ROLL]);
+    EXPECT_EQ(0, unittest_pidLuxFloat_ITerm[FD_ROLL]);
+    EXPECT_EQ(0, unittest_pidLuxFloat_DTerm[FD_ROLL]);
+    EXPECT_EQ(0, unittest_pidLuxFloat_PTerm[FD_PITCH]);
+    EXPECT_EQ(0, unittest_pidLuxFloat_ITerm[FD_PITCH]);
+    EXPECT_EQ(0, unittest_pidLuxFloat_DTerm[FD_PITCH]);
+    EXPECT_EQ(0, unittest_pidLuxFloat_PTerm[FD_YAW]);
+    EXPECT_EQ(0, unittest_pidLuxFloat_ITerm[FD_YAW]);
+    EXPECT_EQ(0, unittest_pidLuxFloat_DTerm[FD_YAW]);
+
+    // set up a rateError of 100 on the roll axis
+    rcCommand[ROLL] = calcLuxRcCommandRoll(100, &controlRate);
+    const float rateErrorRoll = calcLuxAngleRateRoll(&controlRate);
+    EXPECT_EQ(100, rateErrorRoll);// cross check
+
+    // set up a rateError of 100 on the pitch axis
+    rcCommand[PITCH] = calcLuxRcCommandPitch(100, &controlRate);
+    const float rateErrorPitch = calcLuxAngleRatePitch(&controlRate);
+    EXPECT_EQ(100, rateErrorPitch); // cross check
+
+    // set up a rateError of 100 on the yaw axis
+    rcCommand[YAW] = calcLuxRcCommandYaw(100, &controlRate);
+    const float rateErrorYaw = calcLuxAngleRateYaw(&controlRate);
+    EXPECT_EQ(100, rateErrorYaw); // cross check
+
+    // run the PID controller. Check expected PID values
+    // Note D value is multiplied by 1/3 because it is part of 3 point moving average, first two terms initially zero.
+    float ITermRoll = calcLuxITerm(&pidProfile, FD_ROLL, rateErrorRoll);
+    float ITermPitch = calcLuxITerm(&pidProfile, FD_ROLL, rateErrorPitch);
+    float ITermYaw = calcLuxITerm(&pidProfile, FD_ROLL, rateErrorYaw);
+    pid_controller(&pidProfile, &controlRate, max_angle_inclination, &rollAndPitchTrims, &rxConfig);
+    EXPECT_FLOAT_EQ(calcLuxPTerm(&pidProfile, FD_ROLL, rateErrorRoll), unittest_pidLuxFloat_PTerm[FD_ROLL]);
+    EXPECT_FLOAT_EQ(ITermRoll, unittest_pidLuxFloat_ITerm[FD_ROLL]);
+    EXPECT_FLOAT_EQ(calcLuxDTerm(&pidProfile, FD_ROLL, rateErrorRoll) / 3.0f, unittest_pidLuxFloat_DTerm[FD_ROLL]);
+    EXPECT_FLOAT_EQ(calcLuxPTerm(&pidProfile, FD_PITCH, rateErrorPitch), unittest_pidLuxFloat_PTerm[FD_PITCH]);
+    EXPECT_FLOAT_EQ(ITermPitch, unittest_pidLuxFloat_ITerm[FD_PITCH]);
+    EXPECT_FLOAT_EQ(calcLuxDTerm(&pidProfile, FD_PITCH, rateErrorPitch) / 3.0f, unittest_pidLuxFloat_DTerm[FD_PITCH]);
+    EXPECT_FLOAT_EQ(calcLuxPTerm(&pidProfile, FD_YAW, rateErrorYaw), unittest_pidLuxFloat_PTerm[FD_YAW]);
+    EXPECT_FLOAT_EQ(ITermYaw, unittest_pidLuxFloat_ITerm[FD_YAW]);
+    EXPECT_FLOAT_EQ(calcLuxDTerm(&pidProfile, FD_YAW, rateErrorYaw) / 3.0f, unittest_pidLuxFloat_DTerm[FD_YAW]);
+
+    // run the PID controller a second time.
+    // Error rates unchanged, so expect P unchanged, I integrated and D multiplied by 1/3 (2 of 3 terms in moving average are zero)
+    ITermRoll += calcLuxITerm(&pidProfile, FD_ROLL, rateErrorRoll);
+    ITermPitch += calcLuxITerm(&pidProfile, FD_ROLL, rateErrorPitch);
+    pid_controller(&pidProfile, &controlRate, max_angle_inclination, &rollAndPitchTrims, &rxConfig);
+    EXPECT_FLOAT_EQ(calcLuxPTerm(&pidProfile, FD_ROLL, rateErrorRoll), unittest_pidLuxFloat_PTerm[FD_ROLL]);
+    EXPECT_FLOAT_EQ(ITermRoll, unittest_pidLuxFloat_ITerm[FD_ROLL]);
+    EXPECT_FLOAT_EQ(calcLuxDTerm(&pidProfile, FD_ROLL, rateErrorRoll) / 3.0f, unittest_pidLuxFloat_DTerm[FD_ROLL]);
+    EXPECT_FLOAT_EQ(calcLuxPTerm(&pidProfile, FD_PITCH, rateErrorPitch), unittest_pidLuxFloat_PTerm[FD_PITCH]);
+    EXPECT_FLOAT_EQ(ITermPitch, unittest_pidLuxFloat_ITerm[FD_PITCH]);
+    EXPECT_FLOAT_EQ(calcLuxDTerm(&pidProfile, FD_PITCH, rateErrorPitch) / 3.0f, unittest_pidLuxFloat_DTerm[FD_PITCH]);
+
+    // run the PID controller a third time. Error rates unchanged, so expect P and D unchanged, I integrated
+    // Error rates unchanged, so expect P unchanged, I integrated and D multiplied by 1/3 (2 of 3 terms in moving average are zero)
+    ITermRoll += calcLuxITerm(&pidProfile, FD_ROLL, rateErrorRoll);
+    ITermPitch += calcLuxITerm(&pidProfile, FD_ROLL, rateErrorPitch);
+    pid_controller(&pidProfile, &controlRate, max_angle_inclination, &rollAndPitchTrims, &rxConfig);
+    EXPECT_FLOAT_EQ(calcLuxPTerm(&pidProfile, FD_ROLL, rateErrorRoll), unittest_pidLuxFloat_PTerm[FD_ROLL]);
+    EXPECT_FLOAT_EQ(ITermRoll, unittest_pidLuxFloat_ITerm[FD_ROLL]);
+    EXPECT_FLOAT_EQ(calcLuxDTerm(&pidProfile, FD_ROLL, rateErrorRoll) / 3.0f, unittest_pidLuxFloat_DTerm[FD_ROLL]);
+    EXPECT_FLOAT_EQ(calcLuxPTerm(&pidProfile, FD_PITCH, rateErrorPitch), unittest_pidLuxFloat_PTerm[FD_PITCH]);
+    EXPECT_FLOAT_EQ(ITermPitch, unittest_pidLuxFloat_ITerm[FD_PITCH]);
+    EXPECT_FLOAT_EQ(calcLuxDTerm(&pidProfile, FD_PITCH, rateErrorPitch) / 3.0f, unittest_pidLuxFloat_DTerm[FD_PITCH]);
+
+    // run the PID controller a fourth time.
+    // Error rates unchanged, so expect P unchanged, I integrated and D zero, since all terms in moving average are now zero
+    ITermRoll += calcLuxITerm(&pidProfile, FD_ROLL, rateErrorRoll);
+    ITermPitch += calcLuxITerm(&pidProfile, FD_ROLL, rateErrorPitch);
+    pid_controller(&pidProfile, &controlRate, max_angle_inclination, &rollAndPitchTrims, &rxConfig);
+    EXPECT_FLOAT_EQ(calcLuxPTerm(&pidProfile, FD_ROLL, rateErrorRoll), unittest_pidLuxFloat_PTerm[FD_ROLL]);
+    EXPECT_FLOAT_EQ(ITermRoll, unittest_pidLuxFloat_ITerm[FD_ROLL]);
+    EXPECT_FLOAT_EQ(0, unittest_pidLuxFloat_DTerm[FD_ROLL]);
+    EXPECT_FLOAT_EQ(calcLuxPTerm(&pidProfile, FD_PITCH, rateErrorPitch), unittest_pidLuxFloat_PTerm[FD_PITCH]);
+    EXPECT_FLOAT_EQ(ITermPitch, unittest_pidLuxFloat_ITerm[FD_PITCH]);
+    EXPECT_FLOAT_EQ(0, unittest_pidLuxFloat_DTerm[FD_PITCH]);
+}
+
+TEST(PIDUnittest, TestPidLuxFloatIntegrationForLinearFunction)
+{
+    pidProfile_t pidProfile;
+    controlRateConfig_t controlRate;
+    const uint16_t max_angle_inclination = 500; // 50 degrees
+    rollAndPitchTrims_t rollAndPitchTrims;
+    rxConfig_t rxConfig;
+
+    pidControllerInitLuxFloat(&pidProfile, &controlRate, max_angle_inclination, &rollAndPitchTrims, &rxConfig);
+
+    // Test PID integration for a linear function:
+    //    rateError = k * t
+    // Integral:
+    //    IrateError = 0.5 * k * t ^ 2
+    // dT = 0.1s, t ranges from 0.0 to 1.0 in steps of 0.1s
+
+    const float k = 100; // arbitrary value of k
+    float t = 0.0f;
+    // set rateError to k * t
+    rcCommand[ROLL] = calcLuxRcCommandRoll(k * t, &controlRate);
+    EXPECT_FLOAT_EQ(k * t, calcLuxAngleRateRoll(&controlRate)); // cross check
+    pid_controller(&pidProfile, &controlRate, max_angle_inclination, &rollAndPitchTrims, &rxConfig);
+    float pidITerm = unittest_pidLuxFloat_ITerm[FD_ROLL]; // integral as estimated by PID
+    float actITerm = 0.5 * k * t * t * pidProfile.I_f[ROLL] * 10; // actual value of integral
+    EXPECT_FLOAT_EQ(actITerm, pidITerm); // both are zero at this point
+
+    for (int ii = 0; ii < 10; ++ii) {
+        const float actITermPrev = actITerm;
+        const float pidITermPrev = pidITerm;
+        t += dT;
+        // set rateError to k * t
+        rcCommand[ROLL] = calcLuxRcCommandRoll(k * t, &controlRate);
+        EXPECT_FLOAT_EQ(k * t, calcLuxAngleRateRoll(&controlRate)); // cross check
+        pid_controller(&pidProfile, &controlRate, max_angle_inclination, &rollAndPitchTrims, &rxConfig);
+        pidITerm = unittest_pidLuxFloat_ITerm[FD_ROLL];
+        actITerm = 0.5 * k * t * t * pidProfile.I_f[ROLL] * 10;
+        const float pidITermDelta = pidITerm - pidITermPrev;
+        const float actITermDelta = actITerm - actITermPrev;
+        const float error = fabs(actITermDelta - pidITermDelta);
+        // error is limited by rectangle of height k * dT and width dT (then multiplied by pidProfile)
+        const float errorLimit = k * dT * dT * pidProfile.I_f[ROLL] * 10;
+        EXPECT_GE(errorLimit, error); // ie expect errorLimit >= error
+    }
+}
+
+TEST(PIDUnittest, TestPidLuxFloatITermConstrain)
+{
+    const float PID_LUX_FLOAT_MAX_I = 250.0f; // should be defined in pid.h
+    pidProfile_t pidProfile;
+    controlRateConfig_t controlRate;
+    const uint16_t max_angle_inclination = 500; // 50 degrees
+    rollAndPitchTrims_t rollAndPitchTrims;
+    rxConfig_t rxConfig;
+
+    // set rateError to zero, ITerm should be zero
+    pidControllerInitLuxFloat(&pidProfile, &controlRate, max_angle_inclination, &rollAndPitchTrims, &rxConfig);
+    rcCommand[ROLL] = calcLuxRcCommandRoll(0, &controlRate);
+    float rateErrorRoll = calcLuxAngleRateRoll(&controlRate);
+    EXPECT_EQ(0, rateErrorRoll);// cross check
+    pid_controller(&pidProfile, &controlRate, max_angle_inclination, &rollAndPitchTrims, &rxConfig);
+    EXPECT_EQ(0, unittest_pidLuxFloat_ITerm[FD_ROLL]);
+
+    // set rateError to 100, ITerm should not be constrained
+    pidControllerInitLuxFloat(&pidProfile, &controlRate, max_angle_inclination, &rollAndPitchTrims, &rxConfig);
+    rcCommand[ROLL] = calcLuxRcCommandRoll(100, &controlRate);
+    rateErrorRoll = calcLuxAngleRateRoll(&controlRate);
+    EXPECT_EQ(100, rateErrorRoll);// cross check
+    pid_controller(&pidProfile, &controlRate, max_angle_inclination, &rollAndPitchTrims, &rxConfig);
+    EXPECT_FLOAT_EQ(calcLuxITerm(&pidProfile, FD_ROLL, rateErrorRoll), unittest_pidLuxFloat_ITerm[FD_ROLL]);
+
+    // set up a very large rateError to force ITerm to be constrained
+    pidControllerInitLuxFloat(&pidProfile, &controlRate, max_angle_inclination, &rollAndPitchTrims, &rxConfig);
+    pidProfile.I8[PIDROLL] = 255;
+    rcCommand[ROLL] = calcLuxRcCommandRoll(10000, &controlRate);
+    rateErrorRoll = calcLuxAngleRateRoll(&controlRate);
+    EXPECT_EQ(10000, rateErrorRoll);// cross check
+    pid_controller(&pidProfile, &controlRate, max_angle_inclination, &rollAndPitchTrims, &rxConfig);
+    EXPECT_FLOAT_EQ(PID_LUX_FLOAT_MAX_I, unittest_pidLuxFloat_ITerm[FD_ROLL]);
+}
+
+TEST(PIDUnittest, TestPidLuxFloatDTermConstrain)
+{
+    // Note that for all tests D value is multiplied by 1/3 because it is part of 3 point moving average
+    // the first two terms are initially zero.
+
+    const float PID_LUX_FLOAT_MAX_D = 300.0f; // should be defined in pid.h
+    pidProfile_t pidProfile;
+    controlRateConfig_t controlRate;
+    const uint16_t max_angle_inclination = 500; // 50 degrees
+    rollAndPitchTrims_t rollAndPitchTrims;
+    rxConfig_t rxConfig;
+
+    // set rateError to zero, DTerm should be zero
+    pidControllerInitLuxFloat(&pidProfile, &controlRate, max_angle_inclination, &rollAndPitchTrims, &rxConfig);
+    rcCommand[ROLL] = calcLuxRcCommandRoll(0, &controlRate);
+    float rateErrorRoll = calcLuxAngleRateRoll(&controlRate);
+    EXPECT_EQ(0, rateErrorRoll);// cross check
+    pid_controller(&pidProfile, &controlRate, max_angle_inclination, &rollAndPitchTrims, &rxConfig);
+    EXPECT_EQ(0, unittest_pidLuxFloat_DTerm[FD_ROLL]);
+
+    // set rateError to 100, DTerm should not be constrained
+    pidControllerInitLuxFloat(&pidProfile, &controlRate, max_angle_inclination, &rollAndPitchTrims, &rxConfig);
+    rcCommand[ROLL] = calcLuxRcCommandRoll(100, &controlRate);
+    rateErrorRoll = calcLuxAngleRateRoll(&controlRate);
+    EXPECT_EQ(100, rateErrorRoll);// cross check
+    pid_controller(&pidProfile, &controlRate, max_angle_inclination, &rollAndPitchTrims, &rxConfig);
+    EXPECT_FLOAT_EQ(calcLuxDTerm(&pidProfile, FD_ROLL, rateErrorRoll) / 3.0f, unittest_pidLuxFloat_DTerm[FD_ROLL]);
+
+    // set up a very large rateError to force DTerm to be constrained
+    pidControllerInitLuxFloat(&pidProfile, &controlRate, max_angle_inclination, &rollAndPitchTrims, &rxConfig);
+    rcCommand[ROLL] = calcLuxRcCommandRoll(10000, &controlRate);
+    rateErrorRoll = calcLuxAngleRateRoll(&controlRate);
+    EXPECT_EQ(10000, rateErrorRoll);// cross check
+    pid_controller(&pidProfile, &controlRate, max_angle_inclination, &rollAndPitchTrims, &rxConfig);
+    EXPECT_FLOAT_EQ(PID_LUX_FLOAT_MAX_D, unittest_pidLuxFloat_DTerm[FD_ROLL]);
+
+    // now try a smaller value of dT
+    // set rateError to 50, DTerm should not be constrained
+    pidControllerInitLuxFloat(&pidProfile, &controlRate, max_angle_inclination, &rollAndPitchTrims, &rxConfig);
+    dT = 0.01;
+    rcCommand[ROLL] = calcLuxRcCommandRoll(50, &controlRate);
+    rateErrorRoll = calcLuxAngleRateRoll(&controlRate);
+    EXPECT_EQ(50, rateErrorRoll);// cross check
+    pid_controller(&pidProfile, &controlRate, max_angle_inclination, &rollAndPitchTrims, &rxConfig);
+    EXPECT_FLOAT_EQ(calcLuxDTerm(&pidProfile, FD_ROLL, rateErrorRoll) / 3.0f, unittest_pidLuxFloat_DTerm[FD_ROLL]);
+
+    // now try a test for dT = 0.001, which is typical for real world case
+    // set rateError to 30, DTerm should not be constrained
+    pidControllerInitLuxFloat(&pidProfile, &controlRate, max_angle_inclination, &rollAndPitchTrims, &rxConfig);
+    dT = 0.001;
+    rcCommand[ROLL] = calcLuxRcCommandRoll(30, &controlRate);
+    rateErrorRoll = calcLuxAngleRateRoll(&controlRate);
+    EXPECT_EQ(30, rateErrorRoll);// cross check
+    pid_controller(&pidProfile, &controlRate, max_angle_inclination, &rollAndPitchTrims, &rxConfig);
+    EXPECT_FLOAT_EQ(calcLuxDTerm(&pidProfile, FD_ROLL, rateErrorRoll) / 3.0f, unittest_pidLuxFloat_DTerm[FD_ROLL]);
+
+    // set rateError to 32
+    pidControllerInitLuxFloat(&pidProfile, &controlRate, max_angle_inclination, &rollAndPitchTrims, &rxConfig);
+    dT = 0.001;
+    rcCommand[ROLL] = calcLuxRcCommandRoll(32, &controlRate);
+    rateErrorRoll = calcLuxAngleRateRoll(&controlRate);
+    EXPECT_EQ(32, rateErrorRoll);// cross check
+    pid_controller(&pidProfile, &controlRate, max_angle_inclination, &rollAndPitchTrims, &rxConfig);
+    // following test will fail, since DTerm will be constrained for when dT = 0.001
+    //****//EXPECT_FLOAT_EQ(calcLuxDTerm(&pidProfile, FD_ROLL, rateErrorRoll) / 3.0f, unittest_pidLuxFloat_DTerm[FD_ROLL]);
+}
+
+void pidControllerInitMultiWiiRewrite(pidProfile_t *pidProfile, controlRateConfig_t *controlRate, uint16_t max_angle_inclination, rollAndPitchTrims_t *rollAndPitchTrims, rxConfig_t *rxConfig)
+{
+    UNUSED(max_angle_inclination);
+    UNUSED(rxConfig);
+
+    pidSetController(PID_CONTROLLER_MWREWRITE);
+    resetPidProfile(pidProfile);
+    cycleTime = 2048; // normalised cycleTime for pidMultiWiiRewrite
+    resetRollAndPitchTrims(rollAndPitchTrims);
+    pidResetErrorAngle();
+    pidResetErrorGyro();
+    // set up the PIDWeights to 100%, so they are neutral in the tests
+    PIDweight[FD_ROLL] = 100;
+    PIDweight[FD_PITCH] = 100;
+    PIDweight[FD_YAW] = 100;
+    // set up the control rates for calculation of rate error
+    controlRate->rates[ROLL] = 73;
+    controlRate->rates[PITCH] = 73;
+    controlRate->rates[YAW] = 73;
+    // reset the pidMultiWiiRewrite static values
+    for (int ii = FD_ROLL; ii <= FD_YAW; ++ii) {
+        unittest_pidMultiWiiRewrite_lastError[ii] = 0.0f;
+    }
+}
+
+/*
+ * calculate the value of rcCommand[ROLL] required to give a desired rateError
+ */
+int16_t calcMwrRcCommandRoll(int rateError, const controlRateConfig_t *controlRate) {
+    return (rateError << 4) / ((int32_t)(controlRate->rates[ROLL] + 27));
+}
+
+/*
+ * calculate the angleRate as done in pidMultiWiiRewrite, used for cross checking
+ */
+int32_t calcMwrAngleRateRoll(const controlRateConfig_t *controlRate) {
+    return ((int32_t)(controlRate->rates[ROLL] + 27) * rcCommand[ROLL]) >> 4;
+}
+
+/*
+ * calculate the value of rcCommand[PITCH] required to give a desired rateError
+ */
+int16_t calcMwrRcCommandPitch(int rateError, const controlRateConfig_t *controlRate) {
+    return (rateError << 4) / ((int32_t)(controlRate->rates[PITCH] + 27));
+}
+
+/*
+ * calculate the angleRate as done in pidMultiWiiRewrite, used for cross checking
+ */
+int32_t calcMwrAngleRatePitch(const controlRateConfig_t *controlRate) {
+    return ((int32_t)(controlRate->rates[PITCH] + 27) * rcCommand[PITCH]) >> 4;
+}
+
+/*
+ * calculate the value of rcCommand[YAW] required to give a desired rateError
+ */
+int16_t calcMwrRcCommandYaw(int rateError, const controlRateConfig_t *controlRate) {
+    return (rateError << 5) / ((int32_t)(controlRate->rates[YAW] + 27));
+}
+
+/*
+ * calculate the angleRate as done in pidMultiWiiRewrite, used for cross checking
+ */
+int32_t calcMwrAngleRateYaw(const controlRateConfig_t *controlRate) {
+    return ((int32_t)(controlRate->rates[YAW] + 27) * rcCommand[YAW]) >> 5;
+}
+
+int32_t calcMwrPTerm(pidProfile_t *pidProfile, pidIndex_e axis, int rateError) {
+    return (pidProfile->P8[axis] * rateError) >> 7;
+}
+
+int32_t calcMwrITerm(pidProfile_t *pidProfile, pidIndex_e axis, int rateError) {
+    return pidProfile->I8[axis] * (rateError * cycleTime >> 11) >> 13;
+}
+
+int32_t calcMwrDTerm(pidProfile_t *pidProfile, pidIndex_e axis, int rateError) {
+    return (pidProfile->D8[axis] * (rateError * ((uint16_t) 0xFFFF / (cycleTime >> 4))) >> 6) >> 8;
+}
+
+TEST(PIDUnittest, TestPidMultiWiiRewrite)
+{
+    pidProfile_t pidProfile;
+    resetPidProfile(&pidProfile);
+
+    controlRateConfig_t controlRate;
+
+    const uint16_t max_angle_inclination = 500; // 50 degrees
+    rollAndPitchTrims_t rollAndPitchTrims;
+    rxConfig_t rxConfig;
+    pidControllerInitMultiWiiRewrite(&pidProfile, &controlRate, max_angle_inclination, &rollAndPitchTrims, &rxConfig);
+
+    // set up a rateError of zero on all axes
+    rcCommand[ROLL] = 0;
+    rcCommand[PITCH] = 0;
+    rcCommand[YAW] = 0;
+    pid_controller(&pidProfile, &controlRate, max_angle_inclination, &rollAndPitchTrims, &rxConfig);
+    EXPECT_EQ(0, unittest_pidMultiWiiRewrite_PTerm[FD_ROLL]);
+    EXPECT_EQ(0, unittest_pidMultiWiiRewrite_ITerm[FD_ROLL]);
+    EXPECT_EQ(0, unittest_pidMultiWiiRewrite_DTerm[FD_ROLL]);
+    EXPECT_EQ(0, unittest_pidMultiWiiRewrite_PTerm[FD_PITCH]);
+    EXPECT_EQ(0, unittest_pidMultiWiiRewrite_ITerm[FD_PITCH]);
+    EXPECT_EQ(0, unittest_pidMultiWiiRewrite_DTerm[FD_PITCH]);
+    EXPECT_EQ(0, unittest_pidMultiWiiRewrite_PTerm[FD_YAW]);
+    EXPECT_EQ(0, unittest_pidMultiWiiRewrite_ITerm[FD_YAW]);
+    EXPECT_EQ(0, unittest_pidMultiWiiRewrite_DTerm[FD_YAW]);
+
+    // set up a rateError of 1000 on the roll axis
+    rcCommand[ROLL] = calcMwrRcCommandRoll(1000, &controlRate);
+    const int32_t rateErrorRoll = calcMwrAngleRateRoll(&controlRate);
+    EXPECT_EQ(1000, rateErrorRoll); // cross check
+    // set up a rateError of 1000 on the pitch axis
+    rcCommand[PITCH] = calcMwrRcCommandPitch(1000, &controlRate);
+    const int32_t rateErrorPitch = calcMwrAngleRatePitch(&controlRate);
+    EXPECT_EQ(1000, rateErrorPitch); // cross check
+    // set up a rateError of 1000 on the yaw axis
+    rcCommand[YAW] = calcMwrRcCommandYaw(1000, &controlRate);
+    const int32_t rateErrorYaw = calcMwrAngleRateYaw(&controlRate);
+    EXPECT_EQ(1000, rateErrorYaw); // cross check
+
+    // run the PID controller. Check expected PID values
+    pid_controller(&pidProfile, &controlRate, max_angle_inclination, &rollAndPitchTrims, &rxConfig);
+    EXPECT_EQ(calcMwrPTerm(&pidProfile, PIDROLL, rateErrorRoll), unittest_pidMultiWiiRewrite_PTerm[FD_ROLL]);
+    EXPECT_EQ(calcMwrITerm(&pidProfile, PIDROLL, rateErrorRoll), unittest_pidMultiWiiRewrite_ITerm[FD_ROLL]);
+    EXPECT_EQ(calcMwrDTerm(&pidProfile, PIDROLL, rateErrorRoll), unittest_pidMultiWiiRewrite_DTerm[FD_ROLL]);
+    EXPECT_EQ(calcMwrPTerm(&pidProfile, PIDPITCH, rateErrorPitch), unittest_pidMultiWiiRewrite_PTerm[FD_PITCH]);
+    EXPECT_EQ(calcMwrITerm(&pidProfile, PIDPITCH, rateErrorPitch), unittest_pidMultiWiiRewrite_ITerm[FD_PITCH]);
+    EXPECT_EQ(calcMwrDTerm(&pidProfile, PIDPITCH, rateErrorPitch), unittest_pidMultiWiiRewrite_DTerm[FD_PITCH]);
+    EXPECT_EQ(calcMwrPTerm(&pidProfile, PIDYAW, rateErrorYaw), unittest_pidMultiWiiRewrite_PTerm[FD_YAW]);
+    EXPECT_EQ(calcMwrITerm(&pidProfile, PIDYAW, rateErrorYaw), unittest_pidMultiWiiRewrite_ITerm[FD_YAW]);
+    EXPECT_EQ(calcMwrDTerm(&pidProfile, PIDYAW, rateErrorYaw) , unittest_pidMultiWiiRewrite_DTerm[FD_YAW]);
+}
+
+TEST(PIDUnittest, TestPidMultiWiiRewriteITermConstrain)
+{
+    pidProfile_t pidProfile;
+    controlRateConfig_t controlRate;
+    const uint16_t max_angle_inclination = 500; // 50 degrees
+    rollAndPitchTrims_t rollAndPitchTrims;
+    rxConfig_t rxConfig;
+
+    // set rateError to zero, ITerm should be zero
+    pidControllerInitMultiWiiRewrite(&pidProfile, &controlRate, max_angle_inclination, &rollAndPitchTrims, &rxConfig);
+    rcCommand[ROLL] = calcMwrRcCommandRoll(0, &controlRate);
+    int16_t rateErrorRoll = calcMwrAngleRateRoll(&controlRate);
+    EXPECT_EQ(0, rateErrorRoll);// cross check
+    pid_controller(&pidProfile, &controlRate, max_angle_inclination, &rollAndPitchTrims, &rxConfig);
+    EXPECT_EQ(0, unittest_pidMultiWiiRewrite_ITerm[FD_ROLL]);
+
+    // set rateError to 100, ITerm should not be constrained
+    pidControllerInitMultiWiiRewrite(&pidProfile, &controlRate, max_angle_inclination, &rollAndPitchTrims, &rxConfig);
+    rcCommand[ROLL] = calcMwrRcCommandRoll(100, &controlRate);
+    rateErrorRoll = calcMwrAngleRateRoll(&controlRate);
+    EXPECT_EQ(100, rateErrorRoll);// cross check
+    pid_controller(&pidProfile, &controlRate, max_angle_inclination, &rollAndPitchTrims, &rxConfig);
+    EXPECT_EQ(calcMwrITerm(&pidProfile, PIDROLL, rateErrorRoll), unittest_pidMultiWiiRewrite_ITerm[FD_ROLL]);
+
+    // set up a very large rateError and a large cycleTime to force ITerm to be constrained
+    pidControllerInitMultiWiiRewrite(&pidProfile, &controlRate, max_angle_inclination, &rollAndPitchTrims, &rxConfig);
+    cycleTime = 8192;
+    rcCommand[ROLL] = calcMwrRcCommandRoll(32750, &controlRate); // can't use INT16_MAX, since get rounding error
+    rateErrorRoll = calcMwrAngleRateRoll(&controlRate);
+    EXPECT_EQ(32750, rateErrorRoll);// cross check
+    pid_controller(&pidProfile, &controlRate, max_angle_inclination, &rollAndPitchTrims, &rxConfig);
+    EXPECT_EQ(GYRO_I_MAX, unittest_pidMultiWiiRewrite_ITerm[FD_ROLL]);
+}
+
+// STUBS
+
+extern "C" {
+int16_t GPS_angle[ANGLE_INDEX_COUNT] = { 0, 0 };
+int32_t getRcStickDeflection(int32_t axis, uint16_t midrc) {return MIN(ABS(rcData[axis] - midrc), 500);}
+attitudeEulerAngles_t attitude = { { 0, 0, 0 } };
+void resetRollAndPitchTrims(rollAndPitchTrims_t *rollAndPitchTrims) {rollAndPitchTrims->values.roll = 0;rollAndPitchTrims->values.pitch = 0;};
+uint16_t flightModeFlags = 0; // acro mode
+uint8_t motorCount = 4;
+gyro_t gyro;
+int16_t gyroADC[XYZ_AXIS_COUNT];
+int16_t rcCommand[4] = {1500,0,0,0};           // interval [1000;2000] for THROTTLE and [-500;+500] for ROLL/PITCH/YAW
+int16_t rcData[MAX_SUPPORTED_RC_CHANNEL_COUNT];     // interval [1000;2000]
+}

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -413,8 +413,9 @@ TEST(PIDUnittest, TestPidLuxFloatITermConstrain)
     rcCommand[ROLL] = calcLuxRcCommandRoll(100, &controlRate);
     rateErrorRoll = calcLuxAngleRateRoll(&controlRate);
     EXPECT_EQ(100, rateErrorRoll);// cross check
+    const float ITerm = calcLuxITerm(&pidProfile, FD_ROLL, rateErrorRoll);
     pid_controller(&pidProfile, &controlRate, max_angle_inclination, &rollAndPitchTrims, &rxConfig);
-    EXPECT_FLOAT_EQ(calcLuxITerm(&pidProfile, FD_ROLL, rateErrorRoll), unittest_pidLuxFloat_ITerm[FD_ROLL]);
+    EXPECT_FLOAT_EQ(ITerm, unittest_pidLuxFloat_ITerm[FD_ROLL]);
 
     // set up a very large rateError to force ITerm to be constrained
     pidControllerInitLuxFloat(&pidProfile, &controlRate, max_angle_inclination, &rollAndPitchTrims, &rxConfig);


### PR DESCRIPTION
Tests `pidLuxFloat` and `pidMultiWiiRewrite` with minimal intrusion into `pid.c`. Tests:
* basic operation of PID for roll, pitch, and yaw axes
* that contraints to PID values are applied to avoid very large values of `ITerm` and `DTerm` when `rateError` is very large

Additionally, for `pidLuxFloat`, tests:
* `ITerm` accumulates over multiple calls of  `pid_controller` (ie itegration is acually occuring)
* `DTerm` becomes zero after repeated to `pid_controller` with same `rateError` (ie differential is zero when `rateError` is constant)
* Errors of numeric integration used in `pidLuxFloat` are checked against actual integral (ie using calculus) where `rateError` is a linear function of time.
