### PR TITLE
Bit-banged SPI based RTC6705 VTX support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -290,7 +290,9 @@ HIGHEND_SRC = \
 		   sensors/sonar.c \
 		   sensors/barometer.c \
 		   blackbox/blackbox.c \
-		   blackbox/blackbox_io.c
+		   blackbox/blackbox_io.c \
+		   io/vtxrc.c \
+		   drivers/vtx_rtc6705bb.c
 
 VCP_SRC = \
 		   vcp/hw_config.c \

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -515,6 +515,19 @@ STATIC_UNIT_TESTED void resetConf(void)
     masterConfig.blackbox_rate_denom = 1;
 #endif
 
+#ifdef VTXBB
+    masterConfig.vtxbb_ss_pcode = 0;
+    masterConfig.vtxbb_sck_pcode = 0;
+    masterConfig.vtxbb_mosi_pcode = 0;
+#endif
+
+#ifdef VTX
+    masterConfig.vtx_mode = 0;
+    masterConfig.vtx_mhz = 5740;
+    masterConfig.vtx_band = 4;
+    masterConfig.vtx_channel = 1;
+#endif
+
     // alternative defaults settings for COLIBRI RACE targets
 #if defined(COLIBRI_RACE)
     masterConfig.looptime = 1000;

--- a/src/main/config/config.h
+++ b/src/main/config/config.h
@@ -45,6 +45,7 @@ typedef enum {
     FEATURE_BLACKBOX = 1 << 19,
     FEATURE_CHANNEL_FORWARDING = 1 << 20,
     FEATURE_TRANSPONDER = 1 << 21,
+    FEATURE_VTXBB = 1 << 22,
 } features_e;
 
 void handleOneshotFeatureChangeOnRestart(void);

--- a/src/main/config/config_master.h
+++ b/src/main/config/config_master.h
@@ -110,6 +110,19 @@ typedef struct master_t {
     uint8_t blackbox_device;
 #endif
 
+#ifdef VTXBB
+    uint16_t vtxbb_ss_pcode;
+    uint16_t vtxbb_sck_pcode;
+    uint16_t vtxbb_mosi_pcode;
+#endif
+
+#ifdef VTX
+    uint8_t vtx_mode;
+    uint16_t vtx_mhz;
+    uint8_t vtx_band;
+    uint8_t vtx_channel;
+#endif
+
     uint8_t magic_ef;                       // magic number, should be 0xEF
     uint8_t chk;                            // XOR checksum
 } master_t;

--- a/src/main/drivers/pwm_mapping.c
+++ b/src/main/drivers/pwm_mapping.c
@@ -753,6 +753,23 @@ pwmIOConfiguration_t *pwmInit(drv_pwm_config_t *init)
         }
 #endif
 
+#ifdef VTXBB
+        if (init->vtxbbGPIOConfig &&
+            (
+                (timerHardwarePtr->gpio == init->vtxbbGPIOConfig->ssGPIO &&
+                 timerHardwarePtr->pin == init->vtxbbGPIOConfig->ssPin)
+            ||
+                (timerHardwarePtr->gpio == init->vtxbbGPIOConfig->sckGPIO &&
+                 timerHardwarePtr->pin == init->vtxbbGPIOConfig->sckPin)
+            ||
+                (timerHardwarePtr->gpio == init->vtxbbGPIOConfig->mosiGPIO &&
+                 timerHardwarePtr->pin == init->vtxbbGPIOConfig->mosiPin)
+            )
+        ) {
+            continue;
+        }
+#endif
+
         // hacks to allow current functionality
         if (type == MAP_TO_PWM_INPUT && !init->useParallelPWM)
             continue;

--- a/src/main/drivers/pwm_mapping.h
+++ b/src/main/drivers/pwm_mapping.h
@@ -52,6 +52,17 @@ typedef struct sonarGPIOConfig_s {
     uint16_t echoPin;
 } sonarGPIOConfig_t;
 
+#ifdef VTXBB
+typedef struct vtxbbGPIOConfig_s {
+    GPIO_TypeDef *ssGPIO;
+    uint16_t ssPin;
+    GPIO_TypeDef *sckGPIO;
+    uint16_t sckPin;
+    GPIO_TypeDef *mosiGPIO;
+    uint16_t mosiPin;
+} vtxbbGPIOConfig_t;
+#endif
+
 typedef struct drv_pwm_config_s {
     bool useParallelPWM;
     bool usePPM;
@@ -77,6 +88,9 @@ typedef struct drv_pwm_config_s {
 #ifdef SONAR
     bool useSonar;
 #endif
+#ifdef VTXBB
+    bool useVTXBB;
+#endif
 #ifdef USE_SERVOS
     bool useServos;
     bool useChannelForwarding;    // configure additional channels as servos
@@ -88,6 +102,9 @@ typedef struct drv_pwm_config_s {
     uint16_t idlePulse;  // PWM value to use when initializing the driver. set this to either PULSE_1MS (regular pwm),
                          // some higher value (used by 3d mode), or 0, for brushed pwm drivers.
     sonarGPIOConfig_t *sonarGPIOConfig;
+#ifdef VTXBB
+    vtxbbGPIOConfig_t *vtxbbGPIOConfig;
+#endif
 } drv_pwm_config_t;
 
 

--- a/src/main/drivers/vtx.h
+++ b/src/main/drivers/vtx.h
@@ -1,0 +1,20 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNECS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+bool vtxInit();
+void vtxSetChan(int band, int channel);
+void vtxSetFreq(int freq);

--- a/src/main/drivers/vtx_rtc6705.h
+++ b/src/main/drivers/vtx_rtc6705.h
@@ -1,0 +1,33 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* Derived from: */
+/*
+ * Author: Giles Burgess (giles@multiflite.co.uk)
+ *
+ * This source code is provided as is and can be used/modified so long
+ * as this header is maintained with the file at all times.
+ */
+
+#pragma once
+
+#define VTX_BAND_MIN    1
+#define VTX_BAND_MAX    5
+#define VTX_CHANNEL_MIN 1
+#define VTX_CHANNEL_MAX 8
+#define VTX_FREQ_MIN    5600
+#define VTX_FREQ_MAX    5950

--- a/src/main/drivers/vtx_rtc6705bb.c
+++ b/src/main/drivers/vtx_rtc6705bb.c
@@ -1,0 +1,307 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNECS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Bit banging SPI version of RTC6705 VTX
+ *
+ * Compatible with vtx_rtc6705.c by sblakemore for ImpulseRC Singularity FCs,
+ * originated from Giles Burgess (giles@multiflite.co.uk) for MultiFlite FCs.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <strings.h>
+
+#include <platform.h>
+#include <config/config.h>
+
+#include "build_config.h"
+#include "gpio.h"
+#include "system.h"
+
+#include "drivers/vtxbb.h"
+#include "drivers/vtx.h"
+#include "drivers/vtx_rtc6705.h"
+
+// Magic spell to include config_master.h
+
+#include "common/color.h"
+#include "common/axis.h"
+#include "common/maths.h"
+
+#include "drivers/sensor.h"
+#include "drivers/accgyro.h"
+#include "drivers/compass.h"
+#include "drivers/gpio.h"
+#include "drivers/serial.h"
+#include "drivers/timer.h"
+#include "drivers/pwm_rx.h"
+
+#include "io/rc_controls.h"
+
+#include "sensors/sensors.h"
+#include "sensors/gyro.h"
+#include "sensors/acceleration.h"
+#include "sensors/boardalignment.h"
+#include "sensors/battery.h"
+
+#include "io/serial.h"
+#include "io/gimbal.h"
+#include "io/escservo.h"
+#include "io/ledstrip.h"
+#include "io/gps.h"
+
+#include "telemetry/telemetry.h"
+
+#include "flight/mixer.h"
+#include "flight/pid.h"
+#include "flight/imu.h"
+#include "flight/failsafe.h"
+#include "flight/altitudehold.h"
+#include "flight/navigation.h"
+
+#include "config/config_profile.h"
+#include "config/config_master.h"
+
+// End of the spell for config_master.h
+
+#if defined(VTX) && defined(VTXBB)
+//
+// Bit-banging SPI layer
+// Ideally, it would be a separate service with a separate file,
+// e.g., drivers/bus_spi_soft.c or something, but since there is no other
+// device using the service at the moment, it is kept here.
+//
+
+// Requires 3 plain GPIO ports for SS, SCK and MOSI.
+// Find out the ports to use from 'port code' variables:
+// vtxbb_ss_pcode, vtxbb_sck_pcode and vtxbb_mosi_pcode.
+// A port code is a 3-digit decimal number whose 100th
+// represent a GPIO (100 = GPIOA, 200=GPIOC, ... 600=GPIOF),
+// and 10th & 1th are pin number in decimal, for example,
+//     101 = GPIOA, Pin 1 (PA1)
+//     204 = GPIOB, Pin 4 (PB4)
+//     313 = GPIOC, Pin 13 (PC13)
+//     600 = GPIOF, Pin 0 (PF0)
+//     0xx = Invalid
+// etc. Zero in 100th represents an invalid assignment, and is an initial value
+// for the variables.
+
+static bool getGPIOSpecFromCode(int portcode, GPIO_TypeDef **pGPIO, uint16_t *pPin)
+{
+    int gpionum;
+    int pinnum;
+
+    if (portcode < 100)
+        return false;
+
+    gpionum = portcode / 100;
+    pinnum = portcode % 100;
+
+    switch(gpionum) {
+    case 1:
+        *pGPIO = GPIOA;
+        break;
+    case 2:
+        *pGPIO = GPIOB;
+        break;
+    case 3:
+        *pGPIO = GPIOC;
+        break;
+    case 4:
+        *pGPIO = GPIOD;
+        break;
+    case 5:
+        *pGPIO = GPIOE;
+        break;
+    case 6:
+        *pGPIO = GPIOF;
+        break;
+    case 0: // Fall through
+    default:
+        return false;
+    }
+
+    if (pinnum >= 16)
+        return false;
+
+    *pPin = 1 << pinnum;
+
+    return true;
+}
+
+static bool vtxbbHwChecked = false;
+static vtxbbHardware_t vtxbbhw;
+static bool vtxbbhwValid = false;
+
+static bool getGPIOSpec()
+{
+    if (vtxbbHwChecked)
+        return vtxbbhwValid;
+
+    if (getGPIOSpecFromCode(masterConfig.vtxbb_ss_pcode,
+            &vtxbbhw.ss_gpio, &vtxbbhw.ss_pin)
+        && getGPIOSpecFromCode(masterConfig.vtxbb_sck_pcode,
+            &vtxbbhw.sck_gpio, &vtxbbhw.sck_pin)
+        && getGPIOSpecFromCode(masterConfig.vtxbb_mosi_pcode,
+            &vtxbbhw.mosi_gpio, &vtxbbhw.mosi_pin)) {
+	vtxbbhwValid = true;
+    } else
+        vtxbbhwValid = false;
+
+    vtxbbHwChecked = true;
+
+    return vtxbbhwValid;
+}
+
+vtxbbHardware_t *vtxbbGetHardwareConfig()
+{
+    if (getGPIOSpec())
+    	return &vtxbbhw;
+
+    return NULL;
+}
+
+#define	GPIONAME(x) \
+	((x) == GPIOA ? "GPIOA" \
+	:(x) == GPIOB ? "GPIOB" \
+	:(x) == GPIOC ? "GPIOC" \
+	: "UNKNOWN")
+#define	GPIOPIN(x) \
+	(ffs(x) - 1)
+
+bool vtxbbInit(vtxbb_t *vtxbb)
+{
+    gpioInit(vtxbb->ss_gpio, &vtxbb->ss_cfg);
+    gpioInit(vtxbb->sck_gpio, &vtxbb->sck_cfg);
+    gpioInit(vtxbb->mosi_gpio, &vtxbb->mosi_cfg);
+    VTXBB_SS_HI(vtxbb);
+
+    vtxbb->active = true;
+
+    return true;
+}
+
+void vtxbbWrite(vtxbb_t *vtxbb, uint32_t data, int bits)
+{
+    int i;
+
+    VTXBB_SS_LO(vtxbb);
+
+    delayMicroseconds(5);
+
+    for (i = 0; i < bits; i++) {
+
+        if (data & 1)
+            VTXBB_MOSI_HI(vtxbb);
+        else
+            VTXBB_MOSI_LO(vtxbb);
+
+		delayMicroseconds(1);	// Wait for data to settle(!!!)
+
+        VTXBB_SCK_HI(vtxbb);
+
+        delayMicroseconds(1);	// Paranoia
+
+        VTXBB_SCK_LO(vtxbb);
+
+            data >>= 1;
+    }
+
+    VTXBB_SS_HI(vtxbb);
+}
+
+//
+// RTC6705 driver layer
+//
+#define Fosc    8       // Oscillator frequency in MHz
+#define RREG    400     // Fixed R divisor
+
+uint16_t freqTab[VTX_BAND_MAX][VTX_CHANNEL_MAX] = {
+    { 5865, 5846, 5825, 5805, 5785, 5765, 5746, 5725 },
+    { 5733, 5752, 5771, 5790, 5809, 5828, 5847, 5866 },
+    { 5705, 5685, 5665, 5665, 5885, 5905, 5905, 5905 },
+    { 5740, 5760, 5780, 5800, 5820, 5840, 5860, 5880 },
+    { 5658, 5695, 5732, 5769, 5806, 5843, 5880, 5917 }
+};
+
+#define RTC6705WDATA(addr, rw, data) \
+    ((addr & 0xf) | (rw << 4) | (data << 5))
+
+static void rtc6705_SetFreq(vtxbb_t *vtxbb, int freq)
+{
+    int g = freq * RREG / (2 * Fosc);
+    int ndiv = g / 64;
+    int adiv = g % 64;
+
+    vtxbbWrite(vtxbb, RTC6705WDATA(0, 1, RREG), 25);
+
+    delayMicroseconds(20);
+
+    vtxbbWrite(vtxbb, RTC6705WDATA(1, 1, ((ndiv << 7)|adiv)), 25);
+}
+
+static void rtc6705_SetChan(vtxbb_t *vtxbb, int band, int chan)
+{
+    rtc6705_SetFreq(vtxbb, freqTab[band][chan]);
+}
+
+//
+// VTX instance and API
+//
+
+static vtxbb_t vtxbb = {
+    .active = false,
+    .ss_cfg = { .mode = Mode_Out_PP, .speed = Speed_2MHz },
+    .sck_cfg = { .mode = Mode_Out_PP, .speed = Speed_2MHz },
+    .mosi_cfg = { .mode = Mode_Out_PP, .speed = Speed_2MHz } 
+};
+
+bool vtxInit()
+{
+    if (!feature(FEATURE_VTXBB) || !getGPIOSpec())
+        return false;
+
+    vtxbb.ss_gpio = vtxbbhw.ss_gpio;
+    vtxbb.ss_cfg.pin = vtxbbhw.ss_pin;
+    vtxbb.sck_gpio = vtxbbhw.sck_gpio;
+    vtxbb.sck_cfg.pin = vtxbbhw.sck_pin;
+    vtxbb.mosi_gpio = vtxbbhw.mosi_gpio;
+    vtxbb.mosi_cfg.pin = vtxbbhw.mosi_pin;
+
+    if (!vtxbbInit(&vtxbb)) {
+	return false;
+    }
+
+    delayMicroseconds(10000);
+
+    return true;
+}
+
+void vtxSetFreq(int mhz)
+{
+    if (vtxbb.active)
+    	rtc6705_SetFreq(&vtxbb, mhz);
+}
+
+void vtxSetChan(int band, int chan)
+{
+    if (vtxbb.active)
+    	rtc6705_SetChan(&vtxbb, band - 1, chan - 1);
+}
+#endif

--- a/src/main/drivers/vtxbb.h
+++ b/src/main/drivers/vtxbb.h
@@ -1,0 +1,33 @@
+typedef struct vtxbbHardware_s {
+	GPIO_TypeDef *ss_gpio;
+	uint16_t ss_pin;
+	GPIO_TypeDef *sck_gpio;
+	uint16_t sck_pin;
+	GPIO_TypeDef *mosi_gpio;
+	uint16_t mosi_pin;
+} vtxbbHardware_t;
+
+typedef struct vtxbb_s {
+    bool active;
+    GPIO_TypeDef *ss_gpio;
+    gpio_config_t ss_cfg;
+    GPIO_TypeDef *sck_gpio;
+    gpio_config_t sck_cfg;
+    GPIO_TypeDef *mosi_gpio;
+    gpio_config_t mosi_cfg;
+} vtxbb_t;
+
+vtxbbHardware_t *vtxbbGetHardwareConfig();
+
+#define VTXBB_SS_LO(vtxbb) \
+    digitalLo(vtxbb->ss_gpio, vtxbb->ss_cfg.pin)
+#define VTXBB_SS_HI(vtxbb) \
+    digitalHi(vtxbb->ss_gpio, vtxbb->ss_cfg.pin)
+#define VTXBB_SCK_LO(vtxbb) \
+    digitalLo(vtxbb->sck_gpio, vtxbb->sck_cfg.pin)
+#define VTXBB_SCK_HI(vtxbb) \
+    digitalHi(vtxbb->sck_gpio, vtxbb->sck_cfg.pin)
+#define VTXBB_MOSI_LO(vtxbb) \
+    digitalLo(vtxbb->mosi_gpio, vtxbb->mosi_cfg.pin)
+#define VTXBB_MOSI_HI(vtxbb) \
+    digitalHi(vtxbb->mosi_gpio, vtxbb->mosi_cfg.pin)

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -183,7 +183,8 @@ static const char * const featureNames[] = {
     "SERVO_TILT", "SOFTSERIAL", "GPS", "FAILSAFE",
     "SONAR", "TELEMETRY", "CURRENT_METER", "3D", "RX_PARALLEL_PWM",
     "RX_MSP", "RSSI_ADC", "LED_STRIP", "DISPLAY", "ONESHOT125",
-    "BLACKBOX", "CHANNEL_FORWARDING", "TRANSPONDER", NULL
+    "BLACKBOX", "CHANNEL_FORWARDING", "TRANSPONDER", "VTXBB",
+    NULL
 };
 
 // sync this with rxFailsafeChannelMode_e
@@ -706,6 +707,19 @@ const clivalue_t valueTable[] = {
     { "blackbox_rate_num",          VAR_UINT8  | MASTER_VALUE,  &masterConfig.blackbox_rate_num, .config.minmax = { 1,  32 } },
     { "blackbox_rate_denom",        VAR_UINT8  | MASTER_VALUE,  &masterConfig.blackbox_rate_denom, .config.minmax = { 1,  32 } },
     { "blackbox_device",            VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP,  &masterConfig.blackbox_device, .config.lookup = { TABLE_BLACKBOX_DEVICE } },
+#endif
+
+#ifdef VTXBB
+    { "vtxbb_ss_pcode",              VAR_UINT16 | MASTER_VALUE,  &masterConfig.vtxbb_ss_pcode, .config.minmax = { 0,  615 } },
+    { "vtxbb_sck_pcode",             VAR_UINT16 | MASTER_VALUE,  &masterConfig.vtxbb_sck_pcode, .config.minmax = { 0,  615 } },
+    { "vtxbb_mosi_pcode",            VAR_UINT16 | MASTER_VALUE,  &masterConfig.vtxbb_mosi_pcode, .config.minmax = { 0,  615 } },
+#endif
+
+#ifdef VTX
+    { "vtx_mode",                   VAR_UINT8  | MASTER_VALUE,  &masterConfig.vtx_mode, .config.minmax = { 0, 2 } },
+    { "vtx_band",                   VAR_UINT8  | MASTER_VALUE,  &masterConfig.vtx_band, .config.minmax = { 1, 5 } },
+    { "vtx_channel",                VAR_UINT8  | MASTER_VALUE,  &masterConfig.vtx_channel, .config.minmax = { 1, 8 } },
+    { "vtx_mhz",                    VAR_UINT16 | MASTER_VALUE,  &masterConfig.vtx_mhz, .config.minmax = { 5600, 5950 } },
 #endif
 
     { "magzero_x",                  VAR_INT16  | MASTER_VALUE, &masterConfig.magZero.raw[X], .config.minmax = { -32768,  32767 } },

--- a/src/main/io/vtxrc.c
+++ b/src/main/io/vtxrc.c
@@ -1,0 +1,108 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Place holder for future VTXRC integration
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+#include "build_config.h"
+#include "debug.h"
+#include <platform.h>
+#include "scheduler.h"
+
+#include "common/axis.h"
+#include "common/color.h"
+#include "common/maths.h"
+
+#include "drivers/system.h"
+
+#include "drivers/sensor.h"
+#include "drivers/accgyro.h"
+#include "drivers/compass.h"
+
+#include "drivers/serial.h"
+#include "drivers/bus_i2c.h"
+#include "drivers/gpio.h"
+#include "drivers/timer.h"
+#include "drivers/pwm_rx.h"
+#include "drivers/sdcard.h"
+#include "drivers/buf_writer.h"
+#include "rx/rx.h"
+#include "rx/msp.h"
+
+#include "io/escservo.h"
+#include "io/rc_controls.h"
+#include "io/gps.h"
+#include "io/gimbal.h"
+#include "io/serial.h"
+#include "io/ledstrip.h"
+#include "io/flashfs.h"
+#include "io/transponder_ir.h"
+#include "io/asyncfatfs/asyncfatfs.h"
+#include "io/beeper.h"
+#include "io/vtxrc.h"
+
+#include "drivers/vtx.h"
+
+#include "telemetry/telemetry.h"
+
+#include "sensors/boardalignment.h"
+#include "sensors/sensors.h"
+#include "sensors/battery.h"
+#include "sensors/sonar.h"
+#include "sensors/acceleration.h"
+#include "sensors/barometer.h"
+#include "sensors/compass.h"
+#include "sensors/gyro.h"
+
+#include "flight/mixer.h"
+#include "flight/pid.h"
+#include "flight/imu.h"
+#include "flight/failsafe.h"
+#include "flight/navigation.h"
+#include "flight/altitudehold.h"
+
+#include "blackbox/blackbox.h"
+
+#include "mw.h"
+
+#include "config/runtime_config.h"
+#include "config/config.h"
+#include "config/config_profile.h"
+#include "config/config_master.h"
+
+#include "version.h"
+
+void vtxRcInit()
+{
+    vtxInit();
+
+#ifndef VTXRC
+    if (!(masterConfig.vtx_mode == 0 || masterConfig.vtx_mode == 1))
+	masterConfig.vtx_mode = 0;
+#endif
+
+    if (masterConfig.vtx_mode == 0) {
+        vtxSetChan(masterConfig.vtx_band, masterConfig.vtx_channel);
+    } else if (masterConfig.vtx_mode == 1) {
+        vtxSetFreq(masterConfig.vtx_mhz);
+    }
+}

--- a/src/main/io/vtxrc.c
+++ b/src/main/io/vtxrc.c
@@ -91,6 +91,7 @@
 
 #include "version.h"
 
+#ifdef VTX
 void vtxRcInit()
 {
     vtxInit();
@@ -106,3 +107,4 @@ void vtxRcInit()
         vtxSetFreq(masterConfig.vtx_mhz);
     }
 }
+#endif

--- a/src/main/io/vtxrc.h
+++ b/src/main/io/vtxrc.h
@@ -1,0 +1,28 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Place holder for future VTXRC integration.
+
+#pragma once
+
+#define VTX_BAND_MIN    						1
+#define VTX_BAND_MAX    						5
+#define VTX_CHANNEL_MIN 						1
+#define VTX_CHANNEL_MAX 						8
+#define MAX_CHANNEL_ACTIVATION_CONDITION_COUNT 	10
+
+void vtxRcInit();

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -54,6 +54,8 @@
 #include "drivers/usb_io.h"
 #include "drivers/transponder_ir.h"
 #include "drivers/gyro_sync.h"
+#include "drivers/vtx.h"
+#include "drivers/vtxbb.h"
 
 #include "rx/rx.h"
 
@@ -67,6 +69,7 @@
 #include "io/display.h"
 #include "io/asyncfatfs/asyncfatfs.h"
 #include "io/transponder_ir.h"
+#include "io/vtxrc.h"
 
 #include "sensors/sensors.h"
 #include "sensors/sonar.h"
@@ -337,6 +340,25 @@ void init(void)
             .echoPin = sonarHardware->trigger_pin,
         };
         pwm_params.sonarGPIOConfig = &sonarGPIOConfig;
+    }
+#endif
+
+#ifdef VTXBB
+    const vtxbbHardware_t *vtxbbHardware;
+    vtxbbGPIOConfig_t vtxbbGPIOConfig;
+    if (feature(FEATURE_VTXBB) &&
+            (vtxbbHardware = vtxbbGetHardwareConfig())) {
+        vtxbbGPIOConfig.ssGPIO = vtxbbHardware->ss_gpio;
+        vtxbbGPIOConfig.ssPin = vtxbbHardware->ss_pin;
+        vtxbbGPIOConfig.sckGPIO = vtxbbHardware->sck_gpio;
+        vtxbbGPIOConfig.sckPin = vtxbbHardware->sck_pin;
+        vtxbbGPIOConfig.mosiGPIO = vtxbbHardware->mosi_gpio;
+        vtxbbGPIOConfig.mosiPin = vtxbbHardware->mosi_pin;
+        pwm_params.vtxbbGPIOConfig = &vtxbbGPIOConfig;
+        pwm_params.useVTXBB = true;	// Never used ...
+    } else {
+        pwm_params.vtxbbGPIOConfig = NULL;
+        pwm_params.useVTXBB = false;	// Never used ...
     }
 #endif
 
@@ -638,6 +660,10 @@ void init(void)
 
 #ifdef CJMCU
     LED2_ON;
+#endif
+
+#ifdef VTX
+    (void)vtxRcInit();
 #endif
 
     // Latch active features AGAIN since some may be modified by init().

--- a/src/main/target/NAZE/target.h
+++ b/src/main/target/NAZE/target.h
@@ -122,6 +122,8 @@
 #define LED1
 #define INVERTER
 #define DISPLAY
+#define VTX
+#define VTXBB
 
 #define USE_UART1
 #define USE_UART2

--- a/src/main/target/SPRACINGF3/target.h
+++ b/src/main/target/SPRACINGF3/target.h
@@ -168,6 +168,8 @@
 #define TELEMETRY
 #define USE_SERVOS
 #define USE_CLI
+#define VTX
+#define VTXBB
 
 #define SPEKTRUM_BIND
 // UART3,


### PR DESCRIPTION
Add support for VTX control.

For micro builds where every gram is a premier, or builds with concealed VTX, controlling the VTX from FC may be a good idea. This PR provides support for RTC6705 based VTX with SPI signal accessibility.  FX758-2 is an example of such VTX, and TX5823 could be used with a minor mod.

The SPI interface is driven with bit-banging SPI using any three unused GPIO ports.  Native/hardware SPI may be supported in the future.

The entire bit-banged VTX control is enabled by specifying a feature **VTXBB**.
In addition to the **VTXBB** feature, three GPIO ports for SPI signals must be specified with three CLI variables **vtxbb_ss_pcode**, **vtxbb_sck_pcode** and **vtxbb_mosi_pcode**, in 'port code' or 'pcode'.  A port code is a 3 digit number, with 100's place digit specifying GPIO group (GPIOA = 100, GPIOB = 200, ... GPIOF = 600), and lower two digits specifying pin number in decimal.  Port code examples are: PA2 = 102, PB11 = 211, PC13 = 313 and PF5 = 605.

CLI variables **vtx_mode**, **vtx_band**, **vtx_chan** and **vtx_freq** control a frequency which the VTX module will transmit on.  When vtx_mode = 0, the frequency is determined by vtx_band and vtx_chan according to the pre-defined table. When vtx_mode = 1, the frequency is determined directly by vtx_freq. (This scheme is partially compatible with multiFlite and SINGULARITY FC.)

The frequency is set only once upon initialization by init() in this PR.

Currently tested with NAZE and SPRACINGF3.
