### PR TITLE
Add support for 64Mbit (8MB) SPI flash chip Macronix MX25L64.

### DIFF
--- a/docs/Blackbox.md
+++ b/docs/Blackbox.md
@@ -181,12 +181,12 @@ The SPRacingF3 has a larger 8 megabyte dataflash chip onboard which allows for l
 
 These chips are also supported:
 
-* Micron/ST M25P16 - 16 Mbit / 2 MByte
-* Micron N25Q064 - 64 Mbit / 8 MByte
-* Winbond W25Q64 - 64 Mbit / 8 MByte
-* Macronix MX25L64 - 64 Mbit / 8 MByte
-* Micron N25Q0128 - 128 Mbit / 16 MByte
-* Winbond W25Q128 - 128 Mbit / 16 MByte
+* Micron/ST M25P16 - 16 Mbit / 2 MByte ([datasheet](http://www.micron.com/~/media/Documents/Products/Data%20Sheet/NOR%20Flash/Serial%20NOR/M25P/M25P16.pdf))
+* Micron/ST N25Q064 - 64 Mbit / 8 MByte ([datasheet](http://www.micron.com/~/media/documents/products/data-sheet/nor-flash/serial-nor/n25q/n25q_64a_3v_65nm.pdf))
+* Winbond W25Q64 - 64 Mbit / 8 MByte ([datasheet](http://www.winbond.com/resource-files/w25q64fv_revl1_100713.pdf))
+* Macronix MX25L64 - 64 Mbit / 8 MByte ([datasheet](http://media.digikey.com/pdf/Data%20Sheets/Macronix/MX25L6406E.pdf))
+* Micron/ST N25Q128 - 128 Mbit / 16 MByte ([datasheet](http://www.micron.com/~/media/Documents/Products/Data%20Sheet/NOR%20Flash/Serial%20NOR/N25Q/n25q_128mb_3v_65nm.pdf))
+* Winbond W25Q128 - 128 Mbit / 16 MByte ([datasheet](http://www.winbond.com/resource-files/w25q128fv_revhh1_100913_website1.pdf))
 
 #### Enable recording to dataflash
 On the Configurator's CLI tab, you must enter `set blackbox_device=SPIFLASH` to switch to logging to an onboard dataflash chip,

--- a/docs/Blackbox.md
+++ b/docs/Blackbox.md
@@ -184,6 +184,7 @@ These chips are also supported:
 * Micron/ST M25P16 - 16 Mbit / 2 MByte
 * Micron N25Q064 - 64 Mbit / 8 MByte
 * Winbond W25Q64 - 64 Mbit / 8 MByte
+* Macronix MX25L64 - 64 Mbit / 8 MByte
 * Micron N25Q0128 - 128 Mbit / 16 MByte
 * Winbond W25Q128 - 128 Mbit / 16 MByte
 

--- a/src/main/drivers/flash_m25p16.c
+++ b/src/main/drivers/flash_m25p16.c
@@ -46,6 +46,7 @@
 #define JEDEC_ID_WINBOND_W25Q64        0xEF4017
 #define JEDEC_ID_MICRON_N25Q128        0x20ba18
 #define JEDEC_ID_WINBOND_W25Q128       0xEF4018
+#define JEDEC_ID_MACRONIX_MX25L64      0xC22017
 
 #define DISABLE_M25P16       GPIO_SetBits(M25P16_CS_GPIO,   M25P16_CS_PIN)
 #define ENABLE_M25P16        GPIO_ResetBits(M25P16_CS_GPIO, M25P16_CS_PIN)
@@ -159,6 +160,7 @@ static bool m25p16_readIdentification()
             geometry.sectors = 32;
             geometry.pagesPerSector = 256;
         break;
+        case JEDEC_ID_MACRONIX_MX25L64:
         case JEDEC_ID_MICRON_N25Q064:
         case JEDEC_ID_WINBOND_W25Q64:
             geometry.sectors = 128;


### PR DESCRIPTION
This is to add support for another 8MB SPI flash chip, Macronix MX25L64. It's another option for people who want to mod and expand their CF onboard memory for use with Blackbox. Tested on a CC3D. Attached is a picture of the mod and a sample log file recorded with the chip and patch. The log has only some stick movement, no flying.

![img_20160130_244940108 2](https://cloud.githubusercontent.com/assets/8649430/12693347/86eea5b6-c6ee-11e5-9021-bdfd167e3ec7.jpg)

[blackbox_log_2016-01-29_232216_8MB.TXT](https://github.com/cleanflight/cleanflight/files/110644/blackbox_log_2016-01-29_232216_8MB.TXT)
