### PR TITLE
Removed hard requirement of SERIAL_RX on USART2

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -872,9 +872,6 @@ void validateAndFixConfig(void)
 
 #if defined(COLIBRI_RACE)
     masterConfig.serialConfig.portConfigs[0].functionMask = FUNCTION_MSP;
-    if(featureConfigured(FEATURE_RX_SERIAL)) {
-        masterConfig.serialConfig.portConfigs[2].functionMask = FUNCTION_RX_SERIAL;
-    }
 #endif
 
     useRxConfig(&masterConfig.rxConfig);


### PR DESCRIPTION
Let the user have freedom.