### PR TITLE
Implemented support for SRF10 sonar rangefinder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -352,6 +352,7 @@ NAZE_SRC = startup_stm32f10x_md_gcc.S \
 		   drivers/light_ws2811strip.c \
 		   drivers/light_ws2811strip_stm32f10x.c \
 		   drivers/sonar_hcsr04.c \
+		   drivers/sonar_srf10.c \
 		   drivers/pwm_mapping.c \
 		   drivers/pwm_output.c \
 		   drivers/pwm_rx.c \
@@ -402,6 +403,7 @@ EUSTM32F103RC_SRC = startup_stm32f10x_hd_gcc.S \
 		   drivers/serial_uart.c \
 		   drivers/serial_uart_stm32f10x.c \
 		   drivers/sonar_hcsr04.c \
+		   drivers/sonar_srf10.c \
 		   drivers/sound_beeper_stm32f10x.c \
 		   drivers/system_stm32f10x.c \
 		   drivers/timer.c \
@@ -432,6 +434,7 @@ OLIMEXINO_SRC = startup_stm32f10x_md_gcc.S \
 		   drivers/serial_uart.c \
 		   drivers/serial_uart_stm32f10x.c \
 		   drivers/sonar_hcsr04.c \
+		   drivers/sonar_srf10.c \
 		   drivers/sound_beeper_stm32f10x.c \
 		   drivers/system_stm32f10x.c \
 		   drivers/timer.c \
@@ -489,6 +492,7 @@ CC3D_SRC = \
 		   drivers/serial_uart.c \
 		   drivers/serial_uart_stm32f10x.c \
 		   drivers/sonar_hcsr04.c \
+		   drivers/sonar_srf10.c \
 		   drivers/sound_beeper_stm32f10x.c \
 		   drivers/system_stm32f10x.c \
 		   drivers/timer.c \
@@ -596,6 +600,7 @@ SPARKY_SRC = \
 		   drivers/light_ws2811strip_stm32f30x.c \
 		   drivers/serial_usb_vcp.c \
 		   drivers/sonar_hcsr04.c \
+		   drivers/sonar_srf10.c \
 		   $(HIGHEND_SRC) \
 		   $(COMMON_SRC) \
 		   $(VCP_SRC)
@@ -625,6 +630,7 @@ RMDO_SRC = \
 		   drivers/light_ws2811strip_stm32f30x.c \
 		   drivers/serial_softserial.c \
 		   drivers/sonar_hcsr04.c \
+		   drivers/sonar_srf10.c \
 		   io/flashfs.c \
 		   $(HIGHEND_SRC) \
 		   $(COMMON_SRC)
@@ -642,6 +648,7 @@ SPRACINGF3_SRC = \
 		   drivers/light_ws2811strip_stm32f30x.c \
 		   drivers/serial_softserial.c \
 		   drivers/sonar_hcsr04.c \
+		   drivers/sonar_srf10.c \
 		   io/flashfs.c \
 		   $(HIGHEND_SRC) \
 		   $(COMMON_SRC)
@@ -699,6 +706,7 @@ SPRACINGF3MINI_SRC	 = \
 		   drivers/serial_softserial.c \
 		   drivers/serial_usb_vcp.c \
 		   drivers/sonar_hcsr04.c \
+		   drivers/sonar_srf10.c \
 		   drivers/sdcard.c \
 		   drivers/sdcard_standard.c \
 		   drivers/transponder_ir.c \

--- a/src/main/drivers/sonar.h
+++ b/src/main/drivers/sonar.h
@@ -17,20 +17,12 @@
 
 #pragma once
 
-#include <platform.h>
-#include "drivers/sonar.h"
+#define SONAR_OUT_OF_RANGE (-1)
 
-typedef struct sonarHardware_s {
-    uint16_t trigger_pin;
-    GPIO_TypeDef* trigger_gpio;
-    uint16_t echo_pin;
-    GPIO_TypeDef* echo_gpio;
-    uint32_t exti_line;
-    uint8_t exti_pin_source;
-    IRQn_Type exti_irqn;
-} sonarHardware_t;
+typedef struct sonarRange_s {
+    int16_t maxRangeCm;
+    // these are full detection cone angles, maximum tilt is half of this
+    int16_t detectionConeDeciDegrees; // detection cone angle as in device spec
+    int16_t detectionConeExtendedDeciDegrees; // device spec is conservative, in practice have slightly larger detection cone
+} sonarRange_t;
 
-void hcsr04_set_sonar_hardware(const sonarHardware_t *initialSonarHardware);
-void hcsr04_init(sonarRange_t *sonarRange);
-void hcsr04_start_reading(void);
-int32_t hcsr04_get_distance(void);

--- a/src/main/drivers/sonar_hcsr04.c
+++ b/src/main/drivers/sonar_hcsr04.c
@@ -21,11 +21,17 @@
 #include <platform.h>
 #include "build_config.h"
 
-#include "system.h"
-#include "gpio.h"
-#include "nvic.h"
+#include "drivers/system.h"
+#include "drivers/gpio.h"
+#include "drivers/nvic.h"
 
-#include "sonar_hcsr04.h"
+#include "drivers/sonar.h"
+#include "drivers/sonar_hcsr04.h"
+
+#define HCSR04_MAX_RANGE_CM 400 // 4m, from HC-SR04 spec sheet
+#define HCSR04_DETECTION_CONE_DECIDEGREES 300 // recommended cone angle30 degrees, from HC-SR04 spec sheet
+#define HCSR04_DETECTION_CONE_EXTENDED_DECIDEGREES 450 // in practice 45 degrees seems to work well
+
 
 /* HC-SR04 consists of ultrasonic transmitter, receiver, and control circuits.
  * When triggered it sends out a series of 40KHz ultrasonic pulses and receives
@@ -37,8 +43,7 @@
  */
 
 #if defined(SONAR)
-STATIC_UNIT_TESTED volatile int32_t measurement = -1;
-static uint32_t lastMeasurementAt;
+STATIC_UNIT_TESTED volatile int32_t hcsr04SonarPulseTravelTime = 0;
 static sonarHardware_t const *sonarHardware;
 
 #if !defined(UNIT_TEST)
@@ -52,7 +57,7 @@ static void ECHO_EXTI_IRQHandler(void)
     } else {
         timing_stop = micros();
         if (timing_stop > timing_start) {
-            measurement = timing_stop - timing_start;
+            hcsr04SonarPulseTravelTime = timing_stop - timing_start;
         }
     }
 
@@ -75,17 +80,10 @@ void EXTI9_5_IRQHandler(void)
 }
 #endif
 
-void hcsr04_init(const sonarHardware_t *initialSonarHardware, sonarRange_t *sonarRange)
+void hcsr04_set_sonar_hardware(const sonarHardware_t *initialSonarHardware)
 {
     sonarHardware = initialSonarHardware;
-    sonarRange->maxRangeCm = HCSR04_MAX_RANGE_CM;
-    sonarRange->detectionConeDeciDegrees = HCSR04_DETECTION_CONE_DECIDEGREES;
-    sonarRange->detectionConeExtendedDeciDegrees = HCSR04_DETECTION_CONE_EXTENDED_DECIDEGREES;
-
 #if !defined(UNIT_TEST)
-    gpio_config_t gpio;
-    EXTI_InitTypeDef EXTIInit;
-
 #ifdef STM32F10X
     // enable AFIO for EXTI support
     RCC_APB2PeriphClockCmd(RCC_APB2Periph_AFIO, ENABLE);
@@ -98,12 +96,12 @@ void hcsr04_init(const sonarHardware_t *initialSonarHardware, sonarRange_t *sona
     RCC_APB2PeriphClockCmd(RCC_APB2Periph_SYSCFG, ENABLE);
 #endif
 
+    gpio_config_t gpio;
     // trigger pin
     gpio.pin = sonarHardware->trigger_pin;
     gpio.mode = Mode_Out_PP;
     gpio.speed = Speed_2MHz;
     gpioInit(sonarHardware->trigger_gpio, &gpio);
-
     // echo pin
     gpio.pin = sonarHardware->echo_pin;
     gpio.mode = Mode_IN_FLOATING;
@@ -120,6 +118,7 @@ void hcsr04_init(const sonarHardware_t *initialSonarHardware, sonarRange_t *sona
 
     EXTI_ClearITPendingBit(sonarHardware->exti_line);
 
+    EXTI_InitTypeDef EXTIInit;
     EXTIInit.EXTI_Line = sonarHardware->exti_line;
     EXTIInit.EXTI_Mode = EXTI_Mode_Interrupt;
     EXTIInit.EXTI_Trigger = EXTI_Trigger_Rising_Falling;
@@ -127,37 +126,41 @@ void hcsr04_init(const sonarHardware_t *initialSonarHardware, sonarRange_t *sona
     EXTI_Init(&EXTIInit);
 
     NVIC_InitTypeDef NVIC_InitStructure;
-
     NVIC_InitStructure.NVIC_IRQChannel = sonarHardware->exti_irqn;
     NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = NVIC_PRIORITY_BASE(NVIC_PRIO_SONAR_ECHO);
     NVIC_InitStructure.NVIC_IRQChannelSubPriority = NVIC_PRIORITY_SUB(NVIC_PRIO_SONAR_ECHO);
     NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
     NVIC_Init(&NVIC_InitStructure);
-
-    lastMeasurementAt = millis() - 60; // force 1st measurement in hcsr04_get_distance()
-#else
-    lastMeasurementAt = 0; // to avoid "unused" compiler warning
-#endif
+#endif // UNIT_TEST
 }
 
-// measurement reading is done asynchronously, using interrupt
+void hcsr04_init(sonarRange_t *sonarRange)
+{
+    sonarRange->maxRangeCm = HCSR04_MAX_RANGE_CM;
+    sonarRange->detectionConeDeciDegrees = HCSR04_DETECTION_CONE_DECIDEGREES;
+    sonarRange->detectionConeExtendedDeciDegrees = HCSR04_DETECTION_CONE_EXTENDED_DECIDEGREES;
+}
+
+/*
+ * Start a range reading
+ * Called periodically by the scheduler
+ * Measurement reading is done asynchronously, using interrupt
+ */
 void hcsr04_start_reading(void)
 {
 #if !defined(UNIT_TEST)
-    uint32_t now = millis();
-
-    if (now < (lastMeasurementAt + 60)) {
-        // the repeat interval of trig signal should be greater than 60ms
-        // to avoid interference between connective measurements.
-        return;
+     static uint32_t timeOfLastMeasurementMs = 0;
+    // the firing interval of the trigger signal should be greater than 60ms
+    // to avoid interference between consecutive measurements.
+    #define HCSR04_MinimumFiringIntervalMs 60
+    const uint32_t timeNowMs = millis();
+    if (timeNowMs > timeOfLastMeasurementMs + HCSR04_MinimumFiringIntervalMs) {
+        timeOfLastMeasurementMs = timeNowMs;
+        digitalHi(sonarHardware->trigger_gpio, sonarHardware->trigger_pin);
+        //  The width of trigger signal must be greater than 10us, according to device spec
+        delayMicroseconds(11);
+        digitalLo(sonarHardware->trigger_gpio, sonarHardware->trigger_pin);
     }
-
-    lastMeasurementAt = now;
-
-    digitalHi(sonarHardware->trigger_gpio, sonarHardware->trigger_pin);
-    //  The width of trig signal must be greater than 10us
-    delayMicroseconds(11);
-    digitalLo(sonarHardware->trigger_gpio, sonarHardware->trigger_pin);
 #endif
 }
 
@@ -171,8 +174,10 @@ int32_t hcsr04_get_distance(void)
     // object we take half of the distance traveled.
     //
     // 340 m/s = 0.034 cm/microsecond = 29.41176471 *2 = 58.82352941 rounded to 59
-    int32_t distance = measurement / 59;
-
+    int32_t distance = hcsr04SonarPulseTravelTime / 59;
+    if (distance > HCSR04_MAX_RANGE_CM) {
+        distance = SONAR_OUT_OF_RANGE;
+    }
     return distance;
 }
 #endif

--- a/src/main/drivers/sonar_srf10.c
+++ b/src/main/drivers/sonar_srf10.c
@@ -1,0 +1,162 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "platform.h"
+#include "build_config.h"
+
+#include "drivers/system.h"
+#include "drivers/bus_i2c.h"
+
+#include "drivers/sonar.h"
+#include "drivers/sonar_srf10.h"
+
+#if defined(SONAR)
+
+// Technical specification is at: http://robot-electronics.co.uk/htm/srf10tech.htm
+#define SRF10_MAX_RANGE_CM 600 // 6m, from SFR10 spec sheet
+// see http://www.robot-electronics.co.uk/htm/sonar_faq.htm for cone angles
+// FAQ states 55 degrees, conservatively reduced to 50 degrees here
+#define SRF10_DETECTION_CONE_DECIDEGREES 500
+#define SRF10_DETECTION_CONE_EXTENDED_DECIDEGREES 500
+
+// from spec sheet, when range set to 1100cm
+// speed of sound is 340m/s, echo time for 1100cm is 65ms
+#define SRF10_MinimumFiringIntervalFor1100cmRangeMs 65
+// echo time for 600cm is 36ms, round this up to 40
+#define SRF10_MinimumFiringIntervalFor600cmRangeMs 40
+
+// SRF10 hardware constants
+#define SRF10_Address 0xE0
+#define SRF10_AddressI2C (SRF10_Address>>1) // the I2C 7 bit address
+
+#define SRF10_READ_SoftwareRevision 0x00
+#define SRF10_READ_Unused 0x01 // (read value returned is 0x80)
+#define SRF10_READ_Unused_ReturnValue 0x80
+#define SRF10_READ_RangeHighByte 0x02
+#define SRF10_READ_RangeLowByte 0x03
+
+#define SRF10_WRITE_CommandRegister 0x00
+#define SRF10_WRITE_MaxGainRegister 0x01 //(default gain value is 16)
+#define SRF10_WRITE_RangeRegister 0x02 //(default range value is 255)
+
+#define SRF10_COMMAND_InitiateRangingInches 0x50
+#define SRF10_COMMAND_InitiateRangingCm 0x51
+#define SRF10_COMMAND_InitiateRangingMicroSeconds 0x53
+
+#define SRF10_COMMAND_SetGain_40 0x00
+#define SRF10_COMMAND_SetGain_100 0x06
+#define SRF10_COMMAND_SetGain_200 0x09
+#define SRF10_COMMAND_SetGain_300 0x0B
+#define SRF10_COMMAND_SetGain_400 0x0D
+#define SRF10_COMMAND_SetGain_500 0x0E
+#define SRF10_COMMAND_SetGain_600 0x0F
+#define SRF10_COMMAND_SetGain_700 0x10 // default and maximum
+#define SRF10_COMMAND_SetGain_Max 0x10 // default
+
+#define SRF10_COMMAND_ChangeAddress1 0xA0
+#define SRF10_COMMAND_ChangeAddress2 0xAA
+#define SRF10_COMMAND_ChangeAddress3 0xA5
+
+// The range is (RangeRegister + 1) * 43mm
+#define SRF10_RangeValue43mm 0
+#define SRF10_RangeValue86mm 1
+#define SRF10_RangeValue1m 24
+#define SRF10_RangeValue4m 93
+#define SRF10_RangeValue6m 139 // maximum range
+#define SRF10_RangeValue11m 0xFF // exceeds actual maximum range
+
+STATIC_UNIT_TESTED volatile int32_t srf10measurementCm = SONAR_OUT_OF_RANGE;
+static int16_t minimumFiringIntervalMs;
+static uint32_t timeOfLastMeasurementMs;
+
+static bool i2c_srf10_send_command(uint8_t command)
+{
+    return i2cWrite(SRF10_AddressI2C, SRF10_WRITE_CommandRegister, command);
+}
+
+static bool i2c_srf10_send_byte(uint8_t i2cRegister, uint8_t val)
+{
+    return i2cWrite(SRF10_AddressI2C, i2cRegister, val);
+}
+
+static uint8_t i2c_srf10_read_byte(uint8_t i2cRegister)
+{
+    uint8_t byte;
+    i2cRead(SRF10_AddressI2C, i2cRegister, 1, &byte);
+    return byte;
+}
+
+bool srf10_detect()
+{
+    const uint8_t value = i2c_srf10_read_byte(SRF10_READ_Unused);
+    if (value == SRF10_READ_Unused_ReturnValue) {
+        return true;
+    }
+    return false;
+}
+
+void srf10_init(sonarRange_t *sonarRange)
+{
+    sonarRange->maxRangeCm = SRF10_MAX_RANGE_CM;
+    sonarRange->detectionConeDeciDegrees = SRF10_DETECTION_CONE_DECIDEGREES;
+    sonarRange->detectionConeExtendedDeciDegrees = SRF10_DETECTION_CONE_EXTENDED_DECIDEGREES;
+    // set up the SRF10 hardware for a range of 6m
+    minimumFiringIntervalMs = SRF10_MinimumFiringIntervalFor600cmRangeMs;
+    i2c_srf10_send_byte(SRF10_WRITE_MaxGainRegister, SRF10_COMMAND_SetGain_Max);
+    i2c_srf10_send_byte(SRF10_WRITE_RangeRegister, SRF10_RangeValue6m);
+    // initiate first ranging command
+    i2c_srf10_send_command(SRF10_COMMAND_InitiateRangingCm);
+    timeOfLastMeasurementMs = millis();
+}
+
+/*
+ * Start a range reading
+ * Called periodically by the scheduler
+ */
+void srf10_start_reading(void)
+{
+    // check if there is a measurement outstanding, 0xFF is returned if no measurement
+    const uint8_t revision = i2c_srf10_read_byte(SRF10_READ_SoftwareRevision);
+    if (revision != 0xFF) {
+        // there is a measurement
+        const uint8_t lowByte = i2c_srf10_read_byte(SRF10_READ_RangeLowByte);
+        const uint8_t highByte = i2c_srf10_read_byte(SRF10_READ_RangeHighByte);
+        srf10measurementCm =  highByte << 8 | lowByte;
+        if (srf10measurementCm > SRF10_MAX_RANGE_CM) {
+            srf10measurementCm = SONAR_OUT_OF_RANGE;
+        }
+    }
+    const uint32_t timeNowMs = millis();
+    if (timeNowMs > timeOfLastMeasurementMs + minimumFiringIntervalMs) {
+        // measurement repeat interval should be greater than minimumFiringIntervalMs
+        // to avoid interference between connective measurements.
+        timeOfLastMeasurementMs = timeNowMs;
+        i2c_srf10_send_command(SRF10_COMMAND_InitiateRangingCm);
+    }
+}
+
+/**
+ * Get the distance that was measured by the last pulse, in centimeters.
+ */
+int32_t srf10_get_distance(void)
+{
+    return srf10measurementCm;
+}
+#endif

--- a/src/main/drivers/sonar_srf10.h
+++ b/src/main/drivers/sonar_srf10.h
@@ -17,20 +17,11 @@
 
 #pragma once
 
-#include <platform.h>
+#include "platform.h"
 #include "drivers/sonar.h"
 
-typedef struct sonarHardware_s {
-    uint16_t trigger_pin;
-    GPIO_TypeDef* trigger_gpio;
-    uint16_t echo_pin;
-    GPIO_TypeDef* echo_gpio;
-    uint32_t exti_line;
-    uint8_t exti_pin_source;
-    IRQn_Type exti_irqn;
-} sonarHardware_t;
+bool srf10_detect();
+void srf10_init(sonarRange_t *sonarRange);
+void srf10_start_reading(void);
+int32_t srf10_get_distance(void);
 
-void hcsr04_set_sonar_hardware(const sonarHardware_t *initialSonarHardware);
-void hcsr04_init(sonarRange_t *sonarRange);
-void hcsr04_start_reading(void);
-int32_t hcsr04_get_distance(void);

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -338,7 +338,7 @@ void init(void)
     memset(&pwm_params, 0, sizeof(pwm_params));
 
 #ifdef SONAR
-    const sonarHardware_t *sonarHardware;
+    const sonarHardware_t *sonarHardware = NULL;
     if (feature(FEATURE_SONAR)) {
         sonarHardware = sonarGetHardwareConfiguration(batteryConfig()->currentMeterType);
         sonarGPIOConfig_t sonarGPIOConfig = {

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -60,6 +60,7 @@
 #include "drivers/sdcard.h"
 #include "drivers/usb_io.h"
 #include "drivers/transponder_ir.h"
+#include "drivers/sonar.h"
 #include "drivers/gyro_sync.h"
 
 #include "rx/rx.h"
@@ -120,8 +121,6 @@ void mixerUsePWMIOConfiguration(pwmIOConfiguration_t *pwmIOConfiguration);
 void rxInit(modeActivationCondition_t *modeActivationConditions);
 
 void navigationInit(pidProfile_t *pidProfile);
-const sonarHardware_t *sonarGetHardwareConfiguration(currentSensor_e  currentMeterType);
-void sonarInit(const sonarHardware_t *sonarHardware);
 
 #ifdef STM32F303xC
 // from system_stm32f30x.c
@@ -251,7 +250,12 @@ void init(void)
     // Configure the Flash Latency cycles and enable prefetch buffer
     SetSysClock(systemConfig()->emf_avoidance);
 #endif
+#ifdef SONAR
+    // SRF10 does not work with overclocked I2C bus, so don't allow overclocking if using SONAR
+    i2cSetOverclock(feature(FEATURE_SONAR) ? 0 : systemConfig()->i2c_highspeed);
+#else
     i2cSetOverclock(systemConfig()->i2c_highspeed);
+#endif
 
     systemInit();
 
@@ -334,12 +338,11 @@ void init(void)
     memset(&pwm_params, 0, sizeof(pwm_params));
 
 #ifdef SONAR
-    const sonarHardware_t *sonarHardware = NULL;
-
+    const sonarHardware_t *sonarHardware;
     if (feature(FEATURE_SONAR)) {
         sonarHardware = sonarGetHardwareConfiguration(batteryConfig()->currentMeterType);
         sonarGPIOConfig_t sonarGPIOConfig = {
-            .gpio = SONAR_GPIO,
+            .gpio = sonarHardware->echo_gpio,
             .triggerPin = sonarHardware->echo_pin,
             .echoPin = sonarHardware->trigger_pin,
         };

--- a/src/main/sensors/sonar.h
+++ b/src/main/sensors/sonar.h
@@ -17,14 +17,35 @@
 
 #pragma once
 
-#define SONAR_OUT_OF_RANGE (-1)
+#include "drivers/sonar_hcsr04.h"
+#include "drivers/sonar.h"
+#include "io/rc_controls.h" // for throttleStatus_e required by battery.h
+#include "sensors/battery.h"
+
+typedef enum {
+    SONAR_NONE = 0,
+    SONAR_HCSR04,
+    SONAR_SRF10
+} sonarHardwareType_e;
+
+typedef void (*sonarInitFunctionPtr)(sonarRange_t *sonarRange);
+typedef void (*sonarUpdateFunctionPtr)(void);
+typedef int32_t (*sonarReadFunctionPtr)(void);
+
+typedef struct sonarFunctionPointers_s {
+    sonarInitFunctionPtr init;
+    sonarUpdateFunctionPtr update;
+    sonarReadFunctionPtr read;
+} sonarFunctionPointers_t;
 
 extern int16_t sonarMaxRangeCm;
 extern int16_t sonarCfAltCm;
 extern int16_t sonarMaxAltWithTiltCm;
 
-void sonarUpdate(void);
-int32_t sonarRead(void);
+const sonarHardware_t *sonarGetHardwareConfiguration(currentSensor_e currentSensor);
 int32_t sonarCalculateAltitude(int32_t sonarDistance, float cosTiltAngle);
 int32_t sonarGetLatestAltitude(void);
+void sonarInit(const sonarHardware_t *sonarHardware);
+void sonarUpdate(void);
+int32_t sonarRead(void);
 

--- a/src/main/target/CC3D/target.h
+++ b/src/main/target/CC3D/target.h
@@ -134,5 +134,6 @@
 #define USE_CLI
 #define TARGET_MOTOR_COUNT 6
 
+#define SKIP_CLI_COMMAND_HELP
 
 

--- a/src/main/target/NAZE/target.h
+++ b/src/main/target/NAZE/target.h
@@ -216,8 +216,12 @@
 #define DEFAULT FEATURES FEATURE_MOTOR_STOP
 
 #define HARDWARE_BIND_PLUG
-
 // Hardware bind plug at PB5 (Pin 41)
 #define BINDPLUG_PORT  GPIOB
 #define BINDPLUG_PIN   Pin_5
+
+#if (FLASH_SIZE <= 128)
+#define SKIP_CLI_COMMAND_HELP
 #endif
+#endif
+

--- a/src/main/target/NAZE/target.h
+++ b/src/main/target/NAZE/target.h
@@ -204,6 +204,7 @@
 #define BIND_PIN   Pin_3
 
 #define USE_SERIAL_4WAY_BLHELI_INTERFACE
+#define TARGET_MOTOR_COUNT 8
 
 // alternative defaults for AlienFlight F1 target
 #ifdef ALIENFLIGHT

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -231,6 +231,9 @@ $(OBJECT_DIR)/flight_imu_unittest : \
 	$(OBJECT_DIR)/common/filter.o \
 	$(OBJECT_DIR)/flight/altitudehold.o \
 	$(OBJECT_DIR)/flight_imu_unittest.o \
+	$(OBJECT_DIR)/drivers/sonar_hcsr04.o \
+	$(OBJECT_DIR)/drivers/sonar_srf10.o \
+	$(OBJECT_DIR)/sensors/sonar.o \
 	$(OBJECT_DIR)/common/maths.o \
 	$(OBJECT_DIR)/gtest_main.a
 
@@ -295,23 +298,28 @@ $(OBJECT_DIR)/flight_pid_unittest : \
 $(OBJECT_DIR)/flight/altitudehold.o : \
 	$(USER_DIR)/flight/altitudehold.c \
 	$(USER_DIR)/flight/altitudehold.h \
+	$(USER_DIR)/config/config_unittest.h \
 	$(GTEST_HEADERS)
 
 	@mkdir -p $(dir $@)
-	$(CC) $(C_FLAGS) $(TEST_CFLAGS) -c $(USER_DIR)/flight/altitudehold.c -o $@
+	$(CC) $(C_FLAGS) $(TEST_CFLAGS) -DSONAR -c $(USER_DIR)/flight/altitudehold.c -o $@
 
 $(OBJECT_DIR)/flight_altitudehold_unittest.o : \
 	$(TEST_DIR)/flight_altitudehold_unittest.cc \
 	$(USER_DIR)/flight/altitudehold.h \
+	$(USER_DIR)/config/config_unittest.h \
 	$(GTEST_HEADERS)
 
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXX_FLAGS) $(TEST_CFLAGS) -c $(TEST_DIR)/flight_altitudehold_unittest.cc -o $@
 
 $(OBJECT_DIR)/flight_altitudehold_unittest : \
+	$(OBJECT_DIR)/common/maths.o \
 	$(OBJECT_DIR)/flight/altitudehold.o \
 	$(OBJECT_DIR)/flight_altitudehold_unittest.o \
-	$(OBJECT_DIR)/common/maths.o \
+	$(OBJECT_DIR)/drivers/sonar_hcsr04.o \
+	$(OBJECT_DIR)/drivers/sonar_srf10.o \
+	$(OBJECT_DIR)/sensors/sonar.o \
 	$(OBJECT_DIR)/gtest_main.a
 
 	$(CXX) $(CXX_FLAGS) $^ -o $(OBJECT_DIR)/$@
@@ -678,6 +686,13 @@ $(OBJECT_DIR)/drivers/sonar_hcsr04.o : \
 	@mkdir -p $(dir $@)
 	$(CC) $(C_FLAGS) $(TEST_CFLAGS) -DSONAR -c $(USER_DIR)/drivers/sonar_hcsr04.c -o $@
 
+$(OBJECT_DIR)/drivers/sonar_srf10.o : \
+        $(USER_DIR)/drivers/sonar_srf10.c \
+        $(USER_DIR)/drivers/sonar_srf10.h \
+        $(GTEST_HEADERS)
+	@mkdir -p $(dir $@)
+	$(CC) $(C_FLAGS) $(TEST_CFLAGS) -DSONAR -c $(USER_DIR)/drivers/sonar_srf10.c -o $@
+
 $(OBJECT_DIR)/sensors/sonar.o : \
 	$(USER_DIR)/sensors/sonar.c \
 	$(USER_DIR)/sensors/sonar.h \
@@ -689,6 +704,7 @@ $(OBJECT_DIR)/sensors/sonar.o : \
 $(OBJECT_DIR)/sonar_unittest.o : \
 	$(TEST_DIR)/sonar_unittest.cc \
 	$(USER_DIR)/drivers/sonar_hcsr04.h \
+	$(USER_DIR)/drivers/sonar_srf10.h \
 	$(USER_DIR)/sensors/sonar.h \
 	$(GTEST_HEADERS)
 
@@ -698,6 +714,7 @@ $(OBJECT_DIR)/sonar_unittest.o : \
 $(OBJECT_DIR)/sonar_unittest : \
 	$(OBJECT_DIR)/common/maths.o \
 	$(OBJECT_DIR)/drivers/sonar_hcsr04.o \
+	$(OBJECT_DIR)/drivers/sonar_srf10.o \
 	$(OBJECT_DIR)/sensors/sonar.o \
 	$(OBJECT_DIR)/sonar_unittest.o \
 	$(OBJECT_DIR)/gtest_main.a

--- a/src/test/unit/flight_altitudehold_unittest.cc
+++ b/src/test/unit/flight_altitudehold_unittest.cc
@@ -153,53 +153,30 @@ bool rcModeIsActive(boxId_e modeId) { return rcModeActivationMask & (1 << modeId
 int16_t rcCommand[4];
 int16_t rcData[MAX_SUPPORTED_RC_CHANNEL_COUNT];
 
-uint32_t accTimeSum ;        // keep track for integration of acc
-int accSumCount;
-float accVelScale;
+int32_t BaroAlt=0;
+uint32_t accTimeSum=0;        // keep track for integration of acc
+int accSumCount=0;
+float accVelScale=0;
 
 attitudeEulerAngles_t attitude;
 
-//uint16_t acc_1G;
-//int16_t heading;
-//gyro_t gyro;
 int32_t accSum[XYZ_AXIS_COUNT];
-//int16_t magADC[XYZ_AXIS_COUNT];
-int32_t BaroAlt;
 int16_t debug[DEBUG16_VALUE_COUNT];
 
 uint8_t stateFlags;
 uint16_t flightModeFlags;
-uint8_t armingFlags;
 
-int32_t sonarAlt;
-int16_t sonarCfAltCm;
-int16_t sonarMaxAltWithTiltCm;
-
-uint16_t enableFlightMode(flightModeFlags_e mask)
-{
-    return flightModeFlags |= (mask);
-}
-
-uint16_t disableFlightMode(flightModeFlags_e mask)
-{
-    return flightModeFlags &= ~(mask);
-}
-
-void gyroUpdate(void) {};
-bool sensors(uint32_t mask)
-{
-    UNUSED(mask);
-    return false;
-};
-void updateAccelerationReadings(rollAndPitchTrims_t *rollAndPitchTrims)
-{
-    UNUSED(rollAndPitchTrims);
-}
-
+void sensorsSet(uint32_t mask) {UNUSED(mask);}
+uint16_t enableFlightMode(flightModeFlags_e mask) {return flightModeFlags |= (mask);}
+uint16_t disableFlightMode(flightModeFlags_e mask) {return flightModeFlags &= ~(mask);}
 void imuResetAccelerationSum(void) {};
-
-uint32_t micros(void) { return 0; }
-bool isBaroCalibrationComplete(void) { return true; }
+bool isBaroCalibrationComplete(void) {return true;}
 void performBaroCalibrationCycle(void) {}
-int32_t baroCalculateAltitude(void) { return 0; }
+int32_t baroCalculateAltitude(void) {return 0;}
+uint32_t millis(void) {return 0;}
+void delayMicroseconds(uint32_t us) {UNUSED(us);};
+bool feature(uint32_t mask) {UNUSED(mask); return true;};
+float getCosTiltAngle(void) {return 1.0f;};
+bool i2cWrite(uint8_t, uint8_t, uint8_t) {return false;}
+bool i2cRead(uint8_t, uint8_t, uint8_t, uint8_t*) {return false;}
 }

--- a/src/test/unit/flight_imu_unittest.cc
+++ b/src/test/unit/flight_imu_unittest.cc
@@ -205,4 +205,9 @@ uint32_t millis(void) { return 0; }
 bool isBaroCalibrationComplete(void) { return true; }
 void performBaroCalibrationCycle(void) {}
 int32_t baroCalculateAltitude(void) { return 0; }
+void sensorsSet(uint32_t mask) {UNUSED(mask);}
+void delayMicroseconds(uint32_t us) {UNUSED(us);};
+bool feature(uint32_t mask) {UNUSED(mask); return true;};
+bool i2cWrite(uint8_t, uint8_t, uint8_t) {return false;}
+bool i2cRead(uint8_t, uint8_t, uint8_t, uint8_t*) {return false;}
 }


### PR DESCRIPTION
This adds support for the SRF10 sonar rangefinder. 

The SRF10 has some advantages over the HCSR04. It is smaller and lighter, 32x15x10mm, weight 5g, vs 42x20x15mm, weight 15g for the HCSR04. Its quoted range is 6 meters, compared with 4meters quoted for the HCSR04.

The SRF10 is 5V I2C bus based which may or may not be advantageous, depending on the flight controller used. It can connect directly to FCs with 5V I2C bus connectors (e.g. CC3D, SciSky), but requires logic level converters for FCs that have 3.3V I2C buses.

The SRF10 is, however, more expensive than the HCSR04.

The implementation works by replacing the direct calls to the HCSR04 device driver functions by indirect calls via function pointers. This means it is now straightforward to add support for further ranging devices. In particular support for the PulsedLight LIDAR-Lite laser rangefinder should be straightforward to support (I have an implementation in the works).

This PR addresses issue https://github.com/cleanflight/cleanflight/issues/1555

According to http://www.robot-electronics.co.uk/htm/arduino_examples.htm#SRF02,%20SRF08,%20SRF10,%20SRF235

"The SRF02, SRF08, SRF10 and SRF235 all use the same I2C interface. The basic ranging commands are the same..."

So the code should also work for the SRF02, SRF08 and SRF235 (I haven't tested any of these).
