### PR TITLE
Scheduler optimized by using priority queue

### DIFF
--- a/src/main/build_config.h
+++ b/src/main/build_config.h
@@ -22,9 +22,11 @@
 
 #ifdef UNIT_TEST
 #define STATIC_UNIT_TESTED // make visible to unit test
+#define INLINE_UNIT_TESTED // make visible to unit test
 #define UNIT_TESTED
 #else
 #define STATIC_UNIT_TESTED static
+#define INLINE_UNIT_TESTED inline
 #define UNIT_TESTED
 #endif
 

--- a/src/main/build_config.h
+++ b/src/main/build_config.h
@@ -21,11 +21,14 @@
 #define BUILD_BUG_ON(condition) ((void)sizeof(char[1 - 2*!!(condition)]))
 
 #ifdef UNIT_TEST
-#define STATIC_UNIT_TESTED // make visible to unit test
-#define INLINE_UNIT_TESTED // make visible to unit test
+// make these visible to unit test
+#define STATIC_UNIT_TESTED
+#define STATIC_INLINE_UNIT_TESTED
+#define INLINE_UNIT_TESTED
 #define UNIT_TESTED
 #else
 #define STATIC_UNIT_TESTED static
+#define STATIC_INLINE_UNIT_TESTED static inline
 #define INLINE_UNIT_TESTED inline
 #define UNIT_TESTED
 #endif

--- a/src/main/config/config_unittest.h
+++ b/src/main/config/config_unittest.h
@@ -43,7 +43,6 @@ bool unittest_outsideRealtimeGuardInterval;
 
 #else
 
-#define SET_SCHEDULER_LOCALS() {}
 #define GET_SCHEDULER_LOCALS() {}
 
 #endif
@@ -57,10 +56,6 @@ cfTask_t *unittest_scheduler_selectedTask;
 uint8_t unittest_scheduler_selectedTaskDynPrio;
 uint16_t unittest_scheduler_waitingTasks;
 uint32_t unittest_scheduler_timeToNextRealtimeTask;
-
-#define SET_SCHEDULER_LOCALS() \
-    { \
-    }
 
 #define GET_SCHEDULER_LOCALS() \
     { \

--- a/src/main/config/config_unittest.h
+++ b/src/main/config/config_unittest.h
@@ -20,9 +20,6 @@
 #ifdef SRC_MAIN_SCHEDULER_C_
 #ifdef UNIT_TEST
 
-#ifdef SRC_MAIN_SCHEDULER_C_
-#ifdef UNIT_TEST
-
 cfTask_t *unittest_scheduler_selectedTask;
 uint8_t unittest_scheduler_selectedTaskDynamicPriority;
 uint16_t unittest_scheduler_waitingTasks;

--- a/src/main/config/config_unittest.h
+++ b/src/main/config/config_unittest.h
@@ -24,14 +24,15 @@
 #ifdef UNIT_TEST
 
 cfTask_t *unittest_scheduler_selectedTask;
-uint8_t unittest_scheduler_selectedTaskDynPrio;
+uint8_t unittest_scheduler_selectedTaskDynamicPriority;
 uint16_t unittest_scheduler_waitingTasks;
 uint32_t unittest_scheduler_timeToNextRealtimeTask;
+bool unittest_outsideRealtimeGuardInterval;
 
 #define GET_SCHEDULER_LOCALS() \
     { \
     unittest_scheduler_selectedTask = selectedTask; \
-    unittest_scheduler_selectedTaskDynPrio = selectedTaskDynPrio; \
+    unittest_scheduler_selectedTaskDynamicPriority = selectedTaskDynamicPriority; \
     unittest_scheduler_waitingTasks = waitingTasks; \
     unittest_scheduler_timeToNextRealtimeTask = timeToNextRealtimeTask; \
     unittest_outsideRealtimeGuardInterval = outsideRealtimeGuardInterval; \

--- a/src/main/config/config_unittest.h
+++ b/src/main/config/config_unittest.h
@@ -50,6 +50,35 @@ bool unittest_outsideRealtimeGuardInterval;
 #endif
 
 
+#ifdef SRC_MAIN_SCHEDULER_C_
+#ifdef UNIT_TEST
+
+cfTask_t *unittest_scheduler_selectedTask;
+uint8_t unittest_scheduler_selectedTaskDynPrio;
+uint16_t unittest_scheduler_waitingTasks;
+uint32_t unittest_scheduler_timeToNextRealtimeTask;
+
+#define SET_SCHEDULER_LOCALS() \
+    { \
+    }
+
+#define GET_SCHEDULER_LOCALS() \
+    { \
+    unittest_scheduler_selectedTask = selectedTask; \
+    unittest_scheduler_selectedTaskDynPrio = selectedTaskDynPrio; \
+    unittest_scheduler_waitingTasks = waitingTasks; \
+    unittest_scheduler_timeToNextRealtimeTask = timeToNextRealtimeTask; \
+    }
+
+#else
+
+#define SET_SCHEDULER_LOCALS() {}
+#define GET_SCHEDULER_LOCALS() {}
+
+#endif
+#endif
+
+
 #ifdef SRC_MAIN_FLIGHT_PID_C_
 #ifdef UNIT_TEST
 

--- a/src/main/config/config_unittest.h
+++ b/src/main/config/config_unittest.h
@@ -20,35 +20,6 @@
 #ifdef SRC_MAIN_SCHEDULER_C_
 #ifdef UNIT_TEST
 
-uint8_t unittest_scheduler_taskId;
-uint8_t unittest_scheduler_selectedTaskId;
-uint8_t unittest_scheduler_selectedTaskDynPrio;
-uint16_t unittest_scheduler_waitingTasks;
-uint32_t unittest_scheduler_timeToNextRealtimeTask;
-bool unittest_outsideRealtimeGuardInterval;
-
-#define SET_SCHEDULER_LOCALS() \
-    { \
-    }
-
-#define GET_SCHEDULER_LOCALS() \
-    { \
-    unittest_scheduler_taskId = taskId; \
-    unittest_scheduler_selectedTaskId = selectedTaskId; \
-    unittest_scheduler_selectedTaskDynPrio = selectedTaskDynPrio; \
-    unittest_scheduler_waitingTasks = waitingTasks; \
-    unittest_scheduler_timeToNextRealtimeTask = timeToNextRealtimeTask; \
-    unittest_outsideRealtimeGuardInterval = outsideRealtimeGuardInterval; \
-    }
-
-#else
-
-#define GET_SCHEDULER_LOCALS() {}
-
-#endif
-#endif
-
-
 #ifdef SRC_MAIN_SCHEDULER_C_
 #ifdef UNIT_TEST
 
@@ -63,11 +34,11 @@ uint32_t unittest_scheduler_timeToNextRealtimeTask;
     unittest_scheduler_selectedTaskDynPrio = selectedTaskDynPrio; \
     unittest_scheduler_waitingTasks = waitingTasks; \
     unittest_scheduler_timeToNextRealtimeTask = timeToNextRealtimeTask; \
+    unittest_outsideRealtimeGuardInterval = outsideRealtimeGuardInterval; \
     }
 
 #else
 
-#define SET_SCHEDULER_LOCALS() {}
 #define GET_SCHEDULER_LOCALS() {}
 
 #endif

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -700,6 +700,7 @@ int main(void) {
     setTaskEnabled(TASK_TRANSPONDER, feature(FEATURE_TRANSPONDER));
 #endif
 
+    schedulerInit();
     while (1) {
         scheduler();
         processLoopback();

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -656,16 +656,10 @@ void processLoopback(void) {
 int main(void) {
     init();
 
-    /* Setup scheduler */
+    // Setup scheduler
     schedulerInit();
-    if (imuConfig()->gyroSync) {
-        rescheduleTask(TASK_GYROPID, targetLooptime - INTERRUPT_WAIT_TIME);
-    }
-    else {
-        rescheduleTask(TASK_GYROPID, targetLooptime);
-    }
-
     setTaskEnabled(TASK_GYROPID, true);
+    rescheduleTask(TASK_GYROPID, imuConfig()->gyroSync ? targetLooptime - INTERRUPT_WAIT_TIME : targetLooptime);
     setTaskEnabled(TASK_ACCEL, sensors(SENSOR_ACC));
     setTaskEnabled(TASK_SERIAL, true);
 #ifdef BEEPER
@@ -701,7 +695,7 @@ int main(void) {
     setTaskEnabled(TASK_TRANSPONDER, feature(FEATURE_TRANSPONDER));
 #endif
 
-    while (1) {
+    while (true) {
         scheduler();
         processLoopback();
     }

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -657,6 +657,7 @@ int main(void) {
     init();
 
     /* Setup scheduler */
+    schedulerInit();
     if (imuConfig()->gyroSync) {
         rescheduleTask(TASK_GYROPID, targetLooptime - INTERRUPT_WAIT_TIME);
     }
@@ -700,7 +701,6 @@ int main(void) {
     setTaskEnabled(TASK_TRANSPONDER, feature(FEATURE_TRANSPONDER));
 #endif
 
-    schedulerInit();
     while (1) {
         scheduler();
         processLoopback();

--- a/src/main/scheduler.c
+++ b/src/main/scheduler.c
@@ -20,11 +20,13 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <stdint.h>
+#include <string.h>
 
 #include <platform.h>
 
 #include "scheduler.h"
 #include "debug.h"
+#include "build_config.h"
 
 #include "common/maths.h"
 
@@ -47,34 +49,57 @@ uint16_t averageSystemLoadPercent = 0;
 
 static int queuePos = 0;
 static int queueSize = 0;
+// No need for a linked list for the queue, since items are only inserted at startup
 static cfTask_t* queueArray[TASK_COUNT];
 
-static void queueInit(void)
+STATIC_UNIT_TESTED void queueClear(void)
 {
+    memset(queueArray, 0, sizeof(queueArray));
     queuePos = 0;
     queueSize = 0;
-    // put the enabled tasks in the queue in priority order
-    const cfTaskPriority_e priorities[] =
-        {TASK_PRIORITY_MAX, TASK_PRIORITY_REALTIME, TASK_PRIORITY_HIGH, TASK_PRIORITY_MEDIUM, TASK_PRIORITY_LOW, TASK_PRIORITY_IDLE};
-    for (unsigned int ii = 0; ii < sizeof(priorities); ++ii) {
-        const cfTaskPriority_e priority = priorities[ii];
-        for (int taskId = 0; taskId < TASK_COUNT; ++taskId) {
-            cfTask_t *task = &cfTasks[taskId];
-            if (task->staticPriority == priority && task->isEnabled == true) {
-                queueArray[queuePos] = task;
-                ++queuePos;
-                ++queueSize;
-            }
+}
+
+STATIC_UNIT_TESTED void queueAdd(cfTask_t *task)
+{
+    for (int ii = 0; ii < TASK_COUNT; ++ii) {
+        if (queueArray[ii] == task) {
+            return;
+        }
+        if (queueArray[ii] == NULL || queueArray[ii]->staticPriority < task->staticPriority) {
+            memmove(&queueArray[ii+1], &queueArray[ii], sizeof(task) * (TASK_COUNT - ii - 1));
+            queueArray[ii] = task;
+            return;
         }
     }
 }
-static cfTask_t *queueFirst(void)
+
+STATIC_UNIT_TESTED void queueRemove(cfTask_t *task)
+{
+    for (int ii = 0; ii < TASK_COUNT; ++ii) {
+        if (queueArray[ii] == task) {
+            memmove(&queueArray[ii], &queueArray[ii+1], sizeof(task) * (TASK_COUNT - ii - 1));
+            return;
+        }
+    }
+}
+
+STATIC_UNIT_TESTED bool queueContains(cfTask_t *task)
+{
+    for (int ii = 0; ii < TASK_COUNT; ++ii) {
+        if (queueArray[ii] == task) {
+            return true;
+        }
+    }
+    return false;
+}
+
+STATIC_UNIT_TESTED cfTask_t *queueFirst(void)
 {
     queuePos = 0;
     return queueSize > 0 ? queueArray[0] : NULL;
 }
 
-static cfTask_t *queueNext(void) {
+STATIC_UNIT_TESTED cfTask_t *queueNext(void) {
     ++queuePos;
     return queuePos < queueSize ? queueArray[queuePos] : NULL;
 }
@@ -106,7 +131,7 @@ void taskSystem(void)
 void getTaskInfo(cfTaskId_e taskId, cfTaskInfo_t * taskInfo)
 {
     taskInfo->taskName = cfTasks[taskId].taskName;
-    taskInfo->isEnabled= cfTasks[taskId].isEnabled;
+    taskInfo->isEnabled = queueContains(&cfTasks[taskId]);
     taskInfo->desiredPeriod = cfTasks[taskId].desiredPeriod;
     taskInfo->staticPriority = cfTasks[taskId].staticPriority;
     taskInfo->maxExecutionTime = cfTasks[taskId].maxExecutionTime;
@@ -124,11 +149,15 @@ void rescheduleTask(cfTaskId_e taskId, uint32_t newPeriodMicros)
     }
 }
 
-void setTaskEnabled(cfTaskId_e taskId, bool newEnabledState)
+void setTaskEnabled(cfTaskId_e taskId, bool enabled)
 {
     if (taskId == TASK_SELF || taskId < TASK_COUNT) {
         cfTask_t *task = taskId == TASK_SELF ? currentTask : &cfTasks[taskId];
-        task->isEnabled = newEnabledState;
+        if (enabled && task->taskFunc) {
+            queueAdd(task);
+        } else {
+            queueRemove(task);
+        }
     }
 }
 
@@ -144,7 +173,8 @@ uint32_t getTaskDeltaTime(cfTaskId_e taskId)
 
 void schedulerInit(void)
 {
-    queueInit();
+    queueClear();
+    queueAdd(&cfTasks[TASK_SYSTEM]);
 }
 
 void scheduler(void)

--- a/src/main/scheduler.c
+++ b/src/main/scheduler.c
@@ -22,12 +22,9 @@
 #include <string.h>
 
 #ifdef UNIT_TEST
-// cannot include platform.h in UNIT_TEST build, since if included the build #defines (eg MAG, GPS, etc)
-// are set differently to test code
 typedef enum {TEST_IRQ = 0 } IRQn_Type;
-#else
-#include "platform.h"
 #endif
+#include "platform.h"
 
 #include "scheduler.h"
 #include "debug.h"
@@ -62,7 +59,7 @@ static cfTask_t* taskQueueArray[TASK_COUNT + 1]; // extra item for NULL pointer 
 #endif
 STATIC_UNIT_TESTED void queueClear(void)
 {
-    memset(taskQueueArray, 0, sizeof(cfTask_t) * (TASK_COUNT + 1));
+    memset(taskQueueArray, 0, sizeof(taskQueueArray));
     taskQueuePos = 0;
     taskQueueSize = 0;
 }

--- a/src/main/scheduler.c
+++ b/src/main/scheduler.c
@@ -83,7 +83,7 @@ STATIC_UNIT_TESTED bool queueContains(cfTask_t *task)
 
 STATIC_UNIT_TESTED void queueAdd(cfTask_t *task)
 {
-    if ((taskQueueSize >= TASK_COUNT -1) || queueContains(task)) {
+    if ((taskQueueSize >= TASK_COUNT - 1) || queueContains(task)) {
         return;
     }
     for (int ii = 0; ii <= taskQueueSize; ++ii) {

--- a/src/main/scheduler.c
+++ b/src/main/scheduler.c
@@ -47,22 +47,29 @@ uint32_t currentTime = 0;
 uint16_t averageSystemLoadPercent = 0;
 
 
-static int queuePos = 0;
-static int queueSize = 0;
+static int taskQueuePos = 0;
+static int taskQueueSize = 0;
 // No need for a linked list for the queue, since items are only inserted at startup
-static cfTask_t* queueArray[TASK_COUNT];
+STATIC_UNIT_TESTED cfTask_t* taskQueueArray[TASK_COUNT + 1]; // 1 extra space so test code can check for buffer overruns
 
 STATIC_UNIT_TESTED void queueClear(void)
 {
-    memset(queueArray, 0, sizeof(queueArray));
-    queuePos = 0;
-    queueSize = 0;
+    memset(taskQueueArray, 0, (int)(sizeof(taskQueueArray)));
+    taskQueuePos = 0;
+    taskQueueSize = 0;
 }
+
+#ifdef UNIT_TEST
+STATIC_UNIT_TESTED int queueSize(void)
+{
+    return taskQueueSize;
+}
+#endif
 
 STATIC_UNIT_TESTED bool queueContains(cfTask_t *task)
 {
-    for (int ii = 0; ii < queueSize; ++ii) {
-        if (queueArray[ii] == task) {
+    for (int ii = 0; ii < taskQueueSize; ++ii) {
+        if (taskQueueArray[ii] == task) {
             return true;
         }
     }
@@ -71,14 +78,17 @@ STATIC_UNIT_TESTED bool queueContains(cfTask_t *task)
 
 STATIC_UNIT_TESTED void queueAdd(cfTask_t *task)
 {
+    if (taskQueueSize >= TASK_COUNT -1) {
+        return;
+    }
     if (queueContains(task)) {
         return;
     }
-    ++queueSize;
-    for (int ii = 0; ii < queueSize; ++ii) {
-        if (queueArray[ii] == NULL || queueArray[ii]->staticPriority < task->staticPriority) {
-            memmove(&queueArray[ii+1], &queueArray[ii], sizeof(task) * (queueSize - ii - 1));
-            queueArray[ii] = task;
+    ++taskQueueSize;
+    for (int ii = 0; ii < taskQueueSize; ++ii) {
+        if (taskQueueArray[ii] == NULL || taskQueueArray[ii]->staticPriority < task->staticPriority) {
+            memmove(&taskQueueArray[ii+1], &taskQueueArray[ii], sizeof(task) * (taskQueueSize - ii - 1));
+            taskQueueArray[ii] = task;
             return;
         }
     }
@@ -86,9 +96,10 @@ STATIC_UNIT_TESTED void queueAdd(cfTask_t *task)
 
 STATIC_UNIT_TESTED void queueRemove(cfTask_t *task)
 {
-    for (int ii = 0; ii < queueSize; ++ii) {
-        if (queueArray[ii] == task) {
-            memmove(&queueArray[ii], &queueArray[ii+1], sizeof(task) * (queueSize - ii - 1));
+    for (int ii = 0; ii < taskQueueSize; ++ii) {
+        if (taskQueueArray[ii] == task) {
+            --taskQueueSize;
+            memmove(&taskQueueArray[ii], &taskQueueArray[ii+1], sizeof(task) * (taskQueueSize - ii));
             return;
         }
     }
@@ -96,13 +107,14 @@ STATIC_UNIT_TESTED void queueRemove(cfTask_t *task)
 
 STATIC_UNIT_TESTED cfTask_t *queueFirst(void)
 {
-    queuePos = 0;
-    return queueSize > 0 ? queueArray[0] : NULL;
+    taskQueuePos = 0;
+    return taskQueueSize > 0 ? taskQueueArray[0] : NULL;
 }
 
-STATIC_UNIT_TESTED cfTask_t *queueNext(void) {
-    ++queuePos;
-    return queuePos < queueSize ? queueArray[queuePos] : NULL;
+STATIC_UNIT_TESTED cfTask_t *queueNext(void)
+{
+    ++taskQueuePos;
+    return taskQueuePos < taskQueueSize ? taskQueueArray[taskQueuePos] : NULL;
 }
 
 void taskSystem(void)
@@ -180,6 +192,7 @@ void schedulerInit(void)
 
 void scheduler(void)
 {
+    SET_SCHEDULER_LOCALS();
     /* Cache currentTime */
     currentTime = micros();
 

--- a/src/main/scheduler.c
+++ b/src/main/scheduler.c
@@ -50,8 +50,11 @@ uint16_t averageSystemLoadPercent = 0;
 static int taskQueuePos = 0;
 static int taskQueueSize = 0;
 // No need for a linked list for the queue, since items are only inserted at startup
+#ifdef UNIT_TEST
 STATIC_UNIT_TESTED cfTask_t* taskQueueArray[TASK_COUNT + 1]; // 1 extra space so test code can check for buffer overruns
-
+#else
+static cfTask_t* taskQueueArray[TASK_COUNT];
+#endif
 STATIC_UNIT_TESTED void queueClear(void)
 {
     memset(taskQueueArray, 0, (int)(sizeof(taskQueueArray)));
@@ -66,6 +69,7 @@ STATIC_UNIT_TESTED int queueSize(void)
 }
 #endif
 
+#if !defined(SKIP_TASK_STATISTICS) || defined(UNIT_TEST)
 STATIC_UNIT_TESTED bool queueContains(cfTask_t *task)
 {
     for (int ii = 0; ii < taskQueueSize; ++ii) {
@@ -75,6 +79,7 @@ STATIC_UNIT_TESTED bool queueContains(cfTask_t *task)
     }
     return false;
 }
+#endif
 
 STATIC_UNIT_TESTED void queueAdd(cfTask_t *task)
 {

--- a/src/main/scheduler.c
+++ b/src/main/scheduler.c
@@ -260,7 +260,7 @@ void scheduler(void)
         }
     }
 
-    totalWaitingTasksSamples += 1;
+    totalWaitingTasksSamples++;
     totalWaitingTasks += waitingTasks;
 
     /* Found a task that should be run */
@@ -271,12 +271,12 @@ void scheduler(void)
 
         currentTask = selectedTask;
 
-        uint32_t currentTimeBeforeTaskCall = micros();
+        const uint32_t currentTimeBeforeTaskCall = micros();
 
         /* Execute task */
         selectedTask->taskFunc();
 
-        uint32_t taskExecutionTime = micros() - currentTimeBeforeTaskCall;
+        const uint32_t taskExecutionTime = micros() - currentTimeBeforeTaskCall;
 
         selectedTask->averageExecutionTime = ((uint32_t)selectedTask->averageExecutionTime * 31 + taskExecutionTime) / 32;
 #ifndef SKIP_TASK_STATISTICS

--- a/src/main/scheduler.c
+++ b/src/main/scheduler.c
@@ -28,6 +28,7 @@ typedef enum {TEST_IRQ = 0 } IRQn_Type;
 #else
 #include "platform.h"
 #endif
+
 #include "scheduler.h"
 #include "debug.h"
 #include "build_config.h"

--- a/src/main/scheduler.c
+++ b/src/main/scheduler.c
@@ -83,17 +83,14 @@ STATIC_UNIT_TESTED bool queueContains(cfTask_t *task)
 
 STATIC_UNIT_TESTED void queueAdd(cfTask_t *task)
 {
-    if (taskQueueSize >= TASK_COUNT -1) {
+    if ((taskQueueSize >= TASK_COUNT -1) || queueContains(task)) {
         return;
     }
-    if (queueContains(task)) {
-        return;
-    }
-    ++taskQueueSize;
-    for (int ii = 0; ii < taskQueueSize; ++ii) {
+    for (int ii = 0; ii <= taskQueueSize; ++ii) {
         if (taskQueueArray[ii] == NULL || taskQueueArray[ii]->staticPriority < task->staticPriority) {
-            memmove(&taskQueueArray[ii+1], &taskQueueArray[ii], sizeof(task) * (taskQueueSize - ii - 1));
+            memmove(&taskQueueArray[ii+1], &taskQueueArray[ii], sizeof(task) * (taskQueueSize - ii));
             taskQueueArray[ii] = task;
+            ++taskQueueSize;
             return;
         }
     }
@@ -105,9 +102,6 @@ STATIC_UNIT_TESTED void queueRemove(cfTask_t *task)
         if (taskQueueArray[ii] == task) {
             memmove(&taskQueueArray[ii], &taskQueueArray[ii+1], sizeof(task) * (taskQueueSize - ii));
             --taskQueueSize;
-            if (taskQueueSize == 0) {
-                taskQueueArray[0] = NULL; // ensure item zero is null when queue is empty
-            }
             return;
         }
     }

--- a/src/main/scheduler.c
+++ b/src/main/scheduler.c
@@ -59,14 +59,25 @@ STATIC_UNIT_TESTED void queueClear(void)
     queueSize = 0;
 }
 
+STATIC_UNIT_TESTED bool queueContains(cfTask_t *task)
+{
+    for (int ii = 0; ii < queueSize; ++ii) {
+        if (queueArray[ii] == task) {
+            return true;
+        }
+    }
+    return false;
+}
+
 STATIC_UNIT_TESTED void queueAdd(cfTask_t *task)
 {
-    for (int ii = 0; ii < TASK_COUNT; ++ii) {
-        if (queueArray[ii] == task) {
-            return;
-        }
+    if (queueContains(task)) {
+        return;
+    }
+    ++queueSize;
+    for (int ii = 0; ii < queueSize; ++ii) {
         if (queueArray[ii] == NULL || queueArray[ii]->staticPriority < task->staticPriority) {
-            memmove(&queueArray[ii+1], &queueArray[ii], sizeof(task) * (TASK_COUNT - ii - 1));
+            memmove(&queueArray[ii+1], &queueArray[ii], sizeof(task) * (queueSize - ii - 1));
             queueArray[ii] = task;
             return;
         }
@@ -75,22 +86,12 @@ STATIC_UNIT_TESTED void queueAdd(cfTask_t *task)
 
 STATIC_UNIT_TESTED void queueRemove(cfTask_t *task)
 {
-    for (int ii = 0; ii < TASK_COUNT; ++ii) {
+    for (int ii = 0; ii < queueSize; ++ii) {
         if (queueArray[ii] == task) {
-            memmove(&queueArray[ii], &queueArray[ii+1], sizeof(task) * (TASK_COUNT - ii - 1));
+            memmove(&queueArray[ii], &queueArray[ii+1], sizeof(task) * (queueSize - ii - 1));
             return;
         }
     }
-}
-
-STATIC_UNIT_TESTED bool queueContains(cfTask_t *task)
-{
-    for (int ii = 0; ii < TASK_COUNT; ++ii) {
-        if (queueArray[ii] == task) {
-            return true;
-        }
-    }
-    return false;
 }
 
 STATIC_UNIT_TESTED cfTask_t *queueFirst(void)

--- a/src/main/scheduler.c
+++ b/src/main/scheduler.c
@@ -51,9 +51,9 @@ static int taskQueuePos = 0;
 static int taskQueueSize = 0;
 // No need for a linked list for the queue, since items are only inserted at startup
 #ifdef UNIT_TEST
-STATIC_UNIT_TESTED cfTask_t* taskQueueArray[TASK_COUNT + 1]; // 1 extra space so test code can check for buffer overruns
+STATIC_UNIT_TESTED cfTask_t* taskQueueArray[TASK_COUNT + 2]; // 1 extra space so test code can check for buffer overruns
 #else
-static cfTask_t* taskQueueArray[TASK_COUNT];
+static cfTask_t* taskQueueArray[TASK_COUNT + 1]; // extra item for NULL pointer at end of queue
 #endif
 STATIC_UNIT_TESTED void queueClear(void)
 {
@@ -103,23 +103,31 @@ STATIC_UNIT_TESTED void queueRemove(cfTask_t *task)
 {
     for (int ii = 0; ii < taskQueueSize; ++ii) {
         if (taskQueueArray[ii] == task) {
-            --taskQueueSize;
             memmove(&taskQueueArray[ii], &taskQueueArray[ii+1], sizeof(task) * (taskQueueSize - ii));
+            --taskQueueSize;
+            if (taskQueueSize == 0) {
+                taskQueueArray[0] = NULL; // ensure item zero is null when queue is empty
+            }
             return;
         }
     }
 }
 
-STATIC_UNIT_TESTED cfTask_t *queueFirst(void)
+/*
+ * Returns first item queue or NULL if queue empty
+ */
+INLINE_UNIT_TESTED cfTask_t *queueFirst(void)
 {
     taskQueuePos = 0;
-    return taskQueueSize > 0 ? taskQueueArray[0] : NULL;
+    return taskQueueArray[0]; // guaranteed to be NULL if queue is empty
 }
 
-STATIC_UNIT_TESTED cfTask_t *queueNext(void)
+/*
+ * Returns next item in queue or NULL if at end of queue
+ */
+INLINE_UNIT_TESTED cfTask_t *queueNext(void)
 {
-    ++taskQueuePos;
-    return taskQueuePos < taskQueueSize ? taskQueueArray[taskQueuePos] : NULL;
+    return taskQueueArray[++taskQueuePos]; // guaranteed to be NULL at end of queue
 }
 
 void taskSystem(void)
@@ -197,7 +205,6 @@ void schedulerInit(void)
 
 void scheduler(void)
 {
-    SET_SCHEDULER_LOCALS();
     /* Cache currentTime */
     currentTime = micros();
 

--- a/src/main/scheduler.c
+++ b/src/main/scheduler.c
@@ -62,7 +62,7 @@ static cfTask_t* taskQueueArray[TASK_COUNT + 1]; // extra item for NULL pointer 
 #endif
 STATIC_UNIT_TESTED void queueClear(void)
 {
-    memset(taskQueueArray, 0, (int)(sizeof(taskQueueArray)));
+    memset(taskQueueArray, 0, sizeof(cfTask_t) * (TASK_COUNT + 1));
     taskQueuePos = 0;
     taskQueueSize = 0;
 }

--- a/src/main/scheduler.c
+++ b/src/main/scheduler.c
@@ -69,7 +69,6 @@ STATIC_UNIT_TESTED int queueSize(void)
 }
 #endif
 
-#if !defined(SKIP_TASK_STATISTICS) || defined(UNIT_TEST)
 STATIC_UNIT_TESTED bool queueContains(cfTask_t *task)
 {
     for (int ii = 0; ii < taskQueueSize; ++ii) {
@@ -79,7 +78,6 @@ STATIC_UNIT_TESTED bool queueContains(cfTask_t *task)
     }
     return false;
 }
-#endif
 
 STATIC_UNIT_TESTED void queueAdd(cfTask_t *task)
 {

--- a/src/main/scheduler.h
+++ b/src/main/scheduler.h
@@ -92,7 +92,7 @@ typedef struct {
     bool (*checkFunc)(uint32_t currentDeltaTime);
     void (*taskFunc)(void);
     uint32_t desiredPeriod;     // target period of execution
-    uint8_t staticPriority;     // dynamicPriority grows in steps of this size, shouldn't be zero
+    const uint8_t staticPriority;// dynamicPriority grows in steps of this size, shouldn't be zero
 
     /* Scheduling */
     uint8_t dynamicPriority;    // measurement of how old task was last executed, used to avoid task starvation

--- a/src/main/scheduler.h
+++ b/src/main/scheduler.h
@@ -91,17 +91,17 @@ typedef struct {
     const char * taskName;
     bool (*checkFunc)(uint32_t currentDeltaTime);
     void (*taskFunc)(void);
-    uint32_t desiredPeriod;     // target period of execution
-    const uint8_t staticPriority;// dynamicPriority grows in steps of this size, shouldn't be zero
+    uint32_t desiredPeriod;         // target period of execution
+    const uint8_t staticPriority;   // dynamicPriority grows in steps of this size, shouldn't be zero
 
     /* Scheduling */
-    uint8_t dynamicPriority;    // measurement of how old task was last executed, used to avoid task starvation
-    uint32_t lastExecutedAt;    // last time of invocation
-    uint32_t lastSignaledAt;    // time of invocation event for event-driven tasks
+    uint16_t dynamicPriority;       // measurement of how old task was last executed, used to avoid task starvation
     uint16_t taskAgeCycles;
+    uint32_t lastExecutedAt;        // last time of invocation
+    uint32_t lastSignaledAt;        // time of invocation event for event-driven tasks
 
     /* Statistics */
-    uint32_t averageExecutionTime;  // Moving averate over 6 samples, used to calculate guard interval
+    uint32_t averageExecutionTime;  // Moving average over 6 samples, used to calculate guard interval
     uint32_t taskLatestDeltaTime;   //
 #ifndef SKIP_TASK_STATISTICS
     uint32_t maxExecutionTime;

--- a/src/main/scheduler.h
+++ b/src/main/scheduler.h
@@ -119,6 +119,7 @@ void rescheduleTask(cfTaskId_e taskId, uint32_t newPeriodMicros);
 void setTaskEnabled(cfTaskId_e taskId, bool newEnabledState);
 uint32_t getTaskDeltaTime(cfTaskId_e taskId);
 
+void schedulerInit(void);
 void scheduler(void);
 
 #define LOAD_PERCENTAGE_ONE 100

--- a/src/main/scheduler.h
+++ b/src/main/scheduler.h
@@ -91,7 +91,6 @@ typedef struct {
     const char * taskName;
     bool (*checkFunc)(uint32_t currentDeltaTime);
     void (*taskFunc)(void);
-    bool isEnabled;
     uint32_t desiredPeriod;     // target period of execution
     uint8_t staticPriority;     // dynamicPriority grows in steps of this size, shouldn't be zero
 

--- a/src/main/scheduler_tasks.c
+++ b/src/main/scheduler_tasks.c
@@ -42,7 +42,6 @@ void taskSystem(void);
 
 cfTask_t cfTasks[TASK_COUNT] = {
     [TASK_SYSTEM] = {
-        .isEnabled = true,
         .taskName = "SYSTEM",
         .taskFunc = taskSystem,
         .desiredPeriod = 1000000 / 10,              // run every 100 ms

--- a/src/test/unit/scheduler_unittest.cc
+++ b/src/test/unit/scheduler_unittest.cc
@@ -94,6 +94,16 @@ TEST(SchedulerUnittest, TestPriorites)
         EXPECT_EQ(TASK_PRIORITY_MEDIUM, cfTasks[TASK_BATTERY].staticPriority);
 }
 
+TEST(SchedulerUnittest, TestPriorites)
+{
+    // if any of these fail then task priorities have changed and ordering in TestQueue needs to be re-checked
+    EXPECT_EQ(TASK_PRIORITY_HIGH, cfTasks[TASK_SYSTEM].staticPriority);
+    EXPECT_EQ(TASK_PRIORITY_REALTIME, cfTasks[TASK_GYROPID].staticPriority);
+    EXPECT_EQ(TASK_PRIORITY_MEDIUM, cfTasks[TASK_ACCEL].staticPriority);
+    EXPECT_EQ(TASK_PRIORITY_LOW, cfTasks[TASK_SERIAL].staticPriority);
+    EXPECT_EQ(TASK_PRIORITY_MEDIUM, cfTasks[TASK_BATTERY].staticPriority);
+}
+
 TEST(SchedulerUnittest, TestQueueInit)
 {
     queueClear();
@@ -132,11 +142,11 @@ TEST(SchedulerUnittest, TestQueue)
     EXPECT_EQ(NULL, queueNext());
     EXPECT_EQ(deadBeefPtr, taskQueueArray[TASK_COUNT + 1]);
 
-    queueAdd(&cfTasks[TASK_BEEPER]); // TASK_PRIORITY_MEDIUM
+    queueAdd(&cfTasks[TASK_BATTERY]); // TASK_PRIORITY_MEDIUM
     EXPECT_EQ(4, queueSize());
     EXPECT_EQ(&cfTasks[TASK_GYROPID], queueFirst());
     EXPECT_EQ(&cfTasks[TASK_SYSTEM], queueNext());
-    EXPECT_EQ(&cfTasks[TASK_BEEPER], queueNext());
+    EXPECT_EQ(&cfTasks[TASK_BATTERY], queueNext());
     EXPECT_EQ(&cfTasks[TASK_SERIAL], queueNext());
     EXPECT_EQ(NULL, queueNext());
     EXPECT_EQ(deadBeefPtr, taskQueueArray[TASK_COUNT + 1]);
@@ -146,7 +156,7 @@ TEST(SchedulerUnittest, TestQueue)
     EXPECT_EQ(&cfTasks[TASK_GYROPID], queueFirst());
     EXPECT_EQ(&cfTasks[TASK_SYSTEM], queueNext());
     EXPECT_EQ(&cfTasks[TASK_RX], queueNext());
-    EXPECT_EQ(&cfTasks[TASK_BEEPER], queueNext());
+    EXPECT_EQ(&cfTasks[TASK_BATTERY], queueNext());
     EXPECT_EQ(&cfTasks[TASK_SERIAL], queueNext());
     EXPECT_EQ(NULL, queueNext());
     EXPECT_EQ(deadBeefPtr, taskQueueArray[TASK_COUNT + 1]);
@@ -155,19 +165,22 @@ TEST(SchedulerUnittest, TestQueue)
     EXPECT_EQ(4, queueSize());
     EXPECT_EQ(&cfTasks[TASK_GYROPID], queueFirst());
     EXPECT_EQ(&cfTasks[TASK_RX], queueNext());
-    EXPECT_EQ(&cfTasks[TASK_BEEPER], queueNext());
+    EXPECT_EQ(&cfTasks[TASK_BATTERY], queueNext());
     EXPECT_EQ(&cfTasks[TASK_SERIAL], queueNext());
     EXPECT_EQ(NULL, queueNext());
+    EXPECT_EQ(deadBeefPtr, taskQueueArray[TASK_COUNT + 1]);
 }
 
 TEST(SchedulerUnittest, TestQueueArray)
 {
     // test there are no "out by one" errors or buffer overruns when items are added and removed
     queueClear();
-    taskQueueArray[TASK_COUNT + 1] = deadBeefPtr;
+    taskQueueArray[TASK_COUNT + 1] = deadBeefPtr; // note, must set deadBeefPtr after queueClear
 
-    for (int taskId=0; taskId < TASK_COUNT - 1; ++taskId) {
+    for (int taskId = 0; taskId < TASK_COUNT - 1; ++taskId) {
         setTaskEnabled(static_cast<cfTaskId_e>(taskId), true);
+        EXPECT_EQ(taskId + 1, queueSize());
+        EXPECT_EQ(deadBeefPtr, taskQueueArray[TASK_COUNT + 1]);
     }
     EXPECT_EQ(TASK_COUNT - 1, queueSize());
     EXPECT_NE(static_cast<cfTask_t*>(0), taskQueueArray[TASK_COUNT - 2]);

--- a/src/test/unit/scheduler_unittest.cc
+++ b/src/test/unit/scheduler_unittest.cc
@@ -18,7 +18,7 @@
 #include <stdint.h>
 
 extern "C" {
-    #include <platform.h>
+    #include "platform.h"
     #include "scheduler.h"
 }
 
@@ -96,7 +96,8 @@ TEST(SchedulerUnittest, TestPriorites)
 
 TEST(SchedulerUnittest, TestPriorites)
 {
-    // if any of these fail then task priorities have changed and ordering in TestQueue needs to be re-checked
+    EXPECT_EQ(14, TASK_COUNT);
+          // if any of these fail then task priorities have changed and ordering in TestQueue needs to be re-checked
     EXPECT_EQ(TASK_PRIORITY_HIGH, cfTasks[TASK_SYSTEM].staticPriority);
     EXPECT_EQ(TASK_PRIORITY_REALTIME, cfTasks[TASK_GYROPID].staticPriority);
     EXPECT_EQ(TASK_PRIORITY_MEDIUM, cfTasks[TASK_ACCEL].staticPriority);
@@ -381,7 +382,7 @@ TEST(SchedulerUnittest, TestRealTimeGuardInNoTaskRun)
     EXPECT_EQ(300, unittest_scheduler_timeToNextRealtimeTask);
 
     // Nothing should be scheduled in guard period
-    EXPECT_EQ((uint8_t)TASK_NONE, unittest_scheduler_selectedTaskId);
+    EXPECT_EQ(NULL, unittest_scheduler_selectedTask);
     EXPECT_EQ(100000, cfTasks[TASK_SYSTEM].lastExecutedAt);
 
     EXPECT_EQ(200000, cfTasks[TASK_GYROPID].lastExecutedAt);
@@ -406,7 +407,7 @@ TEST(SchedulerUnittest, TestRealTimeGuardOutTaskRun)
     EXPECT_EQ(301, unittest_scheduler_timeToNextRealtimeTask);
 
     // System should be scheduled as not in guard period
-    EXPECT_EQ((uint8_t)TASK_SYSTEM, unittest_scheduler_selectedTaskId);
+    EXPECT_EQ(&cfTasks[TASK_SYSTEM], unittest_scheduler_selectedTask);
     EXPECT_EQ(200699, cfTasks[TASK_SYSTEM].lastExecutedAt);
 
     EXPECT_EQ(200000, cfTasks[TASK_GYROPID].lastExecutedAt);

--- a/src/test/unit/scheduler_unittest.cc
+++ b/src/test/unit/scheduler_unittest.cc
@@ -84,17 +84,6 @@ extern "C" {
 }
 
 TEST(SchedulerUnittest, TestPriorites)
-    {
-        // check that the #defines used by scheduler.c and scheduler_unittest.cc are in sync
-        EXPECT_EQ(14, TASK_COUNT);
-        EXPECT_EQ(TASK_PRIORITY_HIGH, cfTasks[TASK_SYSTEM].staticPriority);
-        EXPECT_EQ(TASK_PRIORITY_REALTIME, cfTasks[TASK_GYROPID].staticPriority);
-        EXPECT_EQ(TASK_PRIORITY_MEDIUM, cfTasks[TASK_ACCEL].staticPriority);
-        EXPECT_EQ(TASK_PRIORITY_LOW, cfTasks[TASK_SERIAL].staticPriority);
-        EXPECT_EQ(TASK_PRIORITY_MEDIUM, cfTasks[TASK_BATTERY].staticPriority);
-}
-
-TEST(SchedulerUnittest, TestPriorites)
 {
     EXPECT_EQ(14, TASK_COUNT);
           // if any of these fail then task priorities have changed and ordering in TestQueue needs to be re-checked


### PR DESCRIPTION
Scheduler optimized by using a priority queue. Underlying scheduling algorithm is unchanged.

Two main optimizations:

1. Removed task `isEnabled` flag. Instead task is enabled if it is in the queue, disabled if it is not. This means the main loop only iterates over the enabled tasks, instead of all tasks checking each if it is enabled
2. Tasks are placed in the queue in priority order. This makes the iteration over the queue more efficient.

Added test code for priority queue.

Flight tested on CC3D, CJMCU and SciSky flight controllers (that's all I have).

See also the discussion in issue https://github.com/cleanflight/cleanflight/issues/1692
