### PR TITLE
Airmode Implementation / Acro optimised mixer and PID controllers

### DIFF
--- a/src/main/io/rc_controls.c
+++ b/src/main/io/rc_controls.c
@@ -59,6 +59,7 @@
 
 #include "mw.h"
 
+#define AIRMODE_DEADBAND 12
 
 static escAndServoConfig_t *escAndServoConfig;
 static pidProfile_t *pidProfile;
@@ -120,6 +121,15 @@ throttleStatus_e calculateThrottleStatus(rxConfig_t *rxConfig, uint16_t deadband
         return THROTTLE_LOW;
 
     return THROTTLE_HIGH;
+}
+
+rollPitchStatus_e calculateRollPitchCenterStatus(rxConfig_t *rxConfig)
+{
+    if (((rcData[PITCH] < (rxConfig->midrc + AIRMODE_DEADBAND)) && (rcData[PITCH] > (rxConfig->midrc -AIRMODE_DEADBAND)))
+            && ((rcData[ROLL] < (rxConfig->midrc + AIRMODE_DEADBAND)) && (rcData[ROLL] > (rxConfig->midrc -AIRMODE_DEADBAND))))
+        return CENTERED;
+
+    return NOT_CENTERED;
 }
 
 void processRcStickPositions(rxConfig_t *rxConfig, throttleStatus_e throttleStatus, bool retarded_arm, bool disarm_kill_switch)

--- a/src/main/io/rc_controls.h
+++ b/src/main/io/rc_controls.h
@@ -48,6 +48,7 @@ typedef enum {
     BOXSERVO3,
     BOXBLACKBOX,
     BOXFAILSAFE,
+    BOXAIRMODE,
     CHECKBOX_ITEM_COUNT
 } boxId_e;
 
@@ -75,6 +76,11 @@ typedef enum {
     THROTTLE_LOW = 0,
     THROTTLE_HIGH
 } throttleStatus_e;
+
+typedef enum {
+    NOT_CENTERED = 0,
+    CENTERED
+} rollPitchStatus_e;
 
 #define ROL_LO (1 << (2 * ROLL))
 #define ROL_CE (3 << (2 * ROLL))
@@ -149,6 +155,7 @@ bool areUsingSticksToArm(void);
 
 bool areSticksInApModePosition(uint16_t ap_mode);
 throttleStatus_e calculateThrottleStatus(rxConfig_t *rxConfig, uint16_t deadband3d_throttle);
+rollPitchStatus_e calculateRollPitchCenterStatus(rxConfig_t *rxConfig);
 void processRcStickPositions(rxConfig_t *rxConfig, throttleStatus_e throttleStatus, bool retarded_arm, bool disarm_kill_switch);
 
 void updateActivatedModes(modeActivationCondition_t *modeActivationConditions);

--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -139,6 +139,7 @@ static const box_t boxes[CHECKBOX_ITEM_COUNT + 1] = {
     { BOXSERVO3, "SERVO3;", 25 },
     { BOXBLACKBOX, "BLACKBOX;", 26 },
     { BOXFAILSAFE, "FAILSAFE;", 27 },
+    { BOXAIRMODE, "AIR MODE;", 28 },
     { CHECKBOX_ITEM_COUNT, NULL, 0xFF }
 };
 
@@ -472,6 +473,8 @@ void mspInit(serialConfig_t *serialConfig)
     }
 #endif
 
+    activeBoxIds[activeBoxIdCount++] = BOXAIRMODE;
+
     if (sensors(SENSOR_ACC) || sensors(SENSOR_MAG)) {
         activeBoxIds[activeBoxIdCount++] = BOXMAG;
         activeBoxIds[activeBoxIdCount++] = BOXHEADFREE;
@@ -572,7 +575,8 @@ static uint32_t packFlightModeFlags(void)
         IS_ENABLED(FLIGHT_MODE(SONAR_MODE)) << BOXSONAR |
         IS_ENABLED(ARMING_FLAG(ARMED)) << BOXARM |
         IS_ENABLED(IS_RC_MODE_ACTIVE(BOXBLACKBOX)) << BOXBLACKBOX |
-        IS_ENABLED(FLIGHT_MODE(FAILSAFE_MODE)) << BOXFAILSAFE;
+        IS_ENABLED(FLIGHT_MODE(FAILSAFE_MODE)) << BOXFAILSAFE |
+        IS_ENABLED(FLIGHT_MODE(BOXAIRMODE)) << BOXAIRMODE;
 
     for (i = 0; i < activeBoxIdCount; i++) {
         int flag = (tmp & (1 << activeBoxIds[i]));

--- a/src/main/target/CC3D/target.h
+++ b/src/main/target/CC3D/target.h
@@ -120,7 +120,7 @@
 
 #define TELEMETRY
 #define SERIAL_RX
-#define SONAR
+//#define SONAR
 #define USE_SERVOS
 #define USE_CLI
 

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -49,6 +49,8 @@ extern "C" {
             uint16_t max_angle_inclination, rollAndPitchTrims_t *angleTrim, rxConfig_t *rxConfig);            // pid controller function prototype
     extern pidControllerFuncPtr pid_controller;
     extern uint8_t PIDweight[3];
+    extern bool motorLimitReached;
+    extern uint32_t rcModeActivationMask;
     float dT; // dT for pidLuxFloat
     float unittest_pidLuxFloat_lastErrorForDelta[3];
     float unittest_pidLuxFloat_delta1[3];
@@ -683,4 +685,6 @@ gyro_t gyro;
 int16_t gyroADC[XYZ_AXIS_COUNT];
 int16_t rcCommand[4] = {1500,0,0,0};           // interval [1000;2000] for THROTTLE and [-500;+500] for ROLL/PITCH/YAW
 int16_t rcData[MAX_SUPPORTED_RC_CHANNEL_COUNT];     // interval [1000;2000]
+bool motorLimitReached;
+uint32_t rcModeActivationMask;
 }


### PR DESCRIPTION
Airmode concept implementation. Mixer improvements to have better stability over the entire throtle range and especially low throttle. 
Additionally to that there are several other tweaks to Iterm to make acrobatic things much more natural and to prevent unnecessary Iterm windups.
This also improves 3D flight experience

Initial idea was from @bdoiron74 like 6 months ago, but I did some extensive testing with it and did some optimalisations to it.

There is some double code in the mixer code, but this is intentional to make it possible to easy remove the old mixer method as this could eventually be a full replacement for the current mixer