### PR TITLE
Updates for Junit xml unit test results and test coverage. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -871,8 +871,9 @@ help: Makefile
 	@sed -n 's/^## //p' $<
 
 ## test        : run the cleanflight test suite
-test:
-	cd src/test && $(MAKE) test || true
+## junittest   : run the cleanflight test suite, producing Junit XML result files.
+test junittest:
+	cd src/test && $(MAKE) $@ || true
 
 # rebuild everything when makefile changes
 $(TARGET_OBJS) : Makefile

--- a/docs/development/Development.md
+++ b/docs/development/Development.md
@@ -42,7 +42,7 @@ This project could really do with some functional tests which test the behaviour
 
 All pull requests to add/improve the testability of the code or testing methods are highly sought!
 
-Note: Tests are written in C++ and linked with with firmware's C code.
+Note: Tests are written in C++ and linked with with firmware's C code. All code is also instrumented using gcov to make test coverage analysis possible.
 
 ### Running the tests.
 
@@ -52,15 +52,45 @@ The tests and test build system is very simple and based off the googletest exam
 make test
 ```
 
+You can also dp:
+
+```
+make junittest
+```
+
 This will build a set of executable files in the `obj/test` folder, one for each `*_unittest.cc` file.
 
-After they have been executed by the make invocation, you can still run them on the command line to execute the tests and to see the test report.
+After they have been executed by the make invocation, you can still run them on the command line to execute the tests and to see the test report. Test reports will also be produced in form of junit XML files, if tests are built and run with the junittest" goal. Junit report files are aved in obj/test directory and has the following  naming pattern <test_name>_results.xml, for example: obj/test/battery_unittest_results.xml 
 
 You can also step-debug the tests in eclipse and you can use the GoogleTest test runner to make building and re-running the tests simple.
 
 The tests are currently always compiled with debugging information enabled, there may be additional warnings, if you see any warnings please attempt to fix them and submit pull requests with the fixes.
 
 Tests are verified and working with GCC 4.9.2.
+
+## Test coverage analysis
+
+There are a number of possibilities to analyse test coverage and produce various reports. There are guides available from many sources, a good overview and link collection to more info can be found on Wikipedia: 
+
+https://en.wikipedia.org/wiki/Gcov
+
+A simple report for a single test can for example be made using this command:
+
+```
+gcov -s src/main/sensors -o obj/test/ battery_unittest.cc
+```
+
+To produce an coverage report in xml format usable by the Cobertura plugin in Jenkins requires installation of a  Python script called "gcovr" from github:
+
+https://github.com/gcovr/gcovr/tree/dev
+
+Example usage in Jenkins:
+
+```
+/gcovr-install-path/gcovr/scripts/gcovr obj/test --root=src/main -x > coverage.xml
+```
+
+There are many other ways to prodice test coverage reports in other formats, like html etc etc. 
 
 ## Using git and github
 

--- a/docs/development/Development.md
+++ b/docs/development/Development.md
@@ -52,7 +52,7 @@ The tests and test build system is very simple and based off the googletest exam
 make test
 ```
 
-You can also dp:
+You can also do:
 
 ```
 make junittest
@@ -60,7 +60,7 @@ make junittest
 
 This will build a set of executable files in the `obj/test` folder, one for each `*_unittest.cc` file.
 
-After they have been executed by the make invocation, you can still run them on the command line to execute the tests and to see the test report. Test reports will also be produced in form of junit XML files, if tests are built and run with the junittest" goal. Junit report files are aved in obj/test directory and has the following  naming pattern <test_name>_results.xml, for example: obj/test/battery_unittest_results.xml 
+After they have been executed by the make invocation, you can still run them on the command line to execute the tests and to see the test report. Test reports will also be produced in form of junit XML files, if tests are built and run with the "junittest" goal. Junit report files are saved in obj/test directory and has the following  naming pattern test_name_results.xml, for example: obj/test/battery_unittest_results.xml 
 
 You can also step-debug the tests in eclipse and you can use the GoogleTest test runner to make building and re-running the tests simple.
 

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -42,6 +42,17 @@ C_FLAGS = $(COMMON_FLAGS) \
 CXX_FLAGS = $(COMMON_FLAGS) \
 	-std=gnu++11
 
+# Compiler flags for coverage instrumentation
+GCOV_CC_FLAGS := -fprofile-arcs -ftest-coverage
+GCOV_L_FLAGS  := -lgcov
+
+C_FLAGS   += $(GCOV_CC_FLAGS) $(GCOV_L_FLAGS)
+CXX_FLAGS += $(GCOV_CC_FLAGS) $(GCOV_L_FLAGS) 
+
+#enable fast Maths tests
+C_FLAGS   += -DFAST_MATH
+CXX_FLAGS += -DFAST_MATH
+
 # Determine the OS and set up the parameter group linker flags accordingly
 UNAME := $(shell uname -s)
 ifeq ($(UNAME), Darwin)
@@ -50,7 +61,6 @@ else
 PG_FLAGS = -Wl,-T,$(TEST_DIR)/parameter_group.ld -Wl,-Map,$(OBJECT_DIR)/$@.map
 endif
 
-#
 # Gather up all of the tests.
 TEST_SRC = $(sort $(wildcard $(TEST_DIR)/*.cc))
 TESTS = $(TEST_SRC:$(TEST_DIR)/%.cc=%)
@@ -62,10 +72,13 @@ GTEST_HEADERS = $(GTEST_DIR)/inc/gtest/*.h
 
 # House-keeping build targets.
 
+## all         : Build all Unit Tests (Default goal)
 all : $(TEST_BINARIES)
 
+## clean       : Cleanup the UnitTest binaries.
 clean :
 	rm -rf $(OBJECT_DIR)
+
 
 # Builds gtest.a and gtest_main.a.
 
@@ -881,9 +894,33 @@ $(OBJECT_DIR)/config_streamer_unittest : \
 
 	$(CXX) $(CXX_FLAGS) $^ -o $(OBJECT_DIR)/$@
 
+## test        : Build and run the Unit Tests
 test: $(TESTS:%=test-%)
 
+## junittest   : Build and run the Unit Tests, producing Junit XML result files."
+junittest: EXEC_OPTS = "--gtest_output=xml:$<_results.xml" 
+junittest: $(TESTS:%=test-%)
+
 test-%: $(OBJECT_DIR)/%
-	$<
+	$< $(EXEC_OPTS)
+
+## help        : print this help message and exit
+## what        : print this help message and exit
+## usage       : print this help message and exit
+help what usage: makefile
+	@echo ""
+	@echo "Makefile for Unit Tests"
+	@echo ""
+	@echo "Usage:"
+	@echo "        make [goal] "
+	@echo ""
+	@echo "Valid goals are:"
+	@echo ""
+	@sed -n 's/^## //p' $<
+	@echo ""
+	@echo "Any of the Unit Test programs can be used as goals:"
+	@$(foreach prg, $(TEST_BINARIES), echo "    $(prg)";)
+
+
 
 -include $(DEPS)

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -907,7 +907,7 @@ test-%: $(OBJECT_DIR)/%
 ## help        : print this help message and exit
 ## what        : print this help message and exit
 ## usage       : print this help message and exit
-help what usage: makefile
+help what usage: Makefile
 	@echo ""
 	@echo "Makefile for Unit Tests"
 	@echo ""


### PR DESCRIPTION
Updates in Makefiles for Junit xml unit test results and test coverage instrumentation (gcov). Also some help texts. Junit xml results are on it's own make target "junittest", keeping the old target "test" the same as before. 
gcov instrumentation is however hardcoded, not an option. Should not affect compatibilty with other build- or test-scripts. No postprocessing or report generation of test coverage data is included as it might require installation of reporting tools like "gcovr" ( https://github.com/gcovr/gcovr/tree/dev ).
Postprocessing is instead done as a separate job step outside the Makefiles. 
Usage:

    make clean
    make junittest
    /home/andho/projects/coverage/gcovr/scripts/gcovr obj/test --root=src/main -x > coverage.xml
   
