### PR TITLE
Improved calculation of stick positions.

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -195,9 +195,8 @@ void filterIsSetCheck(const pidProfile_t *pidProfile) {
 static void pidLuxFloat(const pidProfile_t *pidProfile, const controlRateConfig_t *controlRateConfig,
         uint16_t max_angle_inclination, const rollAndPitchTrims_t *angleTrim, const rxConfig_t *rxConfig)
 {
-    float RateError, errorAngle, AngleRate, gyroRate;
+    float RateError, AngleRate, gyroRate;
     float ITerm,PTerm,DTerm;
-    int32_t stickPosAil, stickPosEle, mostDeflectedPos;
     static float lastErrorForDelta[3];
     static float delta1[3], delta2[3];
     float delta, deltaSum;
@@ -209,15 +208,9 @@ static void pidLuxFloat(const pidProfile_t *pidProfile, const controlRateConfig_
     if (FLIGHT_MODE(HORIZON_MODE)) {
 
         // Figure out the raw stick positions
-        stickPosAil = getRcStickDeflection(ROLL, rxConfig->midrc);
-        stickPosEle = getRcStickDeflection(PITCH, rxConfig->midrc);
-
-        if(ABS(stickPosAil) > ABS(stickPosEle)){
-            mostDeflectedPos = ABS(stickPosAil);
-        }
-        else {
-            mostDeflectedPos = ABS(stickPosEle);
-        }
+        const int32_t stickPosAil = ABS(getRcStickDeflection(ROLL, rxConfig->midrc));
+        const int32_t stickPosEle = ABS(getRcStickDeflection(PITCH, rxConfig->midrc));
+        const int32_t mostDeflectedPos =  MAX(stickPosAil, stickPosEle);
 
         // Progressively turn off the horizon self level strength as the stick is banged over
         horizonLevelStrength = (float)(500 - mostDeflectedPos) / 500;  // 1 at centre stick, 0 = max stick deflection
@@ -240,10 +233,10 @@ static void pidLuxFloat(const pidProfile_t *pidProfile, const controlRateConfig_
          } else {
             // calculate error and limit the angle to the max inclination
 #ifdef GPS
-            errorAngle = (constrain(rcCommand[axis] + GPS_angle[axis], -((int) max_angle_inclination),
+            const float errorAngle = (constrain(rcCommand[axis] + GPS_angle[axis], -((int) max_angle_inclination),
                     +max_angle_inclination) - attitude.raw[axis] + angleTrim->raw[axis]) / 10.0f; // 16 bits is ok here
 #else
-            errorAngle = (constrain(rcCommand[axis], -((int) max_angle_inclination),
+            const float errorAngle = (constrain(rcCommand[axis], -((int) max_angle_inclination),
                     +max_angle_inclination) - attitude.raw[axis] + angleTrim->raw[axis]) / 10.0f; // 16 bits is ok here
 #endif
 
@@ -479,9 +472,6 @@ static void pidMultiWii23(const pidProfile_t *pidProfile, const controlRateConfi
 static void pidMultiWiiRewrite(const pidProfile_t *pidProfile, const controlRateConfig_t *controlRateConfig,
         uint16_t max_angle_inclination, const rollAndPitchTrims_t *angleTrim, const rxConfig_t *rxConfig)
 {
-    UNUSED(rxConfig);
-
-    int32_t errorAngle;
     int axis;
     int32_t delta, deltaSum;
     static int32_t delta1[3], delta2[3];
@@ -490,22 +480,15 @@ static void pidMultiWiiRewrite(const pidProfile_t *pidProfile, const controlRate
     int32_t AngleRateTmp, RateError, gyroRate;
 
     int8_t horizonLevelStrength = 100;
-    int32_t stickPosAil, stickPosEle, mostDeflectedPos;
 
     filterIsSetCheck(pidProfile);
 
     if (FLIGHT_MODE(HORIZON_MODE)) {
 
         // Figure out the raw stick positions
-        stickPosAil = getRcStickDeflection(ROLL, rxConfig->midrc);
-        stickPosEle = getRcStickDeflection(PITCH, rxConfig->midrc);
-
-        if(ABS(stickPosAil) > ABS(stickPosEle)){
-            mostDeflectedPos = ABS(stickPosAil);
-        }
-        else {
-            mostDeflectedPos = ABS(stickPosEle);
-        }
+        const int32_t stickPosAil = ABS(getRcStickDeflection(ROLL, rxConfig->midrc));
+        const int32_t stickPosEle = ABS(getRcStickDeflection(PITCH, rxConfig->midrc));
+        const int32_t mostDeflectedPos =  MAX(stickPosAil, stickPosEle);
 
         // Progressively turn off the horizon self level strength as the stick is banged over
         horizonLevelStrength = (500 - mostDeflectedPos) / 5;  // 100 at centre stick, 0 = max stick deflection
@@ -526,10 +509,10 @@ static void pidMultiWiiRewrite(const pidProfile_t *pidProfile, const controlRate
         } else {
             // calculate error and limit the angle to max configured inclination
 #ifdef GPS
-            errorAngle = constrain(2 * rcCommand[axis] + GPS_angle[axis], -((int) max_angle_inclination),
+            const int32_t errorAngle = constrain(2 * rcCommand[axis] + GPS_angle[axis], -((int) max_angle_inclination),
                     +max_angle_inclination) - attitude.raw[axis] + angleTrim->raw[axis]; // 16 bits is ok here
 #else
-            errorAngle = constrain(2 * rcCommand[axis], -((int) max_angle_inclination),
+            const int32_t errorAngle = constrain(2 * rcCommand[axis], -((int) max_angle_inclination),
                     +max_angle_inclination) - attitude.raw[axis] + angleTrim->raw[axis]; // 16 bits is ok here
 #endif
 


### PR DESCRIPTION
Fixes issue https://github.com/cleanflight/cleanflight/issues/1849

It also makes code clearer to read.

And surprisingly it saves 120 bytes of ROM.