### PR TITLE
Allow direct value setting for in-flight PID/rate adjustment.

### DIFF
--- a/src/main/io/rc_controls.c
+++ b/src/main/io/rc_controls.c
@@ -382,6 +382,8 @@ void configureAdjustmentState(adjustmentRange_t *adjustmentRange) {
     if (adjustmentRange->adjustmentFunction == ADJUSTMENT_RATE_PROFILE) {
         adjustmentState->config.mode = ADJUSTMENT_MODE_SELECT;
         adjustmentState->config.data.selectConfig.switchPositions = 3;
+    } else if (adjustmentRange->enableDirectMode > 0) {
+        adjustmentState->config.mode = ADJUSTMENT_MODE_DIRECT;
     } else {
         adjustmentState->config.mode = ADJUSTMENT_MODE_STEP;
         adjustmentState->config.data.stepConfig.step = 1;
@@ -390,145 +392,156 @@ void configureAdjustmentState(adjustmentRange_t *adjustmentRange) {
     MARK_ADJUSTMENT_FUNCTION_AS_READY(index);
 }
   
-static void setAdjustment(uint8_t* ptr, float* ptrFP, uint8_t adjustment, int delta, float factor, uint8_t min, uint8_t max) {
+static void setAdjustment(uint8_t* ptr, float* ptrFP, uint8_t adjustment, int delta, float factor, uint8_t min, uint8_t max, uint8_t isDirect, float value) {
+  float newValF;
+  int newVal;
   if(ptrFP != 0 && IS_PID_CONTROLLER_FP_BASED(pidProfile->pidController)) {
-    *ptrFP = constrainf((*ptrFP) + (delta / factor), PID_F_MIN, PID_F_MAX);
+    newValF = isDirect ? value : (*ptrFP) + (delta / factor);
+    *ptrFP = constrainf(newValF, PID_F_MIN, PID_F_MAX);
     blackboxLogInflightAdjustmentEventFloat(adjustment, *ptrFP);
   } else {
-    *ptr = constrain((int)(*ptr)+delta, min ,max);
+    newVal = (int) isDirect ? lrintf(value) : (int)(*ptr)+delta;
+    *ptr = constrain(newVal, min, max);
     blackboxLogInflightAdjustmentEvent(adjustment, *ptr);
   }
 }
 
-void applyStepAdjustment(controlRateConfig_t *controlRateConfig, uint8_t adjustmentFunction, int delta) {
-
-    if (delta > 0) {
-        beeperConfirmationBeeps(2);
-    } else {
-        beeperConfirmationBeeps(1);
+void applyAdjustment(controlRateConfig_t *controlRateConfig, uint8_t adjustmentFunction, int delta, uint8_t isDirect, float value) {
+    if (!isDirect) {
+        if (delta > 0) {
+            beeperConfirmationBeeps(2);
+        } else {
+            beeperConfirmationBeeps(1);
+        }
     }
     switch(adjustmentFunction) {
         case ADJUSTMENT_RC_RATE:
-            setAdjustment(&controlRateConfig->rcRate8,0,ADJUSTMENT_RC_RATE,delta,0,RC_RATE_MIN,RC_RATE_MAX);
-            generatePitchRollCurve(controlRateConfig);
+            if (!isDirect || (uint8_t)value != controlRateConfig->rcRate8) {
+                setAdjustment(&controlRateConfig->rcRate8,0,ADJUSTMENT_RC_RATE,delta,0,RC_RATE_MIN,RC_RATE_MAX,isDirect,value);
+                generatePitchRollCurve(controlRateConfig);
+            }
         break;
         case ADJUSTMENT_RC_EXPO:
-            setAdjustment(&controlRateConfig->rcExpo8,0,ADJUSTMENT_RC_EXPO,delta,0,EXPO_MIN,EXPO_MAX);
-            generatePitchRollCurve(controlRateConfig);
+            if (!isDirect || (uint8_t)value != controlRateConfig->rcExpo8) {
+                setAdjustment(&controlRateConfig->rcExpo8,0,ADJUSTMENT_RC_EXPO,delta,0,EXPO_MIN,EXPO_MAX,isDirect,value);
+                generatePitchRollCurve(controlRateConfig);
+            }
         break;
         case ADJUSTMENT_THROTTLE_EXPO:
-            setAdjustment(&controlRateConfig->thrExpo8,0,ADJUSTMENT_THROTTLE_EXPO,delta,0,EXPO_MIN,EXPO_MAX);
-            generateThrottleCurve(controlRateConfig, escAndServoConfig);
+            if (!isDirect || (uint8_t)value != controlRateConfig->thrExpo8) {
+                setAdjustment(&controlRateConfig->thrExpo8,0,ADJUSTMENT_THROTTLE_EXPO,delta,0,EXPO_MIN,EXPO_MAX,isDirect,value);
+                generateThrottleCurve(controlRateConfig, escAndServoConfig);
+            }
         break;
         case ADJUSTMENT_PITCH_ROLL_RATE:
         case ADJUSTMENT_PITCH_RATE:
-            setAdjustment(&controlRateConfig->rates[FD_PITCH],0,ADJUSTMENT_PITCH_RATE,delta,0,0,CONTROL_RATE_CONFIG_ROLL_PITCH_RATE_MAX);
+            setAdjustment(&controlRateConfig->rates[FD_PITCH],0,ADJUSTMENT_PITCH_RATE,delta,0,0,CONTROL_RATE_CONFIG_ROLL_PITCH_RATE_MAX,isDirect,value);
             if (adjustmentFunction == ADJUSTMENT_PITCH_RATE) {
                 break;
             }
             // follow though for combined ADJUSTMENT_PITCH_ROLL_RATE
         case ADJUSTMENT_ROLL_RATE:
-            setAdjustment(&controlRateConfig->rates[FD_ROLL],0,ADJUSTMENT_ROLL_RATE,delta,0,0,CONTROL_RATE_CONFIG_ROLL_PITCH_RATE_MAX);
+            setAdjustment(&controlRateConfig->rates[FD_ROLL],0,ADJUSTMENT_ROLL_RATE,delta,0,0,CONTROL_RATE_CONFIG_ROLL_PITCH_RATE_MAX,isDirect,value);
             break;
         case ADJUSTMENT_YAW_RATE:
-            setAdjustment(&controlRateConfig->rates[FD_YAW],0,ADJUSTMENT_YAW_RATE,delta,0,0,CONTROL_RATE_CONFIG_YAW_RATE_MAX);
+            setAdjustment(&controlRateConfig->rates[FD_YAW],0,ADJUSTMENT_YAW_RATE,delta,0,0,CONTROL_RATE_CONFIG_YAW_RATE_MAX,isDirect,value);
             break;
         case ADJUSTMENT_PITCH_ROLL_P:
         case ADJUSTMENT_PITCH_P:
-            setAdjustment(&pidProfile->P8[PIDPITCH],&pidProfile->P_f[PIDPITCH],ADJUSTMENT_PITCH_P,delta,10.0f,PID_MIN,PID_MAX);
+            setAdjustment(&pidProfile->P8[PIDPITCH],&pidProfile->P_f[PIDPITCH],ADJUSTMENT_PITCH_P,delta,10.0f,PID_MIN,PID_MAX,isDirect,value);
             if (adjustmentFunction == ADJUSTMENT_PITCH_P) {
                 break;
             }
             // follow though for combined ADJUSTMENT_PITCH_ROLL_P
         case ADJUSTMENT_ROLL_P:
-            setAdjustment(&pidProfile->P8[PIDROLL],&pidProfile->P_f[PIDROLL],ADJUSTMENT_ROLL_P,delta,10.0f,PID_MIN,PID_MAX);
+            setAdjustment(&pidProfile->P8[PIDROLL],&pidProfile->P_f[PIDROLL],ADJUSTMENT_ROLL_P,delta,10.0f,PID_MIN,PID_MAX,isDirect,value);
             break;
         case ADJUSTMENT_PITCH_ROLL_I:
         case ADJUSTMENT_PITCH_I:
-            setAdjustment(&pidProfile->I8[PIDPITCH],&pidProfile->I_f[PIDPITCH],ADJUSTMENT_PITCH_I,delta,100.0f,PID_MIN,PID_MAX);
+            setAdjustment(&pidProfile->I8[PIDPITCH],&pidProfile->I_f[PIDPITCH],ADJUSTMENT_PITCH_I,delta,100.0f,PID_MIN,PID_MAX,isDirect,value);
             if (adjustmentFunction == ADJUSTMENT_PITCH_I) {
                 break;
             }
             // follow though for combined ADJUSTMENT_PITCH_ROLL_I
         case ADJUSTMENT_ROLL_I:
-           setAdjustment(&pidProfile->I8[PIDROLL],&pidProfile->I_f[PIDROLL],ADJUSTMENT_ROLL_I,delta,100.0f,PID_MIN,PID_MAX);
+           setAdjustment(&pidProfile->I8[PIDROLL],&pidProfile->I_f[PIDROLL],ADJUSTMENT_ROLL_I,delta,100.0f,PID_MIN,PID_MAX,isDirect,value);
             break;
         case ADJUSTMENT_PITCH_ROLL_D:
         case ADJUSTMENT_PITCH_D:
-            setAdjustment(&pidProfile->D8[PIDPITCH],&pidProfile->D_f[PIDPITCH],ADJUSTMENT_PITCH_D,delta,1000.0f,PID_MIN,PID_MAX);
+            setAdjustment(&pidProfile->D8[PIDPITCH],&pidProfile->D_f[PIDPITCH],ADJUSTMENT_PITCH_D,delta,1000.0f,PID_MIN,PID_MAX,isDirect,value);
             if (adjustmentFunction == ADJUSTMENT_PITCH_D) {
                 break;
             }
             // follow though for combined ADJUSTMENT_PITCH_ROLL_D
         case ADJUSTMENT_ROLL_D:
-            setAdjustment(&pidProfile->D8[PIDROLL],&pidProfile->D_f[PIDROLL],ADJUSTMENT_ROLL_D,delta,1000.0f,PID_MIN,PID_MAX);
+            setAdjustment(&pidProfile->D8[PIDROLL],&pidProfile->D_f[PIDROLL],ADJUSTMENT_ROLL_D,delta,1000.0f,PID_MIN,PID_MAX,isDirect,value);
             break;
         case ADJUSTMENT_YAW_P:
-                setAdjustment(&pidProfile->P8[PIDYAW],&pidProfile->P_f[PIDYAW],ADJUSTMENT_YAW_P,delta,10.0f,PID_MIN,PID_MAX);
+                setAdjustment(&pidProfile->P8[PIDYAW],&pidProfile->P_f[PIDYAW],ADJUSTMENT_YAW_P,delta,10.0f,PID_MIN,PID_MAX,isDirect,value);
             break;
         case ADJUSTMENT_YAW_I:
-            setAdjustment(&pidProfile->I8[PIDYAW],&pidProfile->I_f[PIDYAW],ADJUSTMENT_YAW_I,delta,100.0f,PID_MIN,PID_MAX);
+            setAdjustment(&pidProfile->I8[PIDYAW],&pidProfile->I_f[PIDYAW],ADJUSTMENT_YAW_I,delta,100.0f,PID_MIN,PID_MAX,isDirect,value);
             break;
         case ADJUSTMENT_YAW_D:
-                setAdjustment(&pidProfile->D8[PIDYAW],&pidProfile->D_f[PIDYAW],ADJUSTMENT_YAW_D,delta,1000.0f,PID_MIN,PID_MAX);
+                setAdjustment(&pidProfile->D8[PIDYAW],&pidProfile->D_f[PIDYAW],ADJUSTMENT_YAW_D,delta,1000.0f,PID_MIN,PID_MAX,isDirect,value);
             break;
         case ADJUSTMENT_LEVEL_P:
-            setAdjustment(&pidProfile->P8[PIDLEVEL],&pidProfile->A_level,ADJUSTMENT_LEVEL_P,delta,10.0f,PID_MIN,PID_MAX);
+            setAdjustment(&pidProfile->P8[PIDLEVEL],&pidProfile->A_level,ADJUSTMENT_LEVEL_P,delta,10.0f,PID_MIN,PID_MAX,isDirect,value);
             break;
         case ADJUSTMENT_LEVEL_I:
-            setAdjustment(&pidProfile->I8[PIDLEVEL],&pidProfile->H_level,ADJUSTMENT_LEVEL_I,delta,10.0f,PID_MIN,PID_MAX);
+            setAdjustment(&pidProfile->I8[PIDLEVEL],&pidProfile->H_level,ADJUSTMENT_LEVEL_I,delta,10.0f,PID_MIN,PID_MAX,isDirect,value);
             break;
         case ADJUSTMENT_LEVEL_D:
             if (IS_PID_CONTROLLER_FP_BASED(pidProfile->pidController)) {
-              setAdjustment(&pidProfile->H_sensitivity,0,ADJUSTMENT_LEVEL_D,delta,0,PID_MIN,PID_MAX);
+              setAdjustment(&pidProfile->H_sensitivity,0,ADJUSTMENT_LEVEL_D,delta,0,PID_MIN,PID_MAX,isDirect,value);
             } else {
-              setAdjustment(&pidProfile->D8[PIDLEVEL],0,ADJUSTMENT_LEVEL_D,delta,0,PID_MIN,PID_MAX);
+              setAdjustment(&pidProfile->D8[PIDLEVEL],0,ADJUSTMENT_LEVEL_D,delta,0,PID_MIN,PID_MAX,isDirect,value);
             }
             break;
         case ADJUSTMENT_ALT_P:
-            setAdjustment(&pidProfile->P8[PIDALT],0,ADJUSTMENT_ALT_P,delta,0,PID_MIN,PID_MAX);
+            setAdjustment(&pidProfile->P8[PIDALT],0,ADJUSTMENT_ALT_P,delta,0,PID_MIN,PID_MAX,isDirect,value);
             break;
         case ADJUSTMENT_ALT_I:
-            setAdjustment(&pidProfile->I8[PIDALT],0,ADJUSTMENT_ALT_I,delta,0,PID_MIN,PID_MAX);
+            setAdjustment(&pidProfile->I8[PIDALT],0,ADJUSTMENT_ALT_I,delta,0,PID_MIN,PID_MAX,isDirect,value);
             break;
         case ADJUSTMENT_ALT_D:
-            setAdjustment(&pidProfile->D8[PIDALT],0,ADJUSTMENT_ALT_D,delta,0,PID_MIN,PID_MAX);
+            setAdjustment(&pidProfile->D8[PIDALT],0,ADJUSTMENT_ALT_D,delta,0,PID_MIN,PID_MAX,isDirect,value);
             break;
         case ADJUSTMENT_POS_P:
-            setAdjustment(&pidProfile->P8[PIDPOS],0,ADJUSTMENT_POS_P,delta,0,PID_MIN,PID_MAX);
+            setAdjustment(&pidProfile->P8[PIDPOS],0,ADJUSTMENT_POS_P,delta,0,PID_MIN,PID_MAX,isDirect,value);
             break;
         case ADJUSTMENT_POS_I:
-            setAdjustment(&pidProfile->I8[PIDPOS],0,ADJUSTMENT_POS_I,delta,0,PID_MIN,PID_MAX);
+            setAdjustment(&pidProfile->I8[PIDPOS],0,ADJUSTMENT_POS_I,delta,0,PID_MIN,PID_MAX,isDirect,value);
             break;
         case ADJUSTMENT_POSR_P:
-            setAdjustment(&pidProfile->P8[PIDPOSR],0,ADJUSTMENT_POSR_P,delta,0,PID_MIN,PID_MAX);
+            setAdjustment(&pidProfile->P8[PIDPOSR],0,ADJUSTMENT_POSR_P,delta,0,PID_MIN,PID_MAX,isDirect,value);
             break;
         case ADJUSTMENT_POSR_I:
-            setAdjustment(&pidProfile->I8[PIDPOSR],0,ADJUSTMENT_POSR_I,delta,0,PID_MIN,PID_MAX);
+            setAdjustment(&pidProfile->I8[PIDPOSR],0,ADJUSTMENT_POSR_I,delta,0,PID_MIN,PID_MAX,isDirect,value);
             break;
         case ADJUSTMENT_POSR_D:
-            setAdjustment(&pidProfile->D8[PIDPOSR],0,ADJUSTMENT_POSR_D,delta,0,PID_MIN,PID_MAX);
+            setAdjustment(&pidProfile->D8[PIDPOSR],0,ADJUSTMENT_POSR_D,delta,0,PID_MIN,PID_MAX,isDirect,value);
             break;
        case ADJUSTMENT_NAVR_P:
-            setAdjustment(&pidProfile->P8[PIDNAVR],0,ADJUSTMENT_NAVR_P,delta,0,PID_MIN,PID_MAX);
+            setAdjustment(&pidProfile->P8[PIDNAVR],0,ADJUSTMENT_NAVR_P,delta,0,PID_MIN,PID_MAX,isDirect,value);
             break;
         case ADJUSTMENT_NAVR_I:
-            setAdjustment(&pidProfile->I8[PIDNAVR],0,ADJUSTMENT_NAVR_I,delta,0,PID_MIN,PID_MAX);
+            setAdjustment(&pidProfile->I8[PIDNAVR],0,ADJUSTMENT_NAVR_I,delta,0,PID_MIN,PID_MAX,isDirect,value);
             break;
         case ADJUSTMENT_NAVR_D:
-            setAdjustment(&pidProfile->D8[PIDNAVR],0,ADJUSTMENT_NAVR_D,delta,0,PID_MIN,PID_MAX);
+            setAdjustment(&pidProfile->D8[PIDNAVR],0,ADJUSTMENT_NAVR_D,delta,0,PID_MIN,PID_MAX,isDirect,value);
             break;
         case ADJUSTMENT_MAG_P:
-            setAdjustment(&pidProfile->P8[PIDMAG],0,ADJUSTMENT_MAG_P,delta,0,PID_MIN,PID_MAX);
+            setAdjustment(&pidProfile->P8[PIDMAG],0,ADJUSTMENT_MAG_P,delta,0,PID_MIN,PID_MAX,isDirect,value);
             break;
         case ADJUSTMENT_VEL_P:
-            setAdjustment(&pidProfile->P8[PIDVEL],0,ADJUSTMENT_VEL_P,delta,0,PID_MIN,PID_MAX);
+            setAdjustment(&pidProfile->P8[PIDVEL],0,ADJUSTMENT_VEL_P,delta,0,PID_MIN,PID_MAX,isDirect,value);
             break;
         case ADJUSTMENT_VEL_I:
-            setAdjustment(&pidProfile->I8[PIDVEL],0,ADJUSTMENT_VEL_I,delta,0,PID_MIN,PID_MAX);
+            setAdjustment(&pidProfile->I8[PIDVEL],0,ADJUSTMENT_VEL_I,delta,0,PID_MIN,PID_MAX,isDirect,value);
             break;
         case ADJUSTMENT_VEL_D:
-            setAdjustment(&pidProfile->D8[PIDVEL],0,ADJUSTMENT_VEL_D,delta,0,PID_MIN,PID_MAX);
+            setAdjustment(&pidProfile->D8[PIDVEL],0,ADJUSTMENT_VEL_D,delta,0,PID_MIN,PID_MAX,isDirect,value);
             break;
         default:
             break;
@@ -604,12 +617,18 @@ void processRcAdjustments(controlRateConfig_t *controlRateConfig, rxConfig_t *rx
                 continue;
             }
 
-            applyStepAdjustment(controlRateConfig, adjustmentFunction, delta);
+            applyAdjustment(controlRateConfig, adjustmentFunction, delta, 0, 0.0f);
         } else if (adjustmentState->config.mode == ADJUSTMENT_MODE_SELECT) {
-            uint16_t rangeWidth = ((2100 - 900) / adjustmentState->config.data.selectConfig.switchPositions);
-            uint8_t position = (constrain(rcData[channelIndex], 900, 2100 - 1) - 900) / rangeWidth;
+            uint16_t rangeWidth = ((CHANNEL_RANGE_WIDTH) / adjustmentState->config.data.selectConfig.switchPositions);
+            uint8_t position = (constrain(rcData[channelIndex], CHANNEL_RANGE_MIN, CHANNEL_RANGE_MAX - 1) - CHANNEL_RANGE_MIN) / rangeWidth;
 
             applySelectAdjustment(adjustmentFunction, position);
+        } else if (adjustmentState->config.mode == ADJUSTMENT_MODE_DIRECT) {
+            float valueMin = adjustmentState->range->valueRange.min;
+            float valueMax = adjustmentState->range->valueRange.max;
+            float rangeWidth = valueMax - valueMin;
+            float value = (constrain(rcData[channelIndex], CHANNEL_RANGE_MIN, CHANNEL_RANGE_MAX - 1) - CHANNEL_RANGE_MIN) * rangeWidth / CHANNEL_RANGE_WIDTH + valueMin;
+            applyAdjustment(controlRateConfig, adjustmentFunction, 0, 1, value);
         }
         MARK_ADJUSTMENT_FUNCTION_AS_BUSY(adjustmentIndex);
     }

--- a/src/main/io/rc_controls.h
+++ b/src/main/io/rc_controls.h
@@ -100,6 +100,8 @@ typedef enum {
 #define CHANNEL_RANGE_MIN 900
 #define CHANNEL_RANGE_MAX 2100
 
+#define CHANNEL_RANGE_WIDTH (CHANNEL_RANGE_MAX - CHANNEL_RANGE_MIN)
+
 #define MODE_STEP_TO_CHANNEL_VALUE(step) (CHANNEL_RANGE_MIN + 25 * (step))
 #define CHANNEL_VALUE_TO_STEP(channelValue) ((constrain((channelValue), CHANNEL_RANGE_MIN, CHANNEL_RANGE_MAX) - CHANNEL_RANGE_MIN) / 25)
 
@@ -122,6 +124,11 @@ typedef struct channelRange_s {
     uint8_t startStep;
     uint8_t endStep;
 } channelRange_t;
+
+typedef struct valueRange_s {
+    float min;
+    float max;
+} valueRange_t;
 
 typedef struct modeActivationCondition_s {
     boxId_e modeId;
@@ -216,7 +223,8 @@ typedef enum {
 
 typedef enum {
     ADJUSTMENT_MODE_STEP,
-    ADJUSTMENT_MODE_SELECT
+    ADJUSTMENT_MODE_SELECT,
+    ADJUSTMENT_MODE_DIRECT
 } adjustmentMode_e;
 
 typedef struct adjustmentStepConfig_s {
@@ -249,6 +257,8 @@ typedef struct adjustmentRange_s {
 
     // ... via slot
     uint8_t adjustmentIndex;
+    uint8_t enableDirectMode;
+    valueRange_t valueRange;
 } adjustmentRange_t;
 
 #define ADJUSTMENT_INDEX_OFFSET 1

--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -855,7 +855,10 @@ static bool processOutCommand(uint8_t cmdMSP)
                 1 + // start step
                 1 + // end step
                 1 + // adjustment function
-                1   // aux switch channel index
+                1 + // aux switch channel index
+                1 + // direct mode flag
+                4 + // value range minimum
+                4   // value range maximum
         ));
         for (i = 0; i < MAX_ADJUSTMENT_RANGE_COUNT; i++) {
             adjustmentRange_t *adjRange = &currentProfile->adjustmentRanges[i];
@@ -865,6 +868,9 @@ static bool processOutCommand(uint8_t cmdMSP)
             serialize8(adjRange->range.endStep);
             serialize8(adjRange->adjustmentFunction);
             serialize8(adjRange->auxSwitchChannelIndex);
+            serialize8(adjRange->enableDirectMode);
+            serialize32(adjRange->valueRange.min);
+            serialize32(adjRange->valueRange.max);
         }
         break;
     case MSP_BOXNAMES:
@@ -1314,6 +1320,9 @@ static bool processInCommand(void)
                 adjRange->range.endStep = read8();
                 adjRange->adjustmentFunction = read8();
                 adjRange->auxSwitchChannelIndex = read8();
+                adjRange->enableDirectMode = read8();
+                adjRange->valueRange.min = read32();
+                adjRange->valueRange.max = read32();
             } else {
                 headSerialError(0);
             }


### PR DESCRIPTION
This branch is an attempt to address issue #1842 .
The following changes are introduced:
- Two new fields in `adjustmentRange_t`:
  - `enableDirectMode` - enables "direct mode" for adjustment functions. This means that the rc channel value is scaled and mapped to the target value. For example, a POT turned all the way to the right will set the maximum value for the variable being adjusted. Turning the POT will change the values instantly.
  - `valueRange` - defines min and max floating point values. RC channel values are mapped into this range.
- The cli format for adjustment ranges is augmented with 3 new fields, enableDirectMode, min, and max and the reading and printing of those values in the cli has been implemented.
- Serial MSP is updated for reading and sending the new adjustment range format.

TODO:
- Update adjustment doc explaining new config parameters
- Cleanflight Configurator changes to read, set and display these new adjustment configuration parameters. (Next on my hit list)

This is by no means a finished branch, but I would like to get some feedback about the approach used here to modify the current adjustments system.

Some concerns:
- The valueRange endpoints are completely free to be set by the user. This ignores the scaling of the various values. It might be confusing for the user to have to set a range on Pitch D from 0.02 - 0.05 when the GUI displays D in the 20-50 range, for example.
- Expensive floating point calculations are performed at each cycle to map the rc channel reading into the floating point range defined in config. I don't have a good sense of what the performance impact might be here.

The only way to test this functionality is to use the `adjrange` cli command to enable direct mode and set a value range. The initial adjustments config can still be set up in the GUI, but the value range must be set in CLI, for now.
