### PR TITLE
Sparky LED strip pin rewired to PWM 8

### DIFF
--- a/docs/Board - Sparky.md
+++ b/docs/Board - Sparky.md
@@ -20,7 +20,7 @@ Tested with revision 1 & 2 boards.
 
 # Voltage and current monitoring (ADC support)
 
-Voltage monitoring is possible when enabled via PWM9 pin and current can be monitored via PWM8 pin. The voltage divider and current sensor need to be connected externally. The vbatscale cli parameter need to be adjusted to fit the sensor specification. For more details regarding the sensor hardware you can check here: https://github.com/TauLabs/TauLabs/wiki/User-Guide:-Battery-Configuration
+Voltage monitoring is possible when enabled via PWM9 pin and current can be monitored via PWM8 pin. Be aware that enabling led-strip will reuse PWM8 as the LED output pin. The voltage divider and current sensor need to be connected externally. The vbatscale cli parameter need to be adjusted to fit the sensor specification. For more details regarding the sensor hardware you can check here: https://github.com/TauLabs/TauLabs/wiki/User-Guide:-Battery-Configuration
 
 # Flashing
 

--- a/src/main/drivers/light_ws2811strip_stm32f30x.c
+++ b/src/main/drivers/light_ws2811strip_stm32f30x.c
@@ -94,6 +94,10 @@ void ws2811LedStripHardwareInit(void)
 
     /* DMA1 Channel Config */
     DMA_DeInit(WS2811_DMA_CHANNEL);
+    
+    #ifdef REMAP_TIM17_DMA
+    SYSCFG_DMAChannelRemapConfig(SYSCFG_DMARemap_TIM17, ENABLE);
+    #endif
 
     DMA_StructInit(&DMA_InitStructure);
     DMA_InitStructure.DMA_PeripheralBaseAddr = (uint32_t)&WS2811_TIMER->CCR1;

--- a/src/main/target/SPARKY/target.h
+++ b/src/main/target/SPARKY/target.h
@@ -120,28 +120,10 @@
 #define SONAR
 
 #define LED_STRIP
-#if 1
-// LED strip configuration using PWM motor output pin 5.
-#define LED_STRIP_TIMER TIM16
 
-#define WS2811_GPIO                     GPIOA
-#define WS2811_GPIO_AHB_PERIPHERAL      RCC_AHBPeriph_GPIOA
-#define WS2811_GPIO_AF                  GPIO_AF_1
-#define WS2811_PIN                      GPIO_Pin_6 // TIM16_CH1
-#define WS2811_PIN_SOURCE               GPIO_PinSource6
-#define WS2811_TIMER                    TIM16
-#define WS2811_TIMER_APB2_PERIPHERAL    RCC_APB2Periph_TIM16
-#define WS2811_DMA_CHANNEL              DMA1_Channel3
-#define WS2811_IRQ                      DMA1_Channel3_IRQn
-#define WS2811_DMA_TC_FLAG              DMA1_FLAG_TC3
-#define WS2811_DMA_HANDLER_IDENTIFER    DMA1_CH3_HANDLER
-
-#endif
-
-#if 0
-// Alternate LED strip pin
-// FIXME DMA IRQ Transfer Complete is never called because the  TIM17_DMA_RMP needs to be set in SYSCFG_CFGR1
+// LED strip configuration using PWM motor output pin 8.
 #define LED_STRIP_TIMER TIM17
+#define REMAP_TIM17_DMA
 
 #define WS2811_GPIO                     GPIOA
 #define WS2811_GPIO_AHB_PERIPHERAL      RCC_AHBPeriph_GPIOA
@@ -155,8 +137,6 @@
 #define WS2811_DMA_TC_FLAG              DMA1_FLAG_TC7
 #define WS2811_DMA_HANDLER_IDENTIFER    DMA1_CH7_HANDLER
 
-
-#endif
 
 #define USE_SERIAL_1WIRE
 


### PR DESCRIPTION
The standard pin for WS2812 LED strips is PWM 5 which is unfavourable in some cases. Some changes need to be applied to the target file and light drivers to rewire the output to PWM 8 aka PA7. Most of the code was already there but apparently someone lost interesst in getting through it.

You will find the precompiled binary of the master including my patch in the attachment. I also converted the hex file to the proprietary dfu format for flashing with the DfuSe tool. Happy testing^^.

[cleanflight_SPARKY_patch.zip](https://github.com/cleanflight/cleanflight/files/160420/cleanflight_SPARKY_patch.zip)
