### PR TITLE
Issue 1675 fix. Stores floating point PIDs as 16 bit decimal fixed point

### DIFF
--- a/src/main/io/serial_msp.h
+++ b/src/main/io/serial_msp.h
@@ -270,7 +270,7 @@ typedef enum {
     COMMAND_RECEIVED
 } mspState_e;
 
-#define MSP_PORT_INBUF_SIZE 64
+#define MSP_PORT_INBUF_SIZE 72
 
 typedef struct mspPort_s {
     serialPort_t *port; // null when port unused.

--- a/src/main/io/serial_msp.h
+++ b/src/main/io/serial_msp.h
@@ -249,6 +249,8 @@ static const char * const boardIdentifier = TARGET_BOARD_IDENTIFIER;
 #define MSP_STATUS_EX            150    //out message         cycletime, errors_count, CPU load, sensor present etc
 #define MSP_UID                  160    //out message         Unique device ID
 #define MSP_GPSSVINFO            164    //out message         get Signal Strength (only U-Blox)
+#define MSP_PID_FLOAT            237    //out message         P I D coeffients for floating point PID controllers
+#define MSP_SET_PID_FLOAT        238    //in message          P I D coeffients for floating point PID controllers
 #define MSP_ACC_TRIM             240    //out message         get acc angle trim values
 #define MSP_SET_ACC_TRIM         239    //in message          set acc angle trim values
 #define MSP_SERVO_MIX_RULES      241    //out message         Returns servo mixer configuration

--- a/src/test/unit/serial_msp_unittest.cc
+++ b/src/test/unit/serial_msp_unittest.cc
@@ -352,6 +352,7 @@ TEST_F(SerialMspUnitTest, Test_PIDValuesInt)
     serialReadPos = 0;
     currentPort->cmdMSP = MSP_PID;
     mspProcessReceivedCommand();
+    EXPECT_GT(MSP_PORT_INBUF_SIZE, serialWritePos); // check command doesn't overflow serial buffer
     EXPECT_EQ(3 * PID_ITEM_COUNT, serialBuffer.mspResponse.header.size);
     // check few values, just to make sure they have been written correctly
     EXPECT_EQ(P8_YAW, serialBuffer.mspResponse.payload[6]);
@@ -446,6 +447,7 @@ TEST_F(SerialMspUnitTest, Test_PIDValuesFloat)
     serialReadPos = 0;
     currentPort->cmdMSP = MSP_PID;
     mspProcessReceivedCommand();
+    EXPECT_GT(MSP_PORT_INBUF_SIZE, serialWritePos); // check command doesn't overflow serial buffer
     EXPECT_EQ(3 * PID_ITEM_COUNT, serialBuffer.mspResponse.header.size);
 
     // reset test values to zero, so we can check if they get read properly
@@ -616,6 +618,7 @@ TEST(SerialMspUnittest, Test_MSP_PID_FLOAT)
     serialReadPos = 0;
     currentPort->cmdMSP = MSP_PID_FLOAT;
     mspProcessReceivedCommand();
+    EXPECT_GT(MSP_PORT_INBUF_SIZE, serialWritePos); // check command doesn't overflow serial buffer
     EXPECT_EQ(3 * sizeof(uint16_t) * PID_ITEM_COUNT, serialBuffer.mspResponse.header.size);
 
     // reset test values to zero, so we can check if they get read properly

--- a/src/test/unit/serial_msp_unittest.cc
+++ b/src/test/unit/serial_msp_unittest.cc
@@ -457,8 +457,8 @@ TEST_F(SerialMspUnitTest, Test_PIDValuesFloat)
     serialBuffer.mspResponse.header.direction = '<';
     serialBuffer.mspResponse.header.type = currentPort->cmdMSP;
     // force the checksum
-    serialBuffer.mspResponse.payload[3 * PID_ITEM_COUNT] ^= MSP_PID;
-    serialBuffer.mspResponse.payload[3 * PID_ITEM_COUNT] ^= MSP_SET_PID;
+    serialBuffer.mspResponse.payload[3 * PID_ITEM_COUNT] ^= MSP_PID_FLOAT;
+    serialBuffer.mspResponse.payload[3 * PID_ITEM_COUNT] ^= MSP_SET_PID_FLOAT;
     // copy the command data into the current port inBuf so it can be processed
     memcpy(currentPort->inBuf, serialBuffer.buf, MSP_PORT_INBUF_SIZE);
 


### PR DESCRIPTION
Implementation of storage and retrieval of floating point PID values. Stored as 16 bit decimal fixed point integer with two decimal places, eg the value of 123.45 is stored as the integer 12345.

With test code.