### PR TITLE
Update Ibus with 10ch Support

### DIFF
--- a/docs/Rx.md
+++ b/docs/Rx.md
@@ -108,6 +108,17 @@ http://www.graupner.de/en/products/870ade17-ace8-427f-943b-657040579906/33565/pr
 
 SUMH is a legacy Graupner protocol.  Graupner have issued a firmware updates for many recivers that lets them use SUMD instead.
 
+### IBUS
+
+10 channels via serial currently supported.
+
+IBUS is the FlySky digital serial protocol and is available with the FS-IA6B and
+FS-IA10 receivers. The Turnigy TGY-IA6B and TGY-IA10 are the same
+devices with a different label, therefore they also work.
+
+If you are using a 6ch tx such as the FS-I6 or TGY-I6 then you must flash a 10ch
+firmware on the tx to make use of these extra channels.
+
 ## MultiWii serial protocol (MSP)
 
 Allows you to use MSP commands as the RC input.  Only 8 channel support to maintain compatibility with MSP.

--- a/src/main/rx/ibus.c
+++ b/src/main/rx/ibus.c
@@ -38,7 +38,7 @@
 #include "rx/rx.h"
 #include "rx/ibus.h"
 
-#define IBUS_MAX_CHANNEL 8
+#define IBUS_MAX_CHANNEL 10
 #define IBUS_BUFFSIZE 32
 #define IBUS_SYNCBYTE 0x20
 
@@ -124,6 +124,8 @@ uint8_t ibusFrameStatus(void)
         ibusChannelData[5] = (ibus[13] << 8) + ibus[12];
         ibusChannelData[6] = (ibus[15] << 8) + ibus[14];
         ibusChannelData[7] = (ibus[17] << 8) + ibus[16];
+        ibusChannelData[8] = (ibus[19] << 8) + ibus[18];
+        ibusChannelData[9] = (ibus[21] << 8) + ibus[20];
         
         frameStatus = SERIAL_RX_FRAME_COMPLETE;
     }


### PR DESCRIPTION
Hi Guys, just got into racing quads, loving it!

I use IBUS digital serial with an fs-ia6b rx. The current support in cleanflight reads 8ch but this patch adds ch9 & ch10. I also added a note in the rx docs.

This patch is tested with an FS-I6 tx which is running 10ch firmware and an FS-IA6b rx. It's tested on both an F3 discovery and a naze32 clone called a Skyline32 from EMAX.

It should also work with the FS-IA10 rx but mine hasn't arrived yet to test. I'll mention on here when i know if it works or not.

![ibus](https://cloud.githubusercontent.com/assets/1908742/12438455/fae66fbc-bf1e-11e5-8d90-901dba445422.png)

There's no existing unittest for ibus.c but i'm having problems getting the existing tests running locally just now. Once i sort out these path issues i'll add a couple of cases for ibus.c - it would also provide some documentation of the ibus protocol which is quite thin on the internet.

Cheers,

Craig
