### PR TITLE
SPF3Mini : Fix oneshot kills RX_PPM and MAG orientation

### DIFF
--- a/src/main/drivers/pwm_mapping.c
+++ b/src/main/drivers/pwm_mapping.c
@@ -779,6 +779,11 @@ pwmIOConfiguration_t *pwmInit(drv_pwm_config_t *init)
                 ppmAvoidPWMTimerClash(timerHardwarePtr, TIM2);
             }
 #endif
+#ifdef SPRACINGF3MINI
+            if (init->useOneshot || isMotorBrushed(init->motorPwmRate)) {
+                ppmAvoidPWMTimerClash(timerHardwarePtr, TIM3);
+            }
+#endif
             ppmInConfig(timerHardwarePtr);
             pwmIOConfiguration.ioConfigurations[pwmIOConfiguration.ioCount].flags = PWM_PF_PPM;
             pwmIOConfiguration.ppmInputCount++;

--- a/src/main/target/SPRACINGF3MINI/target.h
+++ b/src/main/target/SPRACINGF3MINI/target.h
@@ -61,7 +61,7 @@
 #define USE_MAG_AK8975
 #define USE_MAG_HMC5883 // External
 
-#define MAG_AK8975_ALIGN CW270_DEG_FLIP
+#define MAG_AK8975_ALIGN CW90_DEG_FLIP
 
 #define SONAR
 #define BEEPER


### PR DESCRIPTION
@Dominic : this is a desesperate tentative to enable oneshot and PPM on my SPF3Mini. I've reproduced what you did for CC3D WITHOUT UNDERSTANDING clearly what I was doing. I can empiricaly see that it seem to work fine with this fix, but again, I do not understand the impact of this change.

This should fix : #1839 and #1814