### PR TITLE
Configurable Delta Approach / rc_smoothing substitute

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -181,6 +181,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
     pidProfile->gyro_soft_lpf = 0;   // no filtering by default
     pidProfile->yaw_pterm_cut_hz = 0;
     pidProfile->dterm_cut_hz = 0;
+    pidProfile->deltaMethod = 1;
 
     pidProfile->P_f[ROLL] = 1.4f;     // new PID with preliminary defaults test carefully
     pidProfile->I_f[ROLL] = 0.4f;
@@ -444,7 +445,7 @@ static void resetConf(void)
     masterConfig.rxConfig.rssi_channel = 0;
     masterConfig.rxConfig.rssi_scale = RSSI_SCALE_DEFAULT;
     masterConfig.rxConfig.rssi_ppm_invert = 0;
-    masterConfig.rxConfig.rcSmoothing = 1;
+    masterConfig.rxConfig.rcSmoothing = 0;
 
     resetAllRxChannelRangeConfigurations(masterConfig.rxConfig.channelRanges);
 

--- a/src/main/config/config_unittest.h
+++ b/src/main/config/config_unittest.h
@@ -21,7 +21,7 @@
 #ifdef SRC_MAIN_FLIGHT_PID_C_
 #ifdef UNIT_TEST
 
-float unittest_pidLuxFloat_lastError[3];
+float unittest_pidLuxFloat_lastErrorForDelta[3];
 float unittest_pidLuxFloat_delta1[3];
 float unittest_pidLuxFloat_delta2[3];
 float unittest_pidLuxFloat_PTerm[3];
@@ -30,14 +30,14 @@ float unittest_pidLuxFloat_DTerm[3];
 
 #define SET_PID_LUX_FLOAT_LOCALS(axis) \
     { \
-        lastError[axis] = unittest_pidLuxFloat_lastError[axis]; \
+        lastErrorForDelta[axis] = unittest_pidLuxFloat_lastErrorForDelta[axis]; \
         delta1[axis] = unittest_pidLuxFloat_delta1[axis]; \
         delta2[axis] = unittest_pidLuxFloat_delta2[axis]; \
     }
 
 #define GET_PID_LUX_FLOAT_LOCALS(axis) \
     { \
-        unittest_pidLuxFloat_lastError[axis] = lastError[axis]; \
+        unittest_pidLuxFloat_lastErrorForDelta[axis] = lastErrorForDelta[axis]; \
         unittest_pidLuxFloat_delta1[axis] = delta1[axis]; \
         unittest_pidLuxFloat_delta2[axis] = delta2[axis]; \
         unittest_pidLuxFloat_PTerm[axis] = PTerm; \
@@ -45,19 +45,19 @@ float unittest_pidLuxFloat_DTerm[3];
         unittest_pidLuxFloat_DTerm[axis] = DTerm; \
     }
 
-int32_t unittest_pidMultiWiiRewrite_lastError[3];
+int32_t unittest_pidMultiWiiRewrite_lastErrorForDelta[3];
 int32_t unittest_pidMultiWiiRewrite_PTerm[3];
 int32_t unittest_pidMultiWiiRewrite_ITerm[3];
 int32_t unittest_pidMultiWiiRewrite_DTerm[3];
 
 #define SET_PID_MULTI_WII_REWRITE_LOCALS(axis) \
     { \
-    lastError[axis] = unittest_pidMultiWiiRewrite_lastError[axis]; \
+    lastErrorForDelta[axis] = unittest_pidMultiWiiRewrite_lastErrorForDelta[axis]; \
     }
 
 #define GET_PID_MULTI_WII_REWRITE_LOCALS(axis) \
     { \
-        unittest_pidMultiWiiRewrite_lastError[axis] = lastError[axis]; \
+        unittest_pidMultiWiiRewrite_lastErrorForDelta[axis] = lastErrorForDelta[axis]; \
         unittest_pidMultiWiiRewrite_PTerm[axis] = PTerm; \
         unittest_pidMultiWiiRewrite_ITerm[axis] = ITerm; \
         unittest_pidMultiWiiRewrite_DTerm[axis] = DTerm; \

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -46,6 +46,11 @@ typedef enum {
     PID_COUNT
 } pidControllerType_e;
 
+typedef enum {
+	DELTA_FROM_ERROR = 0,
+	DELTA_FROM_MEASUREMENT
+} pidDeltaType_e;
+
 #define IS_PID_CONTROLLER_FP_BASED(pidController) (pidController == PID_CONTROLLER_LUX_FLOAT)
 
 typedef struct pidProfile_s {
@@ -66,6 +71,7 @@ typedef struct pidProfile_s {
     uint8_t dterm_cut_hz;                   // (default 17Hz, Range 1-50Hz) Used for PT1 element in PID1, PID2 and PID5
     uint8_t yaw_pterm_cut_hz;               // Used for filering Pterm noise on noisy frames
     uint8_t gyro_soft_lpf;
+    uint8_t deltaMethod;                    // Alternative delta calculation. Delta from gyro might give smoother results
 
 #ifdef GTUNE
     uint8_t  gtune_lolimP[3];               // [0..200] Lower limit of P during G tune

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -379,6 +379,9 @@ static const char * const lookupTableGyroLpf[] = {
     "10HZ"
 };
 
+static const char * const lookupDeltaMethod[] = {
+    "ERROR", "MEASUREMENT"
+};
 
 typedef struct lookupTableEntry_s {
     const char * const *values;
@@ -402,6 +405,7 @@ typedef enum {
     TABLE_SERIAL_RX,
     TABLE_GYRO_FILTER,
     TABLE_GYRO_LPF,
+    TABLE_DELTA_METHOD,
 } lookupTableIndex_e;
 
 static const lookupTableEntry_t lookupTables[] = {
@@ -420,7 +424,8 @@ static const lookupTableEntry_t lookupTables[] = {
     { lookupTablePidController, sizeof(lookupTablePidController) / sizeof(char *) },
     { lookupTableSerialRX, sizeof(lookupTableSerialRX) / sizeof(char *) },
     { lookupTableGyroFilter, sizeof(lookupTableGyroFilter) / sizeof(char *) },
-    { lookupTableGyroLpf, sizeof(lookupTableGyroLpf) / sizeof(char *) }
+    { lookupTableGyroLpf, sizeof(lookupTableGyroLpf) / sizeof(char *) },
+    { lookupDeltaMethod, sizeof(lookupDeltaMethod) / sizeof(char *) }
 };
 
 #define VALUE_TYPE_OFFSET 0
@@ -633,6 +638,8 @@ const clivalue_t valueTable[] = {
 
     { "mag_hardware",               VAR_UINT8  | MASTER_VALUE,  &masterConfig.mag_hardware, .config.minmax = { 0,  MAG_MAX } },
     { "mag_declination",            VAR_INT16  | PROFILE_VALUE, &masterConfig.profile[0].mag_declination, .config.minmax = { -18000,  18000 } },
+
+    { "pid_delta_method",           VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, &masterConfig.profile[0].pidProfile.deltaMethod, .config.lookup = { TABLE_DELTA_METHOD } },
 
     { "pid_controller",             VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, &masterConfig.profile[0].pidProfile.pidController, .config.lookup = { TABLE_PID_CONTROLLER } },
 

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -50,14 +50,14 @@ extern "C" {
     extern pidControllerFuncPtr pid_controller;
     extern uint8_t PIDweight[3];
     float dT; // dT for pidLuxFloat
-    float unittest_pidLuxFloat_lastError[3];
+    float unittest_pidLuxFloat_lastErrorForDelta[3];
     float unittest_pidLuxFloat_delta1[3];
     float unittest_pidLuxFloat_delta2[3];
     float unittest_pidLuxFloat_PTerm[3];
     float unittest_pidLuxFloat_ITerm[3];
     float unittest_pidLuxFloat_DTerm[3];
     int32_t cycleTime; // cycleTime for pidMultiWiiRewrite
-    int32_t unittest_pidMultiWiiRewrite_lastError[3];
+    int32_t unittest_pidMultiWiiRewrite_lastErrorForDelta[3];
     int32_t unittest_pidMultiWiiRewrite_PTerm[3];
     int32_t unittest_pidMultiWiiRewrite_ITerm[3];
     int32_t unittest_pidMultiWiiRewrite_DTerm[3];
@@ -102,6 +102,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
     pidProfile->gyro_soft_lpf = 0;   // no filtering by default
     pidProfile->yaw_pterm_cut_hz = 0;
     pidProfile->dterm_cut_hz = 0;
+    pidProfile->deltaMethod = DELTA_FROM_ERROR;
 
     pidProfile->P_f[FD_ROLL] = 1.4f;     // new PID with preliminary defaults test carefully
     pidProfile->I_f[FD_ROLL] = 0.4f;
@@ -151,7 +152,7 @@ void pidControllerInitLuxFloat(pidProfile_t *pidProfile, controlRateConfig_t *co
     controlRate->rates[YAW] = 90;
     // reset the pidLuxFloat static values
     for (int ii = FD_ROLL; ii <= FD_YAW; ++ii) {
-        unittest_pidLuxFloat_lastError[ii] = 0.0f;
+        unittest_pidLuxFloat_lastErrorForDelta[ii] = 0.0f;
         unittest_pidLuxFloat_delta1[ii] = 0.0f;
         unittest_pidLuxFloat_delta2[ii] = 0.0f;
     }
@@ -525,7 +526,7 @@ void pidControllerInitMultiWiiRewrite(pidProfile_t *pidProfile, controlRateConfi
     controlRate->rates[YAW] = 73;
     // reset the pidMultiWiiRewrite static values
     for (int ii = FD_ROLL; ii <= FD_YAW; ++ii) {
-        unittest_pidMultiWiiRewrite_lastError[ii] = 0;
+        unittest_pidMultiWiiRewrite_lastErrorForDelta[ii] = 0;
     }
 }
 


### PR DESCRIPTION
Error from measurement is much smoother and preferably better default choices. It also makes rc_smoothing not necessary.
This time user can decide what to use. Configurable parameter for all pid controllers

http://brettbeauregard.com/blog/2011/04/improving-the-beginner%E2%80%99s-pid-derivative-kick/