### PR TITLE
allow variable number of leds for thrust ring

### DIFF
--- a/docs/LedStrip.md
+++ b/docs/LedStrip.md
@@ -234,7 +234,7 @@ the same time.  Thrust should normally be combined with Color or Mode/Orientatio
 
 #### Thrust ring state
 
-This mode is allows you to use a 12, 16 or 24 leds ring (e.g. NeoPixel ring) for an afterburner effect. When armed the leds use the following sequences: 2 On, 4 Off, 2 On, 4 Off, and so on.  The light pattern rotates clockwise as throttle increases. 
+This mode is allows you to use one or multiple led rings (e.g. NeoPixel ring) for an afterburner effect. When armed the leds use the following sequences if the total number of leds in the ring is divisible by 6: 2 On, 4 Off, 2 On, 4 Off, and so on. If the number is not divisible by 6, the ring(s) will be broken up equally until either the sequence length is odd or below 6 (e.g. 8 -> 2x 2 On, 2 Off; 20 -> 4x 2 On, 3 Off). The light pattern rotates clockwise as throttle increases. 
 
 A better effect is acheived when LEDs configured for thrust ring have no other functions.
 


### PR DESCRIPTION
Hi!

The current implementation fits nicely for rings consisting of multiples of 6. Yet, when using rings of 8, 10, 16 the ring does not work so well because a fixed sequence length of 6 is assumed, causing inconsistencies during the thrust ring cycle. This pull request fixes this by mimicking the old behaviour for ring sizes being a multiple of 6 and splitting up other lengths until the sequence length is either odd (not divisible by 2) or below 6. This allows nice animations for all numbers of leds.

Best regards
Robert