### PR TITLE
Fix issue #1837 - alt hold jump when enabling.

### DIFF
--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -211,6 +211,7 @@ $(OBJECT_DIR)/altitude_hold_unittest.o : \
 $(OBJECT_DIR)/altitude_hold_unittest : \
 	$(OBJECT_DIR)/flight/altitudehold.o \
 	$(OBJECT_DIR)/altitude_hold_unittest.o \
+    $(OBJECT_DIR)/common/maths.o \
 	$(OBJECT_DIR)/gtest_main.a
 
 	$(CXX) $(CXX_FLAGS) $^ -o $(OBJECT_DIR)/$@

--- a/src/test/unit/altitude_hold_unittest.cc
+++ b/src/test/unit/altitude_hold_unittest.cc
@@ -101,6 +101,46 @@ TEST(AltitudeHoldTest, IsThrustFacingDownwards)
     }
 }
 
+TEST(AltitudeHoldTest, applyMultirotorAltHold)
+{
+    // given
+    escAndServoConfig_t escAndServoConfig;
+    rcControlsConfig_t rcControlsConfig;
+    
+    memset(&escAndServoConfig, 0, sizeof(escAndServoConfig));
+    escAndServoConfig.minthrottle = 1150;
+    escAndServoConfig.maxthrottle = 1850;
+    memset(&rcControlsConfig, 0, sizeof(rcControlsConfig));
+    rcControlsConfig.alt_hold_deadband = 40;
+    
+    configureAltitudeHold(
+                          NULL,
+                          NULL,
+                          &rcControlsConfig,
+                          &escAndServoConfig
+                          );
+    
+    rcData[THROTTLE] = 1400;
+    rcCommand[THROTTLE] = 1500;
+    ACTIVATE_RC_MODE(BOXBARO);
+    updateAltHoldState();
+    
+    // when
+    applyAltHold(NULL);
+    
+    // expect
+    EXPECT_EQ(1500, rcCommand[THROTTLE]);
+    
+    // and given
+    rcControlsConfig.alt_hold_fast_change = 1;
+    
+    // when
+    applyAltHold(NULL);
+    
+    // expect
+    EXPECT_EQ(1500, rcCommand[THROTTLE]);
+}
+
 // STUBS
 
 extern "C" {
@@ -154,17 +194,8 @@ void updateAccelerationReadings(rollAndPitchTrims_t *rollAndPitchTrims)
 
 void imuResetAccelerationSum(void) {};
 
-int32_t applyDeadband(int32_t, int32_t) { return 0; }
 uint32_t micros(void) { return 0; }
 bool isBaroCalibrationComplete(void) { return true; }
 void performBaroCalibrationCycle(void) {}
 int32_t baroCalculateAltitude(void) { return 0; }
-int constrain(int amt, int low, int high)
-{
-    UNUSED(amt);
-    UNUSED(low);
-    UNUSED(high);
-    return 0;
-}
-
 }


### PR DESCRIPTION
Fix issue #1837: avoid mixing up rcData and rcCommand when calculating Alt Hold throttle value. This often causes a slight jump or drop when Alt Mode is activated.