### PR TITLE
Fix usage of macros w/ side-effects

### DIFF
--- a/src/main/flight/navigation.c
+++ b/src/main/flight/navigation.c
@@ -417,7 +417,8 @@ void gpsUsePIDs(pidProfile_t *pidProfile)
 //
 static void GPS_calc_longitude_scaling(int32_t lat)
 {
-    float rads = (ABS((float)lat) / 10000000.0f) * 0.0174532925f;
+    lat = ABS(lat);
+    float rads = ((float)lat / 10000000.0f) * 0.0174532925f;
     GPS_scaleLonDown = cos_approx(rads);
 }
 
@@ -586,7 +587,8 @@ static void GPS_calc_nav_rate(uint16_t max_speed)
 //
 static void GPS_update_crosstrack(void)
 {
-    if (ABS(wrap_18000(target_bearing - original_target_bearing)) < 4500) {     // If we are too far off or too close we don't do track following
+    int32_t target_bearing_error = wrap_18000(target_bearing - original_target_bearing);
+    if (ABS(target_bearing_error) < 4500) {     // If we are too far off or too close we don't do track following
         float temp = (target_bearing - original_target_bearing) * RADX100;
         crosstrack_error = sin_approx(temp) * (wp_distance * CROSSTRACK_GAIN); // Meters we are off track line
         nav_bearing = target_bearing + constrain(crosstrack_error, -3000, 3000);

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -238,6 +238,7 @@ static void pidMultiWii23(pidProfile_t *pidProfile, controlRateConfig_t *control
     UNUSED(rxConfig);
 
     int axis, prop = 0;
+    int pitch, roll;
     int32_t rc, error, errorAngle;
     int32_t PTerm, ITerm, PTermACC, ITermACC, DTerm;
     static int16_t lastGyro[2] = { 0, 0 };
@@ -245,7 +246,10 @@ static void pidMultiWii23(pidProfile_t *pidProfile, controlRateConfig_t *control
     int32_t delta;
 
     if (FLIGHT_MODE(HORIZON_MODE)) {
-        prop = MIN(MAX(ABS(rcCommand[PITCH]), ABS(rcCommand[ROLL])), 512);
+        pitch = ABS(rcCommand[PITCH]);
+        roll = ABS(rcCommand[ROLL]);
+        prop = MAX(pitch, roll);
+        prop = MIN(prop, 512);
     }
 
     // PITCH & ROLL

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -183,7 +183,9 @@ void annexCode(void)
     }
 
     for (axis = 0; axis < 3; axis++) {
-        tmp = MIN(ABS(rcData[axis] - masterConfig.rxConfig.midrc), 500);
+        tmp = rcData[axis] - masterConfig.rxConfig.midrc;
+        tmp = ABS(tmp);
+        tmp = MIN(tmp, 500);
         if (axis == ROLL || axis == PITCH) {
             if (currentProfile->rcControlsConfig.deadband) {
                 if (tmp > currentProfile->rcControlsConfig.deadband) {

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -447,7 +447,8 @@ STATIC_UNIT_TESTED uint16_t applyRxChannelRangeConfiguraton(int sample, rxChanne
     }
 
     sample = scaleRange(sample, range.min, range.max, PWM_RANGE_MIN, PWM_RANGE_MAX);
-    sample = MIN(MAX(PWM_PULSE_MIN, sample), PWM_PULSE_MAX);
+    sample = MAX(sample, PWM_PULSE_MIN);
+    sample = MIN(sample, PWM_PULSE_MAX);
 
     return sample;
 }

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -144,6 +144,20 @@ $(OBJECT_DIR)/encoding_unittest : \
 
 	$(CXX) $(CXX_FLAGS) $^ -o $(OBJECT_DIR)/$@
 
+$(OBJECT_DIR)/evil_macro_unittest.o : \
+	$(TEST_DIR)/evil_macro_unittest.cc \
+	$(USER_DIR)/common/maths.h \
+	$(GTEST_HEADERS)
+
+	@mkdir -p $(dir $@)
+	$(CXX) $(CXX_FLAGS) $(TEST_CFLAGS) -c $(TEST_DIR)/evil_macro_unittest.cc -o $@
+
+$(OBJECT_DIR)/evil_macro_unittest : \
+	$(OBJECT_DIR)/evil_macro_unittest.o \
+	$(OBJECT_DIR)/gtest_main.a
+
+	$(CXX) $(CXX_FLAGS) $^ -o $(OBJECT_DIR)/$@
+
 $(OBJECT_DIR)/flight/imu.o : \
 	$(USER_DIR)/flight/imu.c \
 	$(USER_DIR)/flight/imu.h \

--- a/src/test/unit/evil_macro_unittest.cc
+++ b/src/test/unit/evil_macro_unittest.cc
@@ -1,0 +1,57 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include <limits.h>
+
+#include <math.h>
+
+extern "C" {
+#include "common/maths.h"
+}
+
+#include "unittest_macros.h"
+#include "gtest/gtest.h"
+
+TEST(EvilMacroUnittest, TestMinSideeffect)
+{
+    int i = 0, j = 0;
+    // Left argument side-effects
+    EXPECT_EQ(MIN(++i, 2), 2);
+    // Right argument side-effects
+    EXPECT_EQ(MIN(2, ++j), 2);
+}
+
+TEST(EvilMacroUnittest, TestMaxSideeffect)
+{
+    int i = 4, j = 4;
+    // Left argument side-effects
+    EXPECT_EQ(MAX(--i, 2), 2);
+    // Right argument side-effects
+    EXPECT_EQ(MIN(2, --j), 2);
+}
+
+TEST(EvilMacroUnittest, TestAbsSideeffect)
+{
+    int i = 2, j = -2;
+    // Positive argument side-effects
+    EXPECT_EQ(ABS(--i), 0);
+    // Negative argument side-effects
+    EXPECT_EQ(ABS(++j), 0);
+}


### PR DESCRIPTION
Checking usage of MIN/MAX/ABS macros and making sure that no double evaluation of macro arguments is happening.

Since MIN/MAX/ABS macros are evaluating arguments several times, it may lead to unwanted side-effects. Fortunately I was able to find only the code below, which is just a minor inefficiency.