### PR TITLE
Read GYRO and ACC in one transaction and only use acc when needed.

### DIFF
--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -211,19 +211,19 @@ static float invSqrt(float x)
 
 static uint32_t imuGainResetTime = 0;
 
-void imuResetGainTime(uint32_t millis)
+void imuResetGainTime(uint32_t micros)
 {
-    imuGainResetTime = millis;
+    imuGainResetTime = micros;
 }
 
 static bool imuUseFastGains(void)
 {
-    uint32_t now = millis();
+    uint32_t now = micros();
 
     int32_t millisSinceGainReset = now - imuGainResetTime;
 
     // not armed and within 20 sec from powerup OR within 2 seconds of the gain reset time
-    return (!ARMING_FLAG(ARMED) && now < 20000) || (millisSinceGainReset < 2000L);
+    return (!ARMING_FLAG(ARMED) && now < 20000) || (millisSinceGainReset < (20L * 1000 * 1000));
 }
 
 static float imuGetPGainScaleFactor(void)

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -68,7 +68,6 @@ float fc_acc;
 float smallAngleCosZ = 0;
 
 float magneticDeclination = 0.0f;       // calculated at startup from config
-static bool isAccelUpdatedAtLeastOnce = false;
 
 static imuRuntimeConfig_t *imuRuntimeConfig;
 static pidProfile_t *pidProfile;
@@ -210,9 +209,21 @@ static float invSqrt(float x)
     return 1.0f / sqrtf(x);
 }
 
+static uint32_t imuGainResetTime = 0;
+
+void imuResetGainTime(uint32_t millis)
+{
+    imuGainResetTime = millis;
+}
+
 static bool imuUseFastGains(void)
 {
-    return !ARMING_FLAG(ARMED) && millis() < 20000;
+    uint32_t now = millis();
+
+    int32_t millisSinceGainReset = now - imuGainResetTime;
+
+    // not armed and within 20 sec from powerup OR within 2 seconds of the gain reset time
+    return (!ARMING_FLAG(ARMED) && now < 20000) || (millisSinceGainReset < 2000L);
 }
 
 static float imuGetPGainScaleFactor(void)
@@ -305,7 +316,7 @@ static void imuMahonyAHRSupdate(float dt, float gx, float gy, float gz,
         integralFBz = 0.0f;
     }
 
-    // Calculate kP gain. If we are acquiring initial attitude (not armed and within 20 sec from powerup) scale the kP to converge faster
+    // Calculate kP gain. If we are acquiring initial attitude scale the kP to converge faster
     float dcmKpGain = imuRuntimeConfig->dcm_kp * imuGetPGainScaleFactor();
 
     // Apply proportional and integral feedback
@@ -377,10 +388,11 @@ static bool isMagnetometerHealthy(void)
 }
 #endif
 
-static void imuCalculateEstimatedAttitude(void)
+static uint32_t previousIMUUpdateTime;
+
+void imuCalculateEstimatedAttitude(void)
 {
     static filterStatePt1_t accLPFState[3];
-    static uint32_t previousIMUUpdateTime;
     float rawYawError = 0;
     int32_t axis;
     bool useAcc = false;
@@ -428,25 +440,27 @@ static void imuCalculateEstimatedAttitude(void)
     imuCalculateAcceleration(deltaT); // rotate acc vector into earth frame
 }
 
-void imuUpdateAccelerometer(rollAndPitchTrims_t *accelerometerTrims)
+bool imuUpdateAccelerometer(rollAndPitchTrims_t *accelerometerTrims)
 {
     if (sensors(SENSOR_ACC)) {
         updateAccelerationReadings(accelerometerTrims);
-        isAccelUpdatedAtLeastOnce = true;
+        return true;
     }
+
+    return false;
 }
 
-void imuUpdateGyroAndAttitude(void)
+void resetAttitude(void)
 {
-    gyroUpdate();
+    accADC[X] = 0;
+    accADC[Y] = 0;
+    accADC[Z] = 0;
 
-    if (sensors(SENSOR_ACC) && isAccelUpdatedAtLeastOnce) {
-        imuCalculateEstimatedAttitude();
-    } else {
-        accADC[X] = 0;
-        accADC[Y] = 0;
-        accADC[Z] = 0;
-    }
+    accSmooth[X] = 0;
+    accSmooth[Y] = 0;
+    accSmooth[Z] = 0;
+
+    previousIMUUpdateTime = micros();
 }
 
 float getCosTiltAngle(void)

--- a/src/main/flight/imu.h
+++ b/src/main/flight/imu.h
@@ -62,11 +62,13 @@ void imuConfigure(
     uint16_t throttle_correction_angle
 );
 
-void imuUpdateAccelerometer(rollAndPitchTrims_t *accelerometerTrims);
-void imuUpdateGyroAndAttitude(void);
+bool imuUpdateAccelerometer(rollAndPitchTrims_t *accelerometerTrims);
+void imuCalculateEstimatedAttitude(void);
+void resetAttitude(void);
 float calculateThrottleAngleScale(uint16_t throttle_correction_angle);
 int16_t calculateThrottleAngleCorrection(uint8_t throttle_correction_value);
 float calculateAccZLowPassFilterRCTimeConstant(float accz_lpf_cutoff);
+void imuResetGainTime(uint32_t millis);
 
 int16_t imuCalculateHeading(t_fp_vector *vec);
 

--- a/src/main/mw.h
+++ b/src/main/mw.h
@@ -21,6 +21,7 @@ extern int16_t magHold;
 
 void applyAndSaveAccelerometerTrimsDelta(rollAndPitchTrims_t *rollAndPitchTrimsDelta);
 void handleInflightCalibrationStickPosition();
+bool shouldCalculateAttitude(void);
 
 void mwDisarm(void);
 void mwArm(void);

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -56,8 +56,12 @@ void useGyroConfig(gyroConfig_t *gyroConfigToUse, float gyro_lpf_hz)
 }
 
 void initGyroFilterCoefficients(void) {
-    if (gyroLpfCutFreq) {  /* Initialisation needs to happen once samplingrate is known */
-        for (axis = 0; axis < 3; axis++) BiQuadNewLpf(gyroLpfCutFreq, &gyroFilterState[axis], targetLooptime);
+    if (gyroLpfCutFreq) {
+        // Initialisation needs to happen once sampling rate is known
+        for (axis = 0; axis < 3; axis++) {
+            BiQuadNewLpf(gyroLpfCutFreq, &gyroFilterState[axis], targetLooptime);
+        }
+
         gyroFilterStateIsSet = true;
     }
 }
@@ -138,15 +142,21 @@ void gyroUpdate(void)
     }
 
     // Prepare a copy of int32_t gyroADC for mangling to prevent overflow
-    for (axis = 0; axis < XYZ_AXIS_COUNT; axis++) gyroADC[axis] = gyroADCRaw[axis];
+    for (axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
+        gyroADC[axis] = gyroADCRaw[axis];
+    }
 
     alignSensors(gyroADC, gyroADC, gyroAlign);
 
     if (gyroLpfCutFreq) {
-        if (!gyroFilterStateIsSet) initGyroFilterCoefficients(); /* initialise filter coefficients */
+        if (!gyroFilterStateIsSet) {
+            initGyroFilterCoefficients();
+        }
 
         if (gyroFilterStateIsSet) {
-            for (axis = 0; axis < XYZ_AXIS_COUNT; axis++) gyroADC[axis] = lrintf(applyBiQuadFilter((float) gyroADC[axis], &gyroFilterState[axis]));
+            for (axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
+                gyroADC[axis] = lrintf(applyBiQuadFilter((float) gyroADC[axis], &gyroFilterState[axis]));
+            }
         }
     }
 


### PR DESCRIPTION
 Experimental code that allows the ACC to be enabled and read as soon as

the MPU signals that new data is ready but stored until actually needed.

This is proof-of-concept code and not really sure it's particularly
worthwhile at this time.  Just wanting some feedback as this has been
discussed in the past.