### PR TITLE
fix typo in serial code (was UART5_..._PERIPHERALS_TX instead of RX)

### DIFF
--- a/src/main/drivers/serial_uart_stm32f10x.c
+++ b/src/main/drivers/serial_uart_stm32f10x.c
@@ -436,7 +436,7 @@ uartPort_t *serialUART5(uint32_t baudRate, portMode_t mode, portOptions_t option
     RCC_APB2PeriphClockCmd(UART5_APB2_PERIPHERALS_TX, ENABLE);
 #endif
 #ifdef UART5_APB2_PERIPHERALS_RX
-    RCC_APB2PeriphClockCmd(UART5_APB2_PERIPHERALS_TX, ENABLE);
+    RCC_APB2PeriphClockCmd(UART5_APB2_PERIPHERALS_RX, ENABLE);
 #endif
 
     gpio.speed = Speed_2MHz;

--- a/src/main/drivers/serial_uart_stm32f30x.c
+++ b/src/main/drivers/serial_uart_stm32f30x.c
@@ -509,7 +509,7 @@ uartPort_t *serialUART5(uint32_t baudRate, portMode_t mode, portOptions_t option
     RCC_AHBPeriphClockCmd(UART5_AHB_PERIPHERALS_TX, ENABLE);
 #endif
 #ifdef UART5_AHB_PERIPHERALS_RX
-    RCC_AHBPeriphClockCmd(UART5_AHB_PERIPHERALS_TX, ENABLE);
+    RCC_AHBPeriphClockCmd(UART5_AHB_PERIPHERALS_RX, ENABLE);
 #endif
 
     GPIO_InitStructure.GPIO_Mode  = GPIO_Mode_AF;


### PR DESCRIPTION
fix typo introduced by copy&paste for F1 (UART5_APB2_PERIPHERALS_TX/RX) and F3 (UART5_AHB_PERIPHERALS_TX/RX) targets