### PR TITLE
Added two commands to reserve MSP values for future expansion.

### DIFF
--- a/src/main/io/serial_msp.h
+++ b/src/main/io/serial_msp.h
@@ -242,8 +242,8 @@ static const char * const boardIdentifier = TARGET_BOARD_IDENTIFIER;
 
 #define MSP_EEPROM_WRITE         250    //in message          no param
 
+#define MSP_DEBUG                252    //out message         debug1,debug2,debug3,debug4
 #define MSP_DEBUGMSG             253    //out message         debug string buffer
-#define MSP_DEBUG                254    //out message         debug1,debug2,debug3,debug4
 
 // Additional commands that are not compatible with MultiWii
 #define MSP_STATUS_EX            150    //out message         cycletime, errors_count, CPU load, sensor present etc
@@ -254,6 +254,10 @@ static const char * const boardIdentifier = TARGET_BOARD_IDENTIFIER;
 #define MSP_SERVO_MIX_RULES      241    //out message         Returns servo mixer configuration
 #define MSP_SET_SERVO_MIX_RULE   242    //in message          Sets servo mixer configuration
 #define MSP_SET_1WIRE            243    //in message          Sets 1Wire paththrough
+
+// Commands reserved for future expansion
+#define MSP_EXTENSION_ONE_BYTE   254   // reserved for extension to allow extra byte for command
+#define MSP_EXTENSION_TWO_BYTES  255   // reserved for extension to allow two byte commands
 
 // Each MSP port requires state and a receive buffer, revisit this default if someone needs more than 2 MSP ports.
 #define MAX_MSP_PORT_COUNT 2

--- a/src/main/io/serial_msp.h
+++ b/src/main/io/serial_msp.h
@@ -59,7 +59,7 @@
 #define MSP_PROTOCOL_VERSION                0
 
 #define API_VERSION_MAJOR                   1 // increment when major changes are made
-#define API_VERSION_MINOR                   16 // increment when any change is made, reset to zero when major changes are released after changing API_VERSION_MAJOR
+#define API_VERSION_MINOR                   15 // increment when any change is made, reset to zero when major changes are released after changing API_VERSION_MAJOR
 
 #define API_VERSION_LENGTH                  2
 
@@ -242,8 +242,12 @@ static const char * const boardIdentifier = TARGET_BOARD_IDENTIFIER;
 
 #define MSP_EEPROM_WRITE         250    //in message          no param
 
-#define MSP_DEBUG                252    //out message         debug1,debug2,debug3,debug4
+// Command reserved for future expansion
+#define MSP_EXTENSION_TWO_BYTES  252   // reserved for extension to allow two byte commands
+
+// Debug commands
 #define MSP_DEBUGMSG             253    //out message         debug string buffer
+#define MSP_DEBUG                254    //out message         debug1,debug2,debug3,debug4
 
 // Additional commands that are not compatible with MultiWii
 #define MSP_STATUS_EX            150    //out message         cycletime, errors_count, CPU load, sensor present etc
@@ -255,9 +259,8 @@ static const char * const boardIdentifier = TARGET_BOARD_IDENTIFIER;
 #define MSP_SET_SERVO_MIX_RULE   242    //in message          Sets servo mixer configuration
 #define MSP_SET_1WIRE            243    //in message          Sets 1Wire paththrough
 
-// Commands reserved for future expansion
-#define MSP_EXTENSION_ONE_BYTE   254   // reserved for extension to allow extra byte for command
-#define MSP_EXTENSION_TWO_BYTES  255   // reserved for extension to allow two byte commands
+// Command reserved for future expansion
+#define MSP_EXTENSION_ONE_BYTE   255   // reserved for extension to allow extra byte for command
 
 // Each MSP port requires state and a receive buffer, revisit this default if someone needs more than 2 MSP ports.
 #define MAX_MSP_PORT_COUNT 2


### PR DESCRIPTION
Incremented `API_VERSION_MINOR`. Changed `MSP_DEBUG` from 254 to 252. Added `MSP_EXTENSION_ONE_BYTE` and `MSP_EXTENSION_TWO_BYTES` to reserved values so that it will be possible to implement multi-byte MSP commands in future.

Addresses https://github.com/cleanflight/cleanflight/issues/1651.