### PR TITLE
Add external bmp180 to spf3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -610,7 +610,9 @@ SPRACINGF3_SRC = \
 		   $(STM32F30x_COMMON_SRC) \
 		   drivers/accgyro_mpu.c \
 		   drivers/accgyro_mpu6050.c \
+		   drivers/barometer_bmp085.c \
 		   drivers/barometer_ms5611.c \
+		   drivers/barometer_bmp280.c \
 		   drivers/compass_ak8975.c \
 		   drivers/compass_hmc5883l.c \
 		   drivers/display_ug2864hsweg01.h \

--- a/src/main/target/SPRACINGF3/target.h
+++ b/src/main/target/SPRACINGF3/target.h
@@ -49,6 +49,8 @@
 
 #define BARO
 #define USE_BARO_MS5611
+#define USE_BARO_BMP085
+#define USE_BARO_BMP280
 
 #define MAG
 #define USE_MAG_AK8975


### PR DESCRIPTION
For those who want to convert an acro to deluxe.  This fixes #1903 