### PR TITLE
Negative amperage CURRENT_METER fix

### DIFF
--- a/docs/Battery.md
+++ b/docs/Battery.md
@@ -95,7 +95,7 @@ Configure the current meter type using the `current_meter_type` settings here:
 
 Configure capacity using the `battery_capacity` setting, in mAh units.
 
-If you're using an OSD that expects the multiwii current meter output value, then set `multiwii_current_meter_output` to `1` (this multiplies amperage sent to MSP by 10).
+If you're using an OSD that expects the multiwii current meter output value, then set `multiwii_current_meter_output` to `1` (this multiplies amperage sent to MSP by 10 and truncates negative values)).
 
 ### ADC Sensor
 
@@ -105,6 +105,8 @@ Use the following settings to adjust calibration:
 
 `current_meter_scale`
 `current_meter_offset`
+
+It is recommended to set `multiwii_current_meter_output` to `0` when calibrating ADC current sensor.
 
 ### Virtual Sensor
 

--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -203,7 +203,7 @@ void updateCurrentMeter(int32_t lastUpdateAt, rxConfig_t *rxConfig, uint16_t dea
             break;
     }
 
-    mAhdrawnRaw += (amperage * lastUpdateAt) / 1000;
+    mAhdrawnRaw += (MAX(0, amperage) * lastUpdateAt) / 1000;
     mAhDrawn = mAhdrawnRaw / (3600 * 100);
 }
 


### PR DESCRIPTION
- truncate negative amperage values when calculating drawn battery
capacity
- documentation: clarify side effects of the multiwii current meter
output