### PR TITLE
Refactor i2c_overclock to highSpeedI2c and enable by default

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -482,7 +482,7 @@ static void resetConf(void)
 
     masterConfig.looptime = 3500;
     masterConfig.emf_avoidance = 0;
-    masterConfig.i2c_overclock = 0;
+    masterConfig.highSpeedI2c = 1;
     masterConfig.gyroSync = 0;
     masterConfig.gyroSyncDenominator = 1;
 

--- a/src/main/config/config_master.h
+++ b/src/main/config/config_master.h
@@ -26,8 +26,8 @@ typedef struct master_t {
     uint8_t mixerMode;
     uint32_t enabledFeatures;
     uint16_t looptime;                      // imu loop time in us
-    uint8_t emf_avoidance;                   // change pll settings to avoid noise in the uhf band
-    uint8_t i2c_overclock;                  // Overclock i2c Bus for faster IMU readings
+    uint8_t emf_avoidance;                  // change pll settings to avoid noise in the uhf band
+    uint8_t highSpeedI2c;                   // Overclock i2c Bus for faster IMU readings
     uint8_t gyroSync;                       // Enable interrupt based loop
     uint8_t gyroSyncDenominator;            // Gyro sync Denominator
 

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -480,7 +480,7 @@ typedef struct {
 const clivalue_t valueTable[] = {
     { "looptime",                   VAR_UINT16 | MASTER_VALUE,  &masterConfig.looptime, .config.minmax = {0, 9000} },
     { "emf_avoidance",              VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  &masterConfig.emf_avoidance, .config.lookup = { TABLE_OFF_ON } },
-    { "i2c_overclock",              VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  &masterConfig.i2c_overclock, .config.lookup = { TABLE_OFF_ON } },
+    { "high_speed_i2c",             VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  &masterConfig.highSpeedI2c, .config.lookup = { TABLE_OFF_ON } },
     { "gyro_sync",                  VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  &masterConfig.gyroSync, .config.lookup = { TABLE_OFF_ON } },
     { "gyro_sync_denom",            VAR_UINT8  | MASTER_VALUE,  &masterConfig.gyroSyncDenominator, .config.minmax = { 1,  32 } },
 

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -250,7 +250,7 @@ void init(void)
     // Configure the Flash Latency cycles and enable prefetch buffer
     SetSysClock(masterConfig.emf_avoidance);
 #endif
-    i2cSetOverclock(masterConfig.i2c_overclock);
+    i2cSetOverclock(masterConfig.highSpeedI2c);
 
 #ifdef USE_HARDWARE_REVISION_DETECTION
     detectHardwareRevision();


### PR DESCRIPTION
overclock just sounds like some hack.....this is more suitable.

None of the tested equipment ever showed any issues till now.