### PR TITLE
RC Channel stability.

### DIFF
--- a/src/main/io/rc_controls.c
+++ b/src/main/io/rc_controls.c
@@ -22,7 +22,6 @@
 #include <math.h>
 
 #include "platform.h"
-#include "debug.h"
 
 #include "build_config.h"
 
@@ -351,7 +350,6 @@ void updateActivatedModes(modeActivationCondition_t *modeActivationConditions)
             // if the mode WAS active the keep it active if the channel is unstable.
             if (IS_RC_MODE_ACTIVE_IN_MASK(modeActivationCondition->modeId, currentRCModeActivationMask)) {
                 if (rcChannelStability[AUX1 + modeActivationCondition->auxChannelIndex] != RX_CHANNEL_STABILITY_HIGH) {
-                    debug[3]++;
                     ACTIVATE_RC_MODE(modeActivationCondition->modeId);
                 }
             }

--- a/src/main/io/rc_controls.h
+++ b/src/main/io/rc_controls.h
@@ -53,7 +53,8 @@ typedef enum {
 
 extern uint32_t rcModeActivationMask;
 
-#define IS_RC_MODE_ACTIVE(modeId) ((1 << (modeId)) & rcModeActivationMask)
+#define IS_RC_MODE_ACTIVE_IN_MASK(modeId, mask) ((1 << (modeId)) & mask)
+#define IS_RC_MODE_ACTIVE(modeId) IS_RC_MODE_ACTIVE_IN_MASK(modeId, rcModeActivationMask)
 #define ACTIVATE_RC_MODE(modeId) (rcModeActivationMask |= (1 << modeId))
 
 typedef enum rc_alias {

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -76,6 +76,14 @@ extern const char rcChannelLetters[];
 
 extern int16_t rcData[MAX_SUPPORTED_RC_CHANNEL_COUNT];       // interval [1000;2000]
 
+typedef enum {
+    RX_CHANNEL_STABILITY_LOW = 0,
+    RX_CHANNEL_STABILITY_MEDIUM,
+    RX_CHANNEL_STABILITY_HIGH,
+} rxChannelStability_e;
+
+extern uint8_t rcChannelStability[MAX_SUPPORTED_RC_CHANNEL_COUNT];
+
 #define MAX_MAPPABLE_RX_INPUTS 8
 
 #define RSSI_SCALE_MIN 1
@@ -146,6 +154,7 @@ bool rxIsReceivingSignal(void);
 bool rxAreFlightChannelsValid(void);
 bool shouldProcessRx(uint32_t currentTime);
 void calculateRxChannelsAndUpdateFailsafe(uint32_t currentTime);
+void updateChannelStability(void);
 
 void parseRcChannels(const char *input, rxConfig_t *rxConfig);
 uint8_t serialRxFrameStatus(rxConfig_t *rxConfig);

--- a/src/test/unit/rc_controls_unittest.cc
+++ b/src/test/unit/rc_controls_unittest.cc
@@ -54,6 +54,7 @@ protected:
 
     virtual void SetUp() {
         memset(&modeActivationConditions, 0, sizeof(modeActivationConditions));
+        memset(&rcChannelStability, RX_CHANNEL_STABILITY_HIGH, sizeof(rcChannelStability));
     }
 };
 
@@ -783,5 +784,6 @@ uint8_t armingFlags = 0;
 int16_t heading;
 uint8_t stateFlags = 0;
 int16_t rcData[MAX_SUPPORTED_RC_CHANNEL_COUNT];
+uint8_t rcChannelStability[MAX_SUPPORTED_RC_CHANNEL_COUNT];
 rxRuntimeConfig_t rxRuntimeConfig;
 }


### PR DESCRIPTION
This is an alternative approach to the 'extra disarm safety' in PR #1503.

This PR takes the approach of checking the deltas of the last few channel readings and determining a LOW, MEDIUM or HIGH stability.

This stability value can then be used by all parts of the system, in particular the code that activates/deactivates mode ranges or as well as the code that checks the throttle status before disarming.

This seems to work nicely when you configure a 3 position switch with 3 modes on it.

e.g.  1. angle, 2 - horizon and 3 - acro (no mode).

prior to this, moving the switch from 1 to 3 would breifly activate horizon mode.
with this PR the channel is marked as unstable as it transitions from 1 to 3 and thus horizon mode is not activated while the channel is unstable. angle mode remains active (not disable when the channel is unstable).  when the channel settles down the angle mode is deactivated.

Testing and feedback wanted please.
