### PR TITLE
Update docs to follow latest upstream GCC ARM toolchain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,10 +42,10 @@ language: cpp
 compiler: clang
 
 before_install:
-  - curl --retry 10 --retry-max-time 120 -L "https://launchpad.net/gcc-arm-embedded/4.9/4.9-2015-q2-update/+download/gcc-arm-none-eabi-4_9-2015q2-20150609-linux.tar.bz2" | tar xfj -
+  - curl --retry 10 --retry-max-time 120 -L "https://launchpad.net/gcc-arm-embedded/5.0/5-2015-q4-major/+download/gcc-arm-none-eabi-5_2-2015q4-20151219-linux.tar.bz2" | tar xfj -
 
 install:
-  - export PATH=$PATH:$PWD/gcc-arm-none-eabi-4_9-2015q2/bin
+  - export PATH=$PATH:$PWD/gcc-arm-none-eabi-5_2-2015q4/bin
 
 before_script: arm-none-eabi-gcc --version
 script: ./.travis.sh

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,8 +19,8 @@ Vagrant.configure(2) do |config|
   # documentation for more information about their specific syntax and use.
   config.vm.provision "shell", inline: <<-SHELL
     apt-get remove -y binutils-arm-none-eabi gcc-arm-none-eabi
-    add-apt-repository ppa:terry.guo/gcc-arm-embedded
+    add-apt-repository ppa:team-gcc-arm-embedded/ppa
     apt-get update
-    apt-get install -y git gcc-arm-none-eabi=4.9.3.2015q3-1trusty1
+    apt-get install -y git gcc-arm-embedded=5-2015q4-1~trusty1
   SHELL
 end

--- a/docs/development/Building in Ubuntu.md
+++ b/docs/development/Building in Ubuntu.md
@@ -2,8 +2,8 @@
 
 Building for Ubuntu platform is remarkably easy. The only trick to understand is that the Ubuntu toolchain,
 which they are downstreaming from Debian, is not compatible with Cleanflight. We suggest that you take an
-alternative PPA from Terry Guo, found here:
-https://launchpad.net/~terry.guo/+archive/ubuntu/gcc-arm-embedded
+alternative PPA from the GCC ARM Embedded team, found here:
+https://launchpad.net/~team-gcc-arm-embedded/+archive/ubuntu/ppa
 
 This PPA has several compiler versions and platforms available. For many hardware platforms (notably Naze)
 the 4.9.3 compiler will work fine. For some, older compiler 4.8 (notably Sparky) is more appropriate. We
@@ -12,34 +12,34 @@ If you cannot, please see the section below for further hints on what you might 
 
 ## Setup GNU ARM Toolchain
 
-Note specifically the last paragraph of Terry's PPA documentation -- Ubuntu carries its own package for
-`gcc-arm-none-eabi`, so you'll have to remove it, and then pin the one from the PPA.
+Note specifically the last paragraph of GCC ARM Embedded PPA documentation -- Ubuntu carries its own package for
+`gcc-arm-embedded`, so you'll have to remove it, and then pin the one from the PPA.
 For your release, you should first remove any older pacakges (from Debian or Ubuntu directly), introduce
-Terry's PPA, and update:
+GCC ARM Embedded PPA, and update:
 ```
 sudo apt-get remove binutils-arm-none-eabi gcc-arm-none-eabi
-sudo add-apt-repository ppa:terry.guo/gcc-arm-embedded
+sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa
 sudo apt-get update
 ```
 
-For Ubuntu 14.10 (current release, called Utopic Unicorn), you should pin:
+For Ubuntu 15.10 (current release, called Wily Werewolf), you should pin:
 ```
-sudo apt-get install gcc-arm-none-eabi=4.9.3.2014q4-0utopic12
+sudo apt-get install gcc-arm-embedded=5-2015q4-1~wily1
 ```
 
 For Ubuntu 14.04 (an LTS as of Q1'2015, called Trusty Tahr), you should pin:
 ```
-sudo apt-get install gcc-arm-none-eabi=4.9.3.2014q4-0trusty12
+sudo apt-get install gcc-arm-embedded=5-2015q4-1~trusty1
 ```
 
 For Ubuntu 12.04 (previous LTS, called Precise Penguin), you should pin:
 ```
-sudo apt-get install gcc-arm-none-eabi=4.9.3.2014q4-0precise12
+sudo apt-get install gcc-arm-embedded=5-2015q4-1~precise1
 ```
 
 ## Building on Ubuntu
 
-After the ARM toolchain from Terry is installed, you should be able to build from source.
+After the ARM toolchain from GCC ARM Embedded team is installed, you should be able to build from source.
 ```
 cd src
 git clone git@github.com:cleanflight/cleanflight.git

--- a/docs/development/Building in Ubuntu.md
+++ b/docs/development/Building in Ubuntu.md
@@ -37,6 +37,42 @@ For Ubuntu 12.04 (previous LTS, called Precise Penguin), you should pin:
 sudo apt-get install gcc-arm-embedded=5-2015q4-1~precise1
 ```
 
+## One-time: Long-term developers
+
+The ARM toolchain was provided by an alternative repository prior to 2015 Q4 [1].
+
+For the 2015Q4 GCC 5 release the GCC ARM Embedded team decided to move
+from the old PPA maintained by Terry Guo [1] to a team maintained one [2].
+They also took advantage of that move to rename the package from
+gcc-arm-none-eabi to gcc-arm-embedded.
+
+[1] https://launchpad.net/~terry.guo/+archive/gcc-arm-embedded
+[2] https://launchpad.net/~team-gcc-arm-embedded/+archive/ubuntu/ppa
+
+A consequence of that move is that existing users of the old PPA are not
+automatically upgraded to the 2015Q4 GCC 5 release and need special action
+to do so:
+
+Step 1: Inside Ubuntu, open a terminal and input
+        "sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa"
+        to add the new PPA
+
+Step 2: Input "sudo add-apt-repository -r ppa:terry.guo/gcc-arm-embedded"
+        to remove the old PPA
+
+Step 3: Input "sudo apt-get update" to update apt's database
+
+Step 4: Input "sudo apt-get remove gcc-arm-none-eabi"
+        to remove the 2015Q3 GCC 4.9 package
+
+Step 5: Input "sudo apt-get install gcc-arm-embedded"
+        to install the 2015Q4 GCC 5 release
+
+These steps only need to be performed once: upgrade to future release will
+be done automatically after that.
+
+Refer: https://launchpad.net/gcc-arm-embedded/+announcement/13824
+
 ## Building on Ubuntu
 
 After the ARM toolchain from GCC ARM Embedded team is installed, you should be able to build from source.


### PR DESCRIPTION
For the 2015Q4 GCC 5 release the GCC ARM Embedded team decided to move
from the old PPA maintained by Terry Guo [1] to a team maintained one [2].
They also took advantage of that move to rename the package from
gcc-arm-none-eabi to gcc-arm-embedded.

[1] https://launchpad.net/~terry.guo/+archive/gcc-arm-embedded
[2] https://launchpad.net/~team-gcc-arm-embedded/+archive/ubuntu/ppa

A consequence of that move is that existing users of the old PPA are not
automatically upgraded to the 2015Q4 GCC 5 release and need special action
to do so:

```
Step 1: Inside Ubuntu, open a terminal and input
        "sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa"
        to add the new PPA

Step 2: Input "sudo add-apt-repository -r ppa:terry.guo/gcc-arm-embedded"
        to remove the old PPA

Step 3: Input "sudo apt-get update" to update apt's database

Step 4: Input "sudo apt-get remove gcc-arm-none-eabi"
        to remove the 2015Q3 GCC 4.9 package

Step 5: Input "sudo apt-get install gcc-arm-embedded"
        to install the 2015Q4 GCC 5 release
```

These steps only need to be performed once: upgrade to future release will
be done automatically after that.

https://launchpad.net/gcc-arm-embedded/+announcement/13824