### PR TITLE
Fix Makefile 'make help' feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -766,7 +766,7 @@ bin:    $(TARGET_BIN)
 binary: $(TARGET_BIN)
 hex:    $(TARGET_HEX)
 
-## rule to reinvoke make with TARGET= parameter
+# rule to reinvoke make with TARGET= parameter
 # rules that should be handled in toplevel Makefile, not dependent on TARGET
 GLOBAL_GOALS	= all_targets cppcheck test
 
@@ -774,7 +774,7 @@ GLOBAL_GOALS	= all_targets cppcheck test
 $(VALID_TARGETS):
 	$(MAKE) TARGET=$@ $(filter-out $(VALID_TARGETS) $(GLOBAL_GOALS), $(MAKECMDGOALS))
 
-## rule to build all targets
+## all_targets : Make all TARGETs
 .PHONY: all_targets
 all_targets : $(VALID_TARGETS)
 

--- a/Makefile
+++ b/Makefile
@@ -760,7 +760,7 @@ TARGET_MAP	 = $(OBJECT_DIR)/$(FORKNAME)_$(TARGET).map
 all: hex bin
 
 ## bin         : Make binary filetype
-## binary      : Make binary filtype
+## binary      : Make binary filetype
 ## hex         : Make hex filetype
 bin:    $(TARGET_BIN)
 binary: $(TARGET_BIN)

--- a/Makefile
+++ b/Makefile
@@ -759,7 +759,6 @@ TARGET_MAP	 = $(OBJECT_DIR)/$(FORKNAME)_$(TARGET).map
 ## all         : Make all filetypes, binary and hex
 all: hex bin
 
-## bin         : Make binary filetype
 ## binary      : Make binary filetype
 ## hex         : Make hex filetype
 bin:    $(TARGET_BIN)


### PR DESCRIPTION
Some simple typo and string clean-ups to the `make help` feature.

Output now prints cleanly as:
```
$ make help

Makefile for the cleanflight firmware

Usage:
        make [goal] [TARGET=<target>] [OPTIONS="<options>"]

Valid TARGET values are: ALIENWIIF1 ALIENWIIF3 CC3D CHEBUZZF3 CJMCU COLIBRI_RACE LUX_RACE EUSTM32F103RC MOTOLAB NAZE NAZE32PRO OLIMEXINO PORT103R RMDO SPARKY SPRACINGF3 SPRACINGF3MINI STM32F3DISCOVERY 

Default make goal:
hex         : Make filetype hex only
Optional make goals:
all         : Make all filetypes, binary and hex
binary      : Make binary filetype
hex         : Make hex filetype
all_targets : Make all TARGETs
clean       : clean up all temporary / machine-generated files
flash       : flash firmware (.hex) onto flight controller
st-flash    : flash firmware (.bin) onto flight controller
unbrick     : unbrick flight controller
cppcheck    : run static analysis on C source code
help        : print this help message and exit
test        : run the cleanflight test suite
```