### PR TITLE
Fix broken Lux target

### DIFF
--- a/src/main/target/LUX_RACE/target.h
+++ b/src/main/target/LUX_RACE/target.h
@@ -102,6 +102,9 @@
 #define UART3_TX_PINSOURCE  GPIO_PinSource10
 #define UART3_RX_PINSOURCE  GPIO_PinSource11
 
+#define USE_I2C
+#define I2C_DEVICE (I2CDEV_2)
+
 #define USE_ADC
 
 #define ADC_INSTANCE                ADC1


### PR DESCRIPTION
Re-add some lines that were removed going from the Colibri to the Lux target in #1775 which made it unable to connect over USB, this fixes the issue while not re-introducing the problem with Serial always showing up on UART2.