### PR TITLE
Smart telem : add support for Airmode, send temp when no GPS

### DIFF
--- a/docs/Telemetry.md
+++ b/docs/Telemetry.md
@@ -160,10 +160,10 @@ Tmp1 : actual flight mode, sent as 4 digits. Number is sent as (1)1234. Please i
 
 1. 1 is GPS Hold, 2 is GPS Home, 4 is Headfree
 2. 1 is mag enabled, 2 is baro enabled, 4 is sonar enabled
-3. 1 is angle, 2 is horizon, 4 is passthrough
+3. 1 is angle, 2 is horizon, 4 is airmode
 4. 1 is ok to arm, 2 is arming is prevented,  4 is armed
 
-Tmp2 : GPS lock status, Number is sent as 1234, the numbers are aditives :
+Tmp2 : if no GPS is present, barometer temp is sent, else it is GPS lock status, Number is sent as 1234, the numbers are aditives :
 
 1. 1 is GPS Fix, 2 is GPS Home fix
 2. not used

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -455,7 +455,6 @@ void handleSmartPortTelemetry(void)
 #else
 		    smartPortSendPackage(id, telemTemperature1 / 10);
 #endif
-		    smartPortSendPackage(id, (baroTemperature + 50)/ 100);
                     smartPortHasRequest = 0;
 		}
                 break;

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -146,6 +146,7 @@ static bool smartPortTelemetryEnabled =  false;
 static portSharing_e smartPortPortSharing;
 
 extern void serialInit(serialConfig_t *); // from main.c // FIXME remove this dependency
+extern int16_t telemTemperature1; // FIXME dependency on mw.c
 
 char smartPortState = SPSTATE_UNINITIALIZED;
 static uint8_t smartPortHasRequest = 0;
@@ -449,6 +450,11 @@ void handleSmartPortTelemetry(void)
                 }
 		else {
 		    // if no GPS send real temp
+#ifdef BARO
+		    smartPortSendPackage(id, (baroTemperature + 50)/ 100);
+#else
+		    smartPortSendPackage(id, telemTemperature1 / 10);
+#endif
 		    smartPortSendPackage(id, (baroTemperature + 50)/ 100);
                     smartPortHasRequest = 0;
 		}

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -415,9 +415,7 @@ void handleSmartPortTelemetry(void)
                     tmpi += 10;
                 if (FLIGHT_MODE(HORIZON_MODE))
                     tmpi += 20;
-                if (FLIGHT_MODE(UNUSED_MODE))
-                    tmpi += 40;
-                if (FLIGHT_MODE(PASSTHRU_MODE))
+                if (IS_RC_MODE_ACTIVE(BOXAIRMODE))
                     tmpi += 40;
 
                 if (FLIGHT_MODE(MAG_MODE))
@@ -449,6 +447,11 @@ void handleSmartPortTelemetry(void)
                     smartPortSendPackage(id, 0);
                     smartPortHasRequest = 0;
                 }
+		else {
+		    // if no GPS send real temp
+		    smartPortSendPackage(id, (baroTemperature + 50)/ 100);
+                    smartPortHasRequest = 0;
+		}
                 break;
 #ifdef GPS
             case FSSP_DATAID_GPS_ALT    :


### PR DESCRIPTION
- replace unused mode with airmode on status sending
- when no GPS is featured, send baro/gyro temp instead
- update telemetry docs accordingly

This fixes #1848