### PR TITLE
Removed code in resetConf that zeroed already-zero items. Added test code to check.

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -138,13 +138,6 @@ controlRateConfig_t *currentControlRateProfile;
 
 static const uint8_t EEPROM_CONF_VERSION = 110;
 
-static void resetAccelerometerTrims(flightDynamicsTrims_t *accelerometerTrims)
-{
-    accelerometerTrims->values.pitch = 0;
-    accelerometerTrims->values.roll = 0;
-    accelerometerTrims->values.yaw = 0;
-}
-
 void resetPidProfile(pidProfile_t *pidProfile)
 {
     pidProfile->pidController = 1;
@@ -231,13 +224,6 @@ void resetBarometerConfig(barometerConfig_t *barometerConfig)
 }
 #endif
 
-void resetSensorAlignment(sensorAlignmentConfig_t *sensorAlignmentConfig)
-{
-    sensorAlignmentConfig->gyro_align = ALIGN_DEFAULT;
-    sensorAlignmentConfig->acc_align = ALIGN_DEFAULT;
-    sensorAlignmentConfig->mag_align = ALIGN_DEFAULT;
-}
-
 void resetEscAndServoConfig(escAndServoConfig_t *escAndServoConfig)
 {
     escAndServoConfig->minthrottle = 1150;
@@ -254,21 +240,7 @@ void resetFlight3DConfig(flight3DConfig_t *flight3DConfig)
     flight3DConfig->deadband3d_throttle = 50;
 }
 
-#ifdef TELEMETRY
-void resetTelemetryConfig(telemetryConfig_t *telemetryConfig)
-{
-    telemetryConfig->telemetry_inversion = 0;
-    telemetryConfig->telemetry_switch = 0;
-    telemetryConfig->gpsNoFixLatitude = 0;
-    telemetryConfig->gpsNoFixLongitude = 0;
-    telemetryConfig->frsky_coordinate_format = FRSKY_FORMAT_DMS;
-    telemetryConfig->frsky_unit = FRSKY_UNIT_METRICS;
-    telemetryConfig->frsky_vfas_precision = 0;
-    telemetryConfig->hottAlarmSoundInterval = 5;
-}
-#endif
-
-void resetBatteryConfig(batteryConfig_t *batteryConfig)
+static void resetBatteryConfig(batteryConfig_t *batteryConfig)
 {
     batteryConfig->vbatscale = VBAT_SCALE_DEFAULT;
     batteryConfig->vbatresdivval = VBAT_RESDIVVAL_DEFAULT;
@@ -276,9 +248,7 @@ void resetBatteryConfig(batteryConfig_t *batteryConfig)
     batteryConfig->vbatmaxcellvoltage = 43;
     batteryConfig->vbatmincellvoltage = 33;
     batteryConfig->vbatwarningcellvoltage = 35;
-    batteryConfig->currentMeterOffset = 0;
     batteryConfig->currentMeterScale = 400; // for Allegro ACS758LCB-100U (40mV/A)
-    batteryConfig->batteryCapacity = 0;
     batteryConfig->currentMeterType = CURRENT_SENSOR_ADC;
 }
 
@@ -317,15 +287,7 @@ static void resetControlRateConfig(controlRateConfig_t *controlRateConfig) {
     controlRateConfig->rcRate8 = 90;
     controlRateConfig->rcExpo8 = 65;
     controlRateConfig->thrMid8 = 50;
-    controlRateConfig->thrExpo8 = 0;
-    controlRateConfig->dynThrPID = 0;
-    controlRateConfig->rcYawExpo8 = 0;
     controlRateConfig->tpa_breakpoint = 1500;
-
-    for (uint8_t axis = 0; axis < FLIGHT_DYNAMICS_INDEX_COUNT; axis++) {
-        controlRateConfig->rates[axis] = 0;
-    }
-
 }
 
 void resetRcControlsConfig(rcControlsConfig_t *rcControlsConfig) {
@@ -335,7 +297,7 @@ void resetRcControlsConfig(rcControlsConfig_t *rcControlsConfig) {
     rcControlsConfig->alt_hold_fast_change = 1;
 }
 
-void resetMixerConfig(mixerConfig_t *mixerConfig) {
+static void resetMixerConfig(mixerConfig_t *mixerConfig) {
     mixerConfig->pid_at_min_throttle = 1;
     mixerConfig->airmode_saturation_limit = 50;
     mixerConfig->yaw_motor_direction = 1;
@@ -343,7 +305,6 @@ void resetMixerConfig(mixerConfig_t *mixerConfig) {
 #ifdef USE_SERVOS
     mixerConfig->tri_unarmed_servo = 1;
     mixerConfig->servo_lowpass_freq = 400;
-    mixerConfig->servo_lowpass_enable = 0;
 #endif
 }
 
@@ -378,7 +339,7 @@ uint16_t getCurrentMinthrottle(void)
 }
 
 // Default settings
-static void resetConf(void)
+STATIC_UNIT_TESTED void resetConf(void)
 {
     int i;
 
@@ -407,36 +368,21 @@ static void resetConf(void)
     featureSet(FEATURE_FAILSAFE);
 
     // global settings
-    masterConfig.current_profile_index = 0;     // default profile
     masterConfig.dcm_kp = 2500;                // 1.0 * 10000
-    masterConfig.dcm_ki = 0;                   // 0.003 * 10000
     masterConfig.gyro_lpf = 1;                 // supported by all gyro drivers now. In case of ST gyro, will default to 32Hz instead
     masterConfig.soft_gyro_lpf_hz = 60;        // Software based lpf filter for gyro
 
-    resetAccelerometerTrims(&masterConfig.accZero);
-
-    resetSensorAlignment(&masterConfig.sensorAlignmentConfig);
-
-    masterConfig.boardAlignment.rollDegrees = 0;
-    masterConfig.boardAlignment.pitchDegrees = 0;
-    masterConfig.boardAlignment.yawDegrees = 0;
-    masterConfig.acc_hardware = ACC_DEFAULT;     // default/autodetect
     masterConfig.max_angle_inclination = 500;    // 50 degrees
     masterConfig.yaw_control_direction = 1;
     masterConfig.gyroConfig.gyroMovementCalibrationThreshold = 32;
 
-    masterConfig.mag_hardware = MAG_DEFAULT;     // default/autodetect
-    masterConfig.baro_hardware = BARO_DEFAULT;   // default/autodetect
-
     resetBatteryConfig(&masterConfig.batteryConfig);
 
 #ifdef TELEMETRY
-    resetTelemetryConfig(&masterConfig.telemetryConfig);
+    masterConfig.telemetryConfig.hottAlarmSoundInterval = 5;
 #endif
 
-    masterConfig.rxConfig.serialrx_provider = 0;
     masterConfig.rxConfig.sbus_inversion = 1;
-    masterConfig.rxConfig.spektrum_sat_bind = 0;
     masterConfig.rxConfig.midrc = 1500;
     masterConfig.rxConfig.mincheck = 1100;
     masterConfig.rxConfig.maxcheck = 1900;
@@ -449,16 +395,10 @@ static void resetConf(void)
         channelFailsafeConfiguration->step = (i == THROTTLE) ? CHANNEL_VALUE_TO_RXFAIL_STEP(masterConfig.rxConfig.rx_min_usec) : CHANNEL_VALUE_TO_RXFAIL_STEP(masterConfig.rxConfig.midrc);
     }
 
-    masterConfig.rxConfig.rssi_channel = 0;
     masterConfig.rxConfig.rssi_scale = RSSI_SCALE_DEFAULT;
-    masterConfig.rxConfig.rssi_ppm_invert = 0;
-    masterConfig.rxConfig.rcSmoothing = 0;
 
     resetAllRxChannelRangeConfigurations(masterConfig.rxConfig.channelRanges);
 
-    masterConfig.inputFilteringMode = INPUT_FILTERING_DISABLED;
-
-    masterConfig.retarded_arm = 0;
     masterConfig.disarm_kill_switch = 1;
     masterConfig.auto_disarm_delay = 5;
     masterConfig.small_angle = 25;
@@ -480,16 +420,12 @@ static void resetConf(void)
 
 #ifdef GPS
     // gps/nav stuff
-    masterConfig.gpsConfig.provider = GPS_NMEA;
-    masterConfig.gpsConfig.sbasMode = SBAS_AUTO;
     masterConfig.gpsConfig.autoConfig = GPS_AUTOCONFIG_ON;
-    masterConfig.gpsConfig.autoBaud = GPS_AUTOBAUD_OFF;
 #endif
 
     resetSerialConfig(&masterConfig.serialConfig);
 
     masterConfig.looptime = 2000;
-    masterConfig.emf_avoidance = 0;
     masterConfig.i2c_highspeed = 1;
     masterConfig.gyroSync = 1;
     masterConfig.gyroSyncDenominator = 1;
@@ -526,9 +462,7 @@ static void resetConf(void)
     masterConfig.failsafeConfig.failsafe_delay = 10;              // 1sec
     masterConfig.failsafeConfig.failsafe_off_delay = 200;         // 20sec
     masterConfig.failsafeConfig.failsafe_throttle = 1000;         // default throttle off.
-    masterConfig.failsafeConfig.failsafe_kill_switch = 0;         // default failsafe switch action is identical to rc link loss
     masterConfig.failsafeConfig.failsafe_throttle_low_delay = 100; // default throttle low delay for "just disarm" on failsafe condition
-    masterConfig.failsafeConfig.failsafe_procedure = 0;           // default full failsafe procedure is 0: auto-landing
 
 #ifdef USE_SERVOS
     // servos
@@ -549,10 +483,6 @@ static void resetConf(void)
 #ifdef GPS
     resetGpsProfile(&currentProfile->gpsProfile);
 #endif
-
-    // custom mixer. clear by defaults.
-    for (i = 0; i < MAX_SUPPORTED_MOTORS; i++)
-        masterConfig.customMotorMixer[i].throttle = 0.0f;
 
 #ifdef LED_STRIP
     applyDefaultColors(masterConfig.colors, CONFIGURABLE_COLOR_COUNT);
@@ -859,7 +789,7 @@ void validateAndFixConfig(void)
         masterConfig.mixerConfig.pid_at_min_throttle = 0;
     }
 
-#if defined(LED_STRIP) && defined(TRANSPONDER)
+#if defined(LED_STRIP) && defined(TRANSPONDER) && !defined(UNIT_TEST)
     if ((WS2811_DMA_TC_FLAG == TRANSPONDER_DMA_TC_FLAG) && featureConfigured(FEATURE_TRANSPONDER) && featureConfigured(FEATURE_LED_STRIP)) {
         featureClear(FEATURE_LED_STRIP);
     }
@@ -926,6 +856,9 @@ void readEEPROMAndNotify(void)
     beeperConfirmationBeeps(1);
 }
 
+#ifdef UNIT_TEST
+void writeEEPROM(void) {}
+#else
 void writeEEPROM(void)
 {
     // Generate compile time error if the config does not fit in the reserved area of flash.
@@ -981,6 +914,7 @@ void writeEEPROM(void)
 
     resumeRxSignal();
 }
+#endif
 
 void ensureEEPROMContainsValidData(void)
 {

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -702,6 +702,30 @@ $(OBJECT_DIR)/scheduler_unittest : \
 
 	$(CXX) $(CXX_FLAGS) $^ -o $(OBJECT_DIR)/$@
 
+$(OBJECT_DIR)/config/config.o : \
+	$(USER_DIR)/config/config.c \
+	$(USER_DIR)/config/config.h \
+	$(GTEST_HEADERS)
+
+	@mkdir -p $(dir $@)
+	$(CC) $(C_FLAGS) $(TEST_CFLAGS) -D'FLASH_SIZE = 128' -DSTM32F10X_MD -c $(USER_DIR)/config/config.c -o $@
+
+$(OBJECT_DIR)/config_unittest.o : \
+	$(TEST_DIR)/config_unittest.cc \
+	$(USER_DIR)/config/config.h \
+	$(GTEST_HEADERS)
+
+	@mkdir -p $(dir $@)
+	$(CXX) $(CXX_FLAGS) $(TEST_CFLAGS) -c $(TEST_DIR)/config_unittest.cc -o $@
+
+$(OBJECT_DIR)/config_unittest : \
+	$(OBJECT_DIR)/common/maths.o \
+	$(OBJECT_DIR)/config/config.o \
+	$(OBJECT_DIR)/config_unittest.o \
+	$(OBJECT_DIR)/gtest_main.a
+
+	$(CXX) $(CXX_FLAGS) $^ -o $(OBJECT_DIR)/$@
+
 test: $(TESTS:%=test-%)
 
 test-%: $(OBJECT_DIR)/%

--- a/src/test/unit/config_unittest.cc
+++ b/src/test/unit/config_unittest.cc
@@ -1,0 +1,201 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+
+extern "C" {
+    #include <platform.h>
+    #include "config/config.h"
+    #include "common/axis.h"
+    #include "common/color.h"
+    #include "common/maths.h"
+    #include "drivers/sensor.h"
+    #include "drivers/timer.h"
+    #include "drivers/accgyro.h"
+    #include "drivers/compass.h"
+    #include "drivers/pwm_rx.h"
+    #include "drivers/serial.h"
+    #include "io/escservo.h"
+    #include "io/gimbal.h"
+    #include "io/gps.h"
+    #include "io/ledstrip.h"
+    #include "io/rc_controls.h"
+    #include "io/serial.h"
+    #include "telemetry/telemetry.h"
+    #include "sensors/sensors.h"
+    #include "sensors/acceleration.h"
+    #include "sensors/boardalignment.h"
+    #include "sensors/barometer.h"
+    #include "sensors/battery.h"
+    #include "sensors/compass.h"
+    #include "sensors/gyro.h"
+    #include "flight/pid.h"
+    #include "flight/failsafe.h"
+    #include "flight/imu.h"
+    #include "flight/mixer.h"
+    #include "flight/navigation.h"
+    #include "rx/rx.h"
+    #include "config/config_profile.h"
+    #include "config/config_master.h"
+}
+
+#include "unittest_macros.h"
+#include "gtest/gtest.h"
+
+extern "C" {
+    void resetConf(void);
+    extern master_t masterConfig;
+}
+
+/*
+ * Test that the config items whose default values are zero are indeed set to zero by resetConf().
+ */
+TEST(ConfigUnittest, TestResetConfigZeroValues)
+{
+    memset(&masterConfig, 0xa5, sizeof(master_t));
+    resetConf();
+
+    EXPECT_EQ(0, masterConfig.current_profile_index); // default profile
+    EXPECT_EQ(0, masterConfig.dcm_ki); // 0.003 * 10000
+
+//resetAccelerometerTrims(&masterConfig.accZero);
+    EXPECT_EQ(0, masterConfig.accZero.values.pitch);
+    EXPECT_EQ(0, masterConfig.accZero.values.roll);
+    EXPECT_EQ(0, masterConfig.accZero.values.yaw);
+
+//resetSensorAlignment(&masterConfig.sensorAlignmentConfig);
+    EXPECT_EQ(ALIGN_DEFAULT, masterConfig.sensorAlignmentConfig.gyro_align);
+    EXPECT_EQ(ALIGN_DEFAULT, masterConfig.sensorAlignmentConfig.acc_align);
+    EXPECT_EQ(ALIGN_DEFAULT, masterConfig.sensorAlignmentConfig.mag_align);
+
+    EXPECT_EQ(0, masterConfig.boardAlignment.rollDegrees);
+    EXPECT_EQ(0, masterConfig.boardAlignment.pitchDegrees);
+    EXPECT_EQ(0, masterConfig.boardAlignment.yawDegrees);
+
+    EXPECT_EQ(ACC_DEFAULT, masterConfig.acc_hardware);   // default/autodetect
+    EXPECT_EQ(MAG_DEFAULT, masterConfig.mag_hardware);   // default/autodetect
+    EXPECT_EQ(BARO_DEFAULT, masterConfig.baro_hardware); // default/autodetect
+
+    EXPECT_EQ(0, masterConfig.batteryConfig.currentMeterOffset);
+    EXPECT_EQ(0, masterConfig.batteryConfig.batteryCapacity);
+
+    EXPECT_EQ(0, masterConfig.telemetryConfig.telemetry_inversion);
+    EXPECT_EQ(0, masterConfig.telemetryConfig.telemetry_switch);
+    EXPECT_EQ(0, masterConfig.telemetryConfig.gpsNoFixLatitude);
+    EXPECT_EQ(0, masterConfig.telemetryConfig.gpsNoFixLongitude);
+    EXPECT_EQ(FRSKY_FORMAT_DMS, masterConfig.telemetryConfig.frsky_coordinate_format);
+    EXPECT_EQ(FRSKY_UNIT_METRICS, masterConfig.telemetryConfig.frsky_unit);
+    EXPECT_EQ(0, masterConfig.telemetryConfig.frsky_vfas_precision);
+
+    EXPECT_EQ(0, masterConfig.rxConfig.serialrx_provider);
+    EXPECT_EQ(0, masterConfig.rxConfig.spektrum_sat_bind);
+
+    EXPECT_EQ(0, masterConfig.rxConfig.rssi_channel);
+    EXPECT_EQ(0, masterConfig.rxConfig.rssi_ppm_invert);
+    EXPECT_EQ(0, masterConfig.rxConfig.rcSmoothing);
+
+    EXPECT_EQ(INPUT_FILTERING_DISABLED, masterConfig.inputFilteringMode);
+
+    EXPECT_EQ(0, masterConfig.retarded_arm);
+
+//    resetMixerConfig(&masterConfig.mixerConfig);
+    EXPECT_EQ(0, masterConfig.mixerConfig.servo_lowpass_enable);
+
+    EXPECT_EQ(GPS_NMEA, masterConfig.gpsConfig.provider);
+    EXPECT_EQ(SBAS_AUTO, masterConfig.gpsConfig.sbasMode);
+    EXPECT_EQ(GPS_AUTOBAUD_OFF, masterConfig.gpsConfig.autoBaud);
+
+    EXPECT_EQ(0, masterConfig.emf_avoidance);
+
+// resetControlRateConfig(&masterConfig.controlRateProfiles[0]);
+    EXPECT_EQ(0, masterConfig.controlRateProfiles[0].thrExpo8);
+    EXPECT_EQ(0, masterConfig.controlRateProfiles[0].dynThrPID);
+    EXPECT_EQ(0, masterConfig.controlRateProfiles[0].rcYawExpo8);
+    for (uint8_t axis = 0; axis < FLIGHT_DYNAMICS_INDEX_COUNT; axis++) {
+        EXPECT_EQ(0, masterConfig.controlRateProfiles[0].rates[axis]);
+    }
+
+    EXPECT_EQ(0, masterConfig.failsafeConfig.failsafe_kill_switch); // default failsafe switch action is identical to rc link loss
+    EXPECT_EQ(0, masterConfig.failsafeConfig.failsafe_procedure);   // default full failsafe procedure is 0: auto-landing
+
+    // custom mixer. clear by defaults.
+    for (int i = 0; i < MAX_SUPPORTED_MOTORS; i++) {
+        EXPECT_EQ(0.0f, masterConfig.customMotorMixer[i].throttle);
+    }
+}
+
+// STUBS
+extern "C" {
+
+void applyDefaultLedStripConfig(ledConfig_t *) {}
+void applyDefaultColors(hsvColor_t *, uint8_t) {}
+void beeperConfirmationBeeps(uint8_t) {}
+void StopPwmAllMotors(void) {}
+void useRxConfig(rxConfig_t *) {}
+void useRcControlsConfig(modeActivationCondition_t *, escAndServoConfig_t *, pidProfile_t *) {}
+void useGyroConfig(gyroConfig_t *, float) {}
+void useFailsafeConfig(failsafeConfig_t *) {}
+void useBarometerConfig(barometerConfig_t *) {}
+void telemetryUseConfig(telemetryConfig_t *) {}
+void suspendRxSignal(void) {}
+void setAccelerationTrims(flightDynamicsTrims_t *) {}
+void resumeRxSignal(void) {}
+void resetRollAndPitchTrims(rollAndPitchTrims_t *) {}
+void resetAllRxChannelRangeConfigurations(rxChannelRangeConfiguration_t *) {}
+void resetAdjustmentStates(void) {}
+void pidSetController(pidControllerType_e) {}
+void parseRcChannels(const char *, rxConfig_t *) {}
+#ifdef USE_SERVOS
+void mixerUseConfigs(servoParam_t *, gimbalConfig_t *, flight3DConfig_t *, escAndServoConfig_t *, mixerConfig_t *, airplaneConfig_t *, rxConfig_t *) {}
+#else
+void mixerUseConfigs(flight3DConfig_t *, escAndServoConfig_t *, mixerConfig_t *, airplaneConfig_t *, rxConfig_t *) {}
+#endif
+bool isSerialConfigValid(serialConfig_t *) {return true;}
+void imuConfigure(imuRuntimeConfig_t *, pidProfile_t *,accDeadband_t *,float ,uint16_t) {}
+void gpsUseProfile(gpsProfile_t *) {}
+void gpsUsePIDs(pidProfile_t *) {}
+void generateYawCurve(controlRateConfig_t *) {}
+void generatePitchRollCurve(controlRateConfig_t *) {}
+void generateThrottleCurve(controlRateConfig_t *) {}
+void delay(uint32_t) {}
+void configureAltitudeHold(pidProfile_t *, barometerConfig_t *, rcControlsConfig_t *, escAndServoConfig_t *) {}
+void failureMode(uint8_t) {}
+
+const serialPortIdentifier_e serialPortIdentifiers[SERIAL_PORT_COUNT] = {
+#ifdef USE_VCP
+    SERIAL_PORT_USB_VCP,
+#endif
+#ifdef USE_USART1
+    SERIAL_PORT_USART1,
+#endif
+#ifdef USE_USART2
+    SERIAL_PORT_USART2,
+#endif
+#ifdef USE_USART3
+    SERIAL_PORT_USART3,
+#endif
+#ifdef USE_SOFTSERIAL1
+    SERIAL_PORT_SOFTSERIAL1,
+#endif
+#ifdef USE_SOFTSERIAL2
+    SERIAL_PORT_SOFTSERIAL2,
+#endif
+};
+}
+


### PR DESCRIPTION
Removed code that set values to zero when they had already been zeroed by `memset`. Each item removed has a line of test code that checks that it has indeed been zeroed by `resetConf`.

Saves differing amounts of ROM depending on build `#defines` for build target. About 50 bytes for CC3D. 184 bytes for ALIENWIIF1.

Fixes issue https://github.com/cleanflight/cleanflight/issues/1825