### PR TITLE
Configurable saturation handling in airmode

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -336,7 +336,7 @@ void resetRcControlsConfig(rcControlsConfig_t *rcControlsConfig) {
 
 void resetMixerConfig(mixerConfig_t *mixerConfig) {
     mixerConfig->pid_at_min_throttle = 1;
-    mixerConfig->agressive_airmode = 0;
+    mixerConfig->airmode_saturation_limit = 50;
     mixerConfig->yaw_motor_direction = 1;
     mixerConfig->yaw_jump_prevention_limit = 200;
 #ifdef USE_SERVOS

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -833,7 +833,7 @@ void mixTable(void)
             if (isFailsafeActive) {
                 mixConstrainMotorForFailsafeCondition(i);
             } else if (feature(FEATURE_3D)) {
-                if (throttle >= (rxConfig->midrc + flight3DConfig->deadband3d_throttle))  {
+                if (throttle >= flight3DConfig->deadband3d_high)  {
                     motor[i] = constrain(motor[i], flight3DConfig->deadband3d_high, escAndServoConfig->maxthrottle);
                 } else {
                     motor[i] = constrain(motor[i], escAndServoConfig->minthrottle, flight3DConfig->deadband3d_low);

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -813,12 +813,12 @@ void mixTable(void)
 
         if (rollPitchYawMixRange > throttleRange) {
             motorLimitReached = true;
+            float mixReduction = (float) throttleRange / rollPitchYawMixRange;
             for (i = 0; i < motorCount; i++) {
-                rollPitchYawMix[i] = (rollPitchYawMix[i] * throttleRange) / rollPitchYawMixRange;
-
-                // Get the max correction from center when agressivity enabled. (Some setups don't like this option)
-                if (mixerConfig->agressive_airmode) throttleMin = throttleMax = throttleMin + (throttleRange / 2);
+                rollPitchYawMix[i] =  lrintf((float) rollPitchYawMix[i] * mixReduction);
             }
+            // Get the maximum correction by setting throtte offset to center. Configurable limit will constrain values once limit exceeded to prevent spazzing out in crashes
+            if (mixReduction > (mixerConfig->airmode_saturation_limit / 100.0f)) throttleMin = throttleMax = throttleMin + (throttleRange / 2);
         } else {
             motorLimitReached = false;
             throttleMin = throttleMin + (rollPitchYawMixRange / 2);

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -75,7 +75,7 @@ typedef struct mixer_s {
 
 typedef struct mixerConfig_s {
     uint8_t pid_at_min_throttle;            // when enabled pids are used at minimum throttle
-    uint8_t agressive_airmode;              // Use max possible correction when in saturation in Air mode
+    uint8_t airmode_saturation_limit;       // Use max possible correction when within the limit
     int8_t yaw_motor_direction;
     uint16_t yaw_jump_prevention_limit;      // make limit configurable (original fixed value was 100)
 #ifdef USE_SERVOS

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -589,7 +589,7 @@ const clivalue_t valueTable[] = {
     { "yaw_control_direction",      VAR_INT8   | MASTER_VALUE,  &masterConfig.yaw_control_direction, .config.minmax = { -1,  1 } },
 
     { "pid_at_min_throttle",        VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, &masterConfig.mixerConfig.pid_at_min_throttle, .config.lookup = { TABLE_OFF_ON } },
-    { "agressive_airmode",          VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, &masterConfig.mixerConfig.agressive_airmode, .config.lookup = { TABLE_OFF_ON } },
+    { "airmode_saturation_limit",   VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, &masterConfig.mixerConfig.airmode_saturation_limit, .config.lookup = { TABLE_OFF_ON } },
     { "yaw_motor_direction",        VAR_INT8   | MASTER_VALUE, &masterConfig.mixerConfig.yaw_motor_direction, .config.minmax = { -1,  1 } },
     { "yaw_jump_prevention_limit",  VAR_UINT16 | MASTER_VALUE, &masterConfig.mixerConfig.yaw_jump_prevention_limit, .config.minmax = { YAW_JUMP_PREVENTION_LIMIT_LOW,  YAW_JUMP_PREVENTION_LIMIT_HIGH } },
 


### PR DESCRIPTION
Saturation handling can now be configured in percentage.

Default setting of 50% should be able to prevent quad trying to correct too hard in crashes, but still be able to have smooth transitions in flight.