### PR TITLE
Docs: Add instructions to restore dRonin bootloader on Sparky, CC3D, and Lux

### DIFF
--- a/docs/Board - CC3D.md
+++ b/docs/Board - CC3D.md
@@ -126,7 +126,15 @@ The following features are not available:
  * Display
  * Sonar
 
-# Restoring OpenPilot bootloader
+## Restoring dRonin/Tau Labs Bootloader
+To restore the dRonin bootloader (currently Tau Labs compatible):
+* Download a [dRonin release package](https://github.com/d-ronin/dRonin/releases), inside there will be a file called `ef_coptercontrol.hex`. This image includes both the bootloader and the firmware.
+* Flash the `ef_coptercontrol.hex` image using the Cleanflight Configurator app firmware flasher, choosing to load a local firmware (or by another method of your choice should you so desire). 
+* You should now be able to connect to the dRonin GCS.
+
+Note: this section is only applicable if you have overwritten the bootloader, e.g. by flashing using the "Single binary image mode" instructions above.
+
+## Restoring OpenPilot bootloader
 
 If you have a JLink debugger, you can use JLinkExe to flash the open pilot bootloader.
 

--- a/docs/Board - ColibriRace.md
+++ b/docs/Board - ColibriRace.md
@@ -124,3 +124,13 @@ The Colibri RACE is a STM32F3 based flight control designed specifically to work
 	| --- | ----------------- | -------------------------------------------- |
 	| 1   | IR TX             |                                              |
 	| 2   | Ground            |                                              |
+
+## dRonin bootloader
+
+This section is applicable to the Lumenier Lux flight controller, also running the Colibri Race target in Cleanflight. Flashing cleanflight will erase the dRonin bootloader, this is not a problem and can easily be restored using Cleanflight Configurator as detailed below.
+
+### Restoring dRonin Bootloader
+To restore the dRonin bootloader:
+* Download a [dRonin release package](https://github.com/d-ronin/dRonin/releases), inside there will be a file called `ef_lux.hex`. This image includes both the bootloader and the firmware.
+* Flash the `ef_lux.hex` image using the Cleanflight Configurator app firmware flasher, choosing to load a local firmware (or by another method of your choice should you so desire). 
+* You should now be able to connect to the dRonin GCS.

--- a/docs/Board - Sparky.md
+++ b/docs/Board - Sparky.md
@@ -160,7 +160,13 @@ See Sparky schematic for CONN2 pinouts.
 
 ## TauLabs bootloader
 
-Flashing cleanflight will erase the TauLabs bootloader, this is not a problem and can easily be restored using the st flashloader tool.
+Flashing cleanflight will erase the TauLabs bootloader, this is not a problem and can easily be restored using the st flashloader tool or Cleanflight Configurator as detailed below.
+
+### Restoring dRonin/Tau Labs Bootloader
+To restore the dRonin bootloader (currently Tau Labs compatible):
+* Download a [dRonin release package](https://github.com/d-ronin/dRonin/releases), inside there will be a file called `ef_sparky.hex`. This image includes both the bootloader and the firmware.
+* Flash the `ef_sparky.hex` image using the Cleanflight Configurator app firmware flasher, choosing to load a local firmware (or by another method of your choice should you so desire). 
+* You should now be able to connect to the dRonin GCS.
 
 # Serial Ports
 


### PR DESCRIPTION
This is an update of #1380. We include hex images in our release packages now so it is unnecessary for Cleanflight to host them. dRonin bootloader is fully compatible with Tau Labs as well.