### PR TITLE
Config structure registration improved

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -83,16 +83,7 @@
 #include "blackbox.h"
 #include "blackbox_io.h"
 
-blackboxConfig_t blackboxConfig;
-
-static const pgRegistry_t blackboxConfigRegistry PG_REGISTRY_SECTION =
-{
-    .base = (uint8_t *)&blackboxConfig,
-    .size = sizeof(blackboxConfig),
-    .pgn = PG_BLACKBOX_CONFIG,
-    .format = 0,
-    .flags = PGC_SYSTEM
-};
+PG_REGISTER(blackboxConfig_t, blackboxConfig, PG_BLACKBOX_CONFIG, 0);
 
 #define BLACKBOX_I_INTERVAL 32
 #define BLACKBOX_SHUTDOWN_TIMEOUT_MILLIS 200

--- a/src/main/blackbox/blackbox.h
+++ b/src/main/blackbox/blackbox.h
@@ -25,7 +25,7 @@ typedef struct blackboxConfig_s {
     uint8_t device;
 } blackboxConfig_t;
 
-extern blackboxConfig_t blackboxConfig;
+PG_DECLARE(blackboxConfig_t, blackboxConfig);
 
 void blackboxLogEvent(FlightLogEvent event, flightLogEventData_t *data);
 

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -96,38 +96,12 @@ static uint32_t activeFeaturesLatch = 0;
 static uint8_t currentControlRateProfileIndex = 0;
 controlRateConfig_t *currentControlRateProfile;
 
-master_t masterConfig;                 // master config struct with data independent from profiles
-static const pgRegistry_t masterRegistry PG_REGISTRY_SECTION = {
-    .base = (uint8_t *)&masterConfig,
-    .size = sizeof(masterConfig),
-    .pgn = PG_MASTER,
-    .flags = PGC_SYSTEM
-};
-
-STATIC_UNIT_TESTED profile_t profileStorage[MAX_PROFILE_COUNT];
-profile_t *currentProfile;
-
-static const pgRegistry_t profileRegistry PG_REGISTRY_SECTION =
-{
-    .base = (uint8_t *)&profileStorage,
-    .ptr = (uint8_t **)&currentProfile,
-    .size = sizeof(profileStorage[0]),
-    .pgn = PG_PROFILE,
-    .format = 0,
-    .flags = PGC_PROFILE
-};
-
+PG_REGISTER(master_t, masterConfig, 0, 0);
+PG_REGISTER_PROFILE(profile_t, currentProfile, PG_PROFILE, 0);
 
 // FIXME this should probably be defined in a separate file.  Drivers should be aware of parameter groups.
 
-static const pgRegistry_t pwmRxConfigRegistry PG_REGISTRY_SECTION =
-{
-    .base = (uint8_t *)&pwmRxConfig,
-    .size = sizeof(pwmRxConfig),
-    .pgn = PG_DRIVER_PWM_RX_CONFIG,
-    .format = 0,
-    .flags = PGC_SYSTEM
-};
+PG_REGISTER(pwmRxConfig_t, pwmRxConfig, PG_DRIVER_PWM_RX_CONFIG, 0);
 
 void resetPidProfile(pidProfile_t *pidProfile)
 {

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -96,8 +96,6 @@ static uint32_t activeFeaturesLatch = 0;
 static uint8_t currentControlRateProfileIndex = 0;
 controlRateConfig_t *currentControlRateProfile;
 
-static const void *pg_registry_tail PG_REGISTRY_TAIL_SECTION;
-
 master_t masterConfig;                 // master config struct with data independent from profiles
 static const pgRegistry_t masterRegistry PG_REGISTRY_SECTION = {
     .base = (uint8_t *)&masterConfig,
@@ -613,20 +611,23 @@ STATIC_UNIT_TESTED void resetConf(void)
     customMotorMixer[7].yaw = -1.0f;
 #endif
 
-    // FIXME implement differently
-
     // copy first profile into remaining profile
-    for (i = 1; i < MAX_PROFILE_COUNT; i++) {
-        memcpy(&profileStorage[i], &profileStorage[0], sizeof(profile_t));
+    PG_FOREACH_PROFILE(reg) {
+        for (int i = 1; i < MAX_PROFILE_COUNT; i++) {
+            memcpy(reg->base + i * reg->size, reg->base, reg->size);
+        }
     }
+
+    // FIXME implement differently
 
     // copy first control rate config into remaining profile
     for (i = 1; i < MAX_CONTROL_RATE_PROFILE_COUNT; i++) {
         memcpy(&controlRateProfiles[i], &controlRateProfiles[0], sizeof(controlRateConfig_t));
     }
 
+    // TODO
     for (i = 1; i < MAX_PROFILE_COUNT; i++) {
-        profileStorage[i].defaultRateProfileIndex = i % MAX_CONTROL_RATE_PROFILE_COUNT;
+        currentProfileStorage[i].defaultRateProfileIndex = i % MAX_CONTROL_RATE_PROFILE_COUNT;
     }
 }
 

--- a/src/main/config/config_eeprom.c
+++ b/src/main/config/config_eeprom.c
@@ -102,6 +102,7 @@ static uint8_t updateChecksum(uint8_t chk, const void *data, uint32_t length)
 uint8_t pgMatcherForConfigRecord(const pgRegistry_t *candidate, const void *criteria)
 {
     const configRecord_t *record = (const configRecord_t *)criteria;
+
     return (candidate->pgn == record->pgn && candidate->format == record->format);
 }
 

--- a/src/main/config/config_eeprom.c
+++ b/src/main/config/config_eeprom.c
@@ -102,7 +102,6 @@ static uint8_t updateChecksum(uint8_t chk, const void *data, uint32_t length)
 uint8_t pgMatcherForConfigRecord(const pgRegistry_t *candidate, const void *criteria)
 {
     const configRecord_t *record = (const configRecord_t *)criteria;
-
     return (candidate->pgn == record->pgn && candidate->format == record->format);
 }
 

--- a/src/main/config/config_master.h
+++ b/src/main/config/config_master.h
@@ -67,5 +67,5 @@ typedef struct master_t {
 #endif
 } master_t;
 
-extern master_t masterConfig;
+PG_DECLARE(master_t, masterConfig);
 extern controlRateConfig_t *currentControlRateProfile;

--- a/src/main/drivers/adc_stm32f10x.c
+++ b/src/main/drivers/adc_stm32f10x.c
@@ -23,6 +23,8 @@
 
 #include "build_config.h"
 
+#include "config/parameter_group.h"
+
 #include "system.h"
 
 #include "sensors/sensors.h" // FIXME dependency into the main code

--- a/src/main/drivers/compass_ak8975.c
+++ b/src/main/drivers/compass_ak8975.c
@@ -27,6 +27,8 @@
 #include "common/axis.h"
 #include "common/maths.h"
 
+#include "config/parameter_group.h"
+
 #include "system.h"
 #include "gpio.h"
 #include "bus_i2c.h"

--- a/src/main/drivers/compass_hmc5883l.c
+++ b/src/main/drivers/compass_hmc5883l.c
@@ -27,6 +27,8 @@
 #include "common/axis.h"
 #include "common/maths.h"
 
+#include "config/parameter_group.h"
+
 #include "system.h"
 #include "nvic.h"
 #include "gpio.h"

--- a/src/main/drivers/pwm_mapping.c
+++ b/src/main/drivers/pwm_mapping.c
@@ -22,6 +22,8 @@
 
 #include <platform.h>
 
+#include "config/parameter_group.h"
+
 #include "gpio.h"
 #include "timer.h"
 #include "drivers/bus_i2c.h"

--- a/src/main/drivers/pwm_rx.c
+++ b/src/main/drivers/pwm_rx.c
@@ -26,6 +26,8 @@
 
 #include "common/utils.h"
 
+#include "config/parameter_group.h"
+
 #include "system.h"
 
 #include "nvic.h"
@@ -49,8 +51,6 @@
 
 // TODO - change to timer clocks ticks
 #define INPUT_FILTER_TO_HELP_WITH_NOISE_FROM_OPENLRS_TELEMETRY_RX 0x03
-
-pwmRxConfig_t pwmRxConfig;
 
 void pwmICConfig(TIM_TypeDef *tim, uint8_t channel, uint16_t polarity);
 

--- a/src/main/drivers/pwm_rx.h
+++ b/src/main/drivers/pwm_rx.h
@@ -26,7 +26,7 @@ typedef struct pwmRxConfig_s {
     inputFilteringMode_e inputFilteringMode;  // Use hardware input filtering, e.g. for OrangeRX PPM/PWM receivers.
 } pwmRxConfig_t;
 
-extern pwmRxConfig_t pwmRxConfig;
+PG_DECLARE(pwmRxConfig_t, pwmRxConfig);
 
 #define PPM_RCVR_TIMEOUT            0
 

--- a/src/main/flight/altitudehold.c
+++ b/src/main/flight/altitudehold.c
@@ -29,6 +29,9 @@
 #include "common/maths.h"
 #include "common/axis.h"
 
+#include "config/runtime_config.h"
+#include "config/parameter_group.h"
+
 #include "drivers/sensor.h"
 #include "drivers/accgyro.h"
 #include "drivers/sonar_hcsr04.h"
@@ -46,8 +49,6 @@
 #include "flight/mixer.h"
 #include "flight/pid.h"
 #include "flight/imu.h"
-
-#include "config/runtime_config.h"
 
 int32_t setVelocity = 0;
 uint8_t velocityControl = 0;

--- a/src/main/flight/failsafe.c
+++ b/src/main/flight/failsafe.c
@@ -53,16 +53,7 @@
 
 static failsafeState_t failsafeState;
 
-failsafeConfig_t failsafeConfig;
-
-static const pgRegistry_t failsafeConfigRegistry PG_REGISTRY_SECTION =
-{
-    .base = (uint8_t *)&failsafeConfig,
-    .size = sizeof(failsafeConfig),
-    .pgn = PG_FAILSAFE_CONFIG,
-    .format = 0,
-    .flags = PGC_SYSTEM
-};
+PG_REGISTER(failsafeConfig_t, failsafeConfig, PG_FAILSAFE_CONFIG, 0);
 
 static rxConfig_t *rxConfig;
 

--- a/src/main/flight/failsafe.h
+++ b/src/main/flight/failsafe.h
@@ -70,7 +70,8 @@ typedef struct failsafeState_s {
     failsafeRxLinkState_e rxLinkState;
 } failsafeState_t;
 
-extern failsafeConfig_t failsafeConfig;
+PG_DECLARE(failsafeConfig_t, failsafeConfig);
+
 void useFailsafeConfig();
 
 void failsafeStartMonitoring(void);

--- a/src/main/flight/gtune.c
+++ b/src/main/flight/gtune.c
@@ -24,11 +24,15 @@
 
 #ifdef GTUNE
 
+#include "build_config.h"
+
 #include "common/axis.h"
 #include "common/maths.h"
 
 #include "config/parameter_group.h"
 #include "config/parameter_group_ids.h"
+#include "config/runtime_config.h"
+#include "config/config.h"
 
 #include "drivers/system.h"
 #include "drivers/sensor.h"
@@ -41,12 +45,9 @@
 #include "flight/pid.h"
 #include "flight/imu.h"
 
-#include "config/config.h"
 #include "blackbox/blackbox.h"
 
 #include "io/rc_controls.h"
-
-#include "config/runtime_config.h"
 
 #include "gtune.h"
 
@@ -95,18 +96,7 @@ extern uint8_t motorCount;
     pidProfile->gtune_average_cycles = 16;  [8..128] Number of looptime cycles used for gyro average calculation
 */
 
-gtuneConfig_t gtuneConfigStorage[MAX_PROFILE_COUNT];
-gtuneConfig_t *gtuneConfig;
-
-static const pgRegistry_t gtuneConfigRegistry PG_REGISTRY_SECTION =
-{
-    .base = (uint8_t *)&gtuneConfigStorage,
-    .ptr = (uint8_t **)&gtuneConfig,
-    .size = sizeof(gtuneConfigStorage[0]),
-    .pgn = PG_GTUNE_CONFIG,
-    .format = 0,
-    .flags = PGC_PROFILE
-};
+PG_REGISTER_PROFILE(gtuneConfig_t, gtuneConfig, PG_GTUNE_CONFIG, 0);
 
 static int16_t delay_cycles;
 static int16_t time_skip[3];

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -30,6 +30,9 @@
 #include "common/axis.h"
 #include "common/filter.h"
 
+#include "config/runtime_config.h"
+#include "config/parameter_group.h"
+
 #include "drivers/system.h"
 #include "drivers/sensor.h"
 #include "drivers/accgyro.h"
@@ -47,8 +50,6 @@
 #include "flight/imu.h"
 
 #include "io/gps.h"
-
-#include "config/runtime_config.h"
 
 // the limit (in degrees/second) beyond which we stop integrating
 // omega_I. At larger spin rates the DCM PI controller can get 'dizzy'

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -73,15 +73,9 @@ static rxConfig_t *rxConfig;
 
 static mixerMode_e currentMixerMode;
 
-motorMixer_t customMotorMixer[MAX_SUPPORTED_MOTORS];
 static motorMixer_t currentMixer[MAX_SUPPORTED_MOTORS];
 
-static const pgRegistry_t motorMixerRegistry PG_REGISTRY_SECTION = {
-    .base = (uint8_t *)&customMotorMixer,
-    .size = sizeof(customMotorMixer),
-    .pgn = PG_MOTOR_MIXER,
-    .flags = PGC_SYSTEM
-};
+PG_REGISTER_ARR(motorMixer_t, MAX_SUPPORTED_MOTORS, customMotorMixer, PG_MOTOR_MIXER, 0);
 
 #ifdef USE_SERVOS
 static uint8_t servoRuleCount = 0;

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -32,6 +32,11 @@
 #include "common/maths.h"
 #include "common/filter.h"
 
+#include "config/runtime_config.h"
+#include "config/config_unittest.h"
+#include "config/parameter_group.h"
+#include "config/config.h"
+
 #include "drivers/sensor.h"
 #include "drivers/accgyro.h"
 #include "drivers/gyro_sync.h"
@@ -50,10 +55,6 @@
 #include "flight/navigation.h"
 #include "flight/gtune.h"
 #include "flight/mixer.h"
-
-#include "config/runtime_config.h"
-#include "config/config_unittest.h"
-#include "config/config.h"
 
 extern uint8_t motorCount;
 extern float dT;
@@ -80,19 +81,7 @@ typedef void (*pidControllerFuncPtr)( controlRateConfig_t *controlRateConfig,
 
 pidControllerFuncPtr pid_controller = pidMultiWiiRewrite; // which pid controller are we using
 
-pidProfile_t pidProfileStorage[MAX_PROFILE_COUNT];
-pidProfile_t *pidProfile;
-
-static const pgRegistry_t pidProfileRegistry PG_REGISTRY_SECTION =
-{
-    .base = (uint8_t *)&pidProfileStorage,
-    .ptr = (uint8_t **)&pidProfile,
-    .size = sizeof(pidProfileStorage[0]),
-    .pgn = PG_PID_PROFILE,
-    .format = 0,
-    .flags = PGC_PROFILE
-};
-
+PG_REGISTER_PROFILE(pidProfile_t,  pidProfile, PG_PID_PROFILE, 0);
 
 void pidResetErrorAngle(void)
 {

--- a/src/main/io/beeper.c
+++ b/src/main/io/beeper.c
@@ -22,6 +22,10 @@
 #include <platform.h>
 #include "build_config.h"
 
+#include "config/runtime_config.h"
+#include "config/config.h"
+#include "config/parameter_group.h"
+
 #include "io/rc_controls.h"
 
 #include "drivers/gpio.h"
@@ -35,10 +39,6 @@
 #ifdef GPS
 #include "io/gps.h"
 #endif
-
-#include "config/runtime_config.h"
-#include "config/config.h"
-
 
 #include "io/beeper.h"
 

--- a/src/main/io/escservo.c
+++ b/src/main/io/escservo.c
@@ -29,14 +29,5 @@
 
 #include "escservo.h"
 
-escAndServoConfig_t escAndServoConfig;
-
-static const pgRegistry_t escAndServoConfigRegistry PG_REGISTRY_SECTION =
-{
-    .base = (uint8_t *)&escAndServoConfig,
-    .size = sizeof(escAndServoConfig),
-    .pgn = PG_ESC_AND_SERVO_CONFIG,
-    .format = 0,
-    .flags = PGC_SYSTEM
-};
+PG_REGISTER(escAndServoConfig_t, escAndServoConfig, PG_ESC_AND_SERVO_CONFIG, 0);
 

--- a/src/main/io/escservo.h
+++ b/src/main/io/escservo.h
@@ -29,4 +29,4 @@ typedef struct escAndServoConfig_s {
     uint16_t servo_pwm_rate;                // The update rate of servo outputs (50-498Hz)
 } escAndServoConfig_t;
 
-extern escAndServoConfig_t escAndServoConfig;
+PG_DECLARE(escAndServoConfig_t, escAndServoConfig);

--- a/src/main/io/gimbal.c
+++ b/src/main/io/gimbal.c
@@ -19,6 +19,7 @@
 #include <stdint.h>
 
 #include <platform.h>
+#include "build_config.h"
 
 #include "debug.h"
 
@@ -31,16 +32,6 @@
 
 #ifdef USE_SERVOS
 
-gimbalConfig_t gimbalConfigStorage[MAX_PROFILE_COUNT];
-gimbalConfig_t *gimbalConfig;
+PG_REGISTER_PROFILE(gimbalConfig_t, gimbalConfig, PG_GIMBAL_CONFIG, 0);
 
-static const pgRegistry_t gimbalConfigRegistry PG_REGISTRY_SECTION =
-{
-    .base = (uint8_t *)&gimbalConfigStorage,
-    .ptr = (uint8_t **)&gimbalConfig,
-    .size = sizeof(gimbalConfigStorage[0]),
-    .pgn = PG_GIMBAL_CONFIG,
-    .format = 0,
-    .flags = PGC_PROFILE
-};
 #endif

--- a/src/main/io/gimbal.h
+++ b/src/main/io/gimbal.h
@@ -28,4 +28,4 @@ typedef struct gimbalConfig_s {
     uint8_t mode;
 } gimbalConfig_t;
 
-extern gimbalConfig_t *gimbalConfig;
+PG_DECLARE_PROFILE(gimbalConfig_t, gimbalConfig);

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -30,6 +30,10 @@
 #include "common/axis.h"
 #include "common/utils.h"
 
+#include "config/parameter_group.h"
+#include "config/config.h"
+#include "config/runtime_config.h"
+
 #include "drivers/system.h"
 #include "drivers/serial.h"
 #include "drivers/serial_uart.h"
@@ -45,9 +49,6 @@
 #include "flight/gps_conversion.h"
 #include "flight/pid.h"
 #include "flight/navigation.h"
-
-#include "config/config.h"
-#include "config/runtime_config.h"
 
 
 #ifdef GPS

--- a/src/main/io/rc_controls.c
+++ b/src/main/io/rc_controls.c
@@ -63,23 +63,8 @@
 
 #define AIRMODE_DEADBAND 12
 
-controlRateConfig_t controlRateProfiles[MAX_CONTROL_RATE_PROFILE_COUNT];
-
-static const pgRegistry_t controlRateProfilesRegistry PG_REGISTRY_SECTION = {
-    .base = (uint8_t *)&controlRateProfiles,
-    .size = sizeof(controlRateProfiles),
-    .pgn = PG_CONTROL_RATE_PROFILES,
-    .flags = PGC_SYSTEM
-};
-
-armingConfig_t armingConfig;
-
-static const pgRegistry_t armingConfigRegistry PG_REGISTRY_SECTION = {
-    .base = (uint8_t *)&armingConfig,
-    .size = sizeof(armingConfig),
-    .pgn = PG_ARMING_CONFIG,
-    .flags = PGC_SYSTEM
-};
+PG_REGISTER_ARR(controlRateConfig_t, MAX_CONTROL_RATE_PROFILE_COUNT, controlRateProfiles, PG_CONTROL_RATE_PROFILES, 0);
+PG_REGISTER(armingConfig_t, armingConfig, PG_ARMING_CONFIG, 0);
 
 // true if arming is done via the sticks (as opposed to a switch)
 static bool isUsingSticksToArm = true;

--- a/src/main/io/rc_controls.h
+++ b/src/main/io/rc_controls.h
@@ -143,7 +143,7 @@ typedef struct controlRateConfig_s {
 } controlRateConfig_t;
 
 #define MAX_CONTROL_RATE_PROFILE_COUNT 3
-extern controlRateConfig_t controlRateProfiles[MAX_CONTROL_RATE_PROFILE_COUNT];
+PG_DECLARE_ARR(controlRateConfig_t, MAX_CONTROL_RATE_PROFILE_COUNT, controlRateProfiles);
 
 extern int16_t rcCommand[4];
 
@@ -162,7 +162,7 @@ typedef struct armingConfig_s {
     uint8_t max_arm_angle;                  // specifies the maximum angle allow arming at.
 } armingConfig_t;
 
-extern armingConfig_t armingConfig;
+PG_DECLARE(armingConfig_t, armingConfig);
 
 bool areUsingSticksToArm(void);
 

--- a/src/main/io/rc_curves.c
+++ b/src/main/io/rc_curves.c
@@ -18,6 +18,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "config/parameter_group.h"
+
 #include "rx/rx.h"
 #include "io/rc_controls.h"
 #include "io/escservo.h"

--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -48,21 +48,13 @@
 #include "serial_msp.h"
 
 #include "config/config.h"
+#include "config/parameter_group.h"
 
 #ifdef TELEMETRY
 #include "telemetry/telemetry.h"
 #endif
 
-serialConfig_t serialConfig;
-
-static const pgRegistry_t serialConfigRegistry PG_REGISTRY_SECTION =
-{
-    .base = (uint8_t *)&serialConfig,
-    .size = sizeof(serialConfig),
-    .pgn = PG_SERIAL_CONFIG,
-    .format = 0,
-    .flags = PGC_SYSTEM
-};
+PG_REGISTER(serialConfig_t, serialConfig, PG_SERIAL_CONFIG, 0);
 
 static serialPortUsage_t serialPortUsageList[SERIAL_PORT_COUNT];
 

--- a/src/main/io/transponder_ir.c
+++ b/src/main/io/transponder_ir.c
@@ -39,16 +39,7 @@
 static bool transponderInitialised = false;
 static bool transponderRepeat = false;
 
-transponderConfig_t transponderConfig;
-
-static const pgRegistry_t transponderConfigRegistry PG_REGISTRY_SECTION =
-{
-    .base = (uint8_t *)&transponderConfig,
-    .size = sizeof(transponderConfig),
-    .pgn = PG_TRANSPONDER_CONFIG,
-    .format = 0,
-    .flags = PGC_SYSTEM
-};
+PG_REGISTER(transponderConfig_t, transponderConfig, PG_TRANSPONDER_CONFIG, 0);
 
 // timers
 static uint32_t nextUpdateAt = 0;

--- a/src/main/rx/ibus.c
+++ b/src/main/rx/ibus.c
@@ -29,6 +29,8 @@
 
 #include "build_config.h"
 
+#include "config/parameter_group.h"
+
 #include "drivers/system.h"
 
 #include "drivers/serial.h"

--- a/src/main/rx/msp.c
+++ b/src/main/rx/msp.c
@@ -22,6 +22,8 @@
 
 #include "build_config.h"
 
+#include "config/parameter_group.h"
+
 #include "drivers/system.h"
 
 #include "drivers/serial.h"

--- a/src/main/rx/pwm.c
+++ b/src/main/rx/pwm.c
@@ -25,11 +25,15 @@
 
 #include <platform.h>
 
+#include "config/config.h"
+#include "config/parameter_group.h"
+
 #include "drivers/gpio.h"
 #include "drivers/timer.h"
 #include "drivers/pwm_rx.h"
 
 #include "config/config.h"
+#include "config/parameter_group.h"
 
 #include "rx/rx.h"
 #include "rx/pwm.h"

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -134,7 +134,7 @@ typedef struct rxRuntimeConfig_s {
     uint8_t channelCount;                  // number of rc channels as reported by current input driver
 } rxRuntimeConfig_t;
 
-extern rxRuntimeConfig_t rxRuntimeConfig;
+PG_DECLARE(rxRuntimeConfig_t,rxRuntimeConfig);
 
 void useRxConfig(rxConfig_t *rxConfigToUse);
 

--- a/src/main/rx/sbus.c
+++ b/src/main/rx/sbus.c
@@ -23,6 +23,8 @@
 
 #include "build_config.h"
 
+#include "config/parameter_group.h"
+
 #include "drivers/system.h"
 
 #include "drivers/gpio.h"

--- a/src/main/rx/spektrum.c
+++ b/src/main/rx/spektrum.c
@@ -22,6 +22,9 @@
 #include <platform.h>
 #include "debug.h"
 
+#include "config/parameter_group.h"
+#include "config/config.h"
+
 #include "drivers/gpio.h"
 #include "drivers/system.h"
 
@@ -30,8 +33,6 @@
 #include "drivers/serial.h"
 #include "drivers/serial_uart.h"
 #include "io/serial.h"
-
-#include "config/config.h"
 
 #include "rx/rx.h"
 #include "rx/spektrum.h"

--- a/src/main/rx/sumd.c
+++ b/src/main/rx/sumd.c
@@ -23,6 +23,8 @@
 
 #include "build_config.h"
 
+#include "config/parameter_group.h"
+
 #include "drivers/system.h"
 
 #include "drivers/serial.h"

--- a/src/main/rx/sumh.c
+++ b/src/main/rx/sumh.c
@@ -29,6 +29,8 @@
 
 #include "build_config.h"
 
+#include "config/parameter_group.h"
+
 #include "drivers/system.h"
 
 #include "drivers/serial.h"

--- a/src/main/rx/xbus.c
+++ b/src/main/rx/xbus.c
@@ -21,6 +21,8 @@
 
 #include <platform.h>
 
+#include "config/parameter_group.h"
+
 #include "drivers/system.h"
 
 #include "drivers/serial.h"

--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -53,16 +53,7 @@ uint16_t amperageLatestADC = 0;     // most recent raw reading from current ADC
 int32_t amperage = 0;               // amperage read by current sensor in centiampere (1/100th A)
 int32_t mAhDrawn = 0;               // milliampere hours drawn from the battery since start
 
-batteryConfig_t batteryConfig;
-
-static const pgRegistry_t batteryRegistry PG_REGISTRY_SECTION =
-{
-    .base = (uint8_t *)&batteryConfig,
-    .size = sizeof(batteryConfig),
-    .pgn = PG_BATTERY_CONFIG,
-    .format = 0,
-    .flags = PGC_SYSTEM
-};
+PG_REGISTER(batteryConfig_t, batteryConfig, PG_BATTERY_CONFIG, 0);
 
 static batteryState_e batteryState;
 static biquad_t vbatFilterState;

--- a/src/main/sensors/battery.h
+++ b/src/main/sensors/battery.h
@@ -47,7 +47,7 @@ typedef struct batteryConfig_s {
     uint16_t batteryCapacity;               // mAh
 } batteryConfig_t;
 
-extern batteryConfig_t batteryConfig;
+PG_DECLARE(batteryConfig_t, batteryConfig);
 
 typedef enum {
     BATTERY_OK = 0,

--- a/src/main/sensors/boardalignment.c
+++ b/src/main/sensors/boardalignment.c
@@ -30,16 +30,7 @@
 
 #include "boardalignment.h"
 
-boardAlignment_t boardAlignment;
-
-static const pgRegistry_t boardAlignmentRegistry PG_REGISTRY_SECTION =
-{
-    .base = (uint8_t *)&boardAlignment,
-    .size = sizeof(boardAlignment),
-    .pgn = PG_BOARD_ALIGNMENT,
-    .format = 0,
-    .flags = PGC_SYSTEM
-};
+PG_REGISTER(boardAlignment_t, boardAlignment, PG_BOARD_ALIGNMENT, 1);
 
 static bool standardBoardAlignment = true;     // board orientation correction
 static float boardRotation[3][3];              // matrix

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -51,17 +51,8 @@ static bool gyroFilterStateIsSet;
 int axis;
 
 gyro_t gyro;                      // gyro access functions
-gyroConfig_t gyroConfig;
+PG_REGISTER(gyroConfig_t, gyroConfig, PG_GYRO_CONFIG, 0);
 sensor_align_e gyroAlign = 0;
-
-static const pgRegistry_t gyroConfigRegistry PG_REGISTRY_SECTION =
-{
-    .base = (uint8_t *)&gyroConfig,
-    .size = sizeof(gyroConfig),
-    .pgn = PG_GYRO_CONFIG,
-    .format = 0,
-    .flags = PGC_SYSTEM
-};
 
 void initGyroFilterCoefficients(void) {
     if (gyroConfig.soft_gyro_lpf_hz) {

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -41,7 +41,7 @@ typedef struct gyroConfig_s {
     float soft_gyro_lpf_hz;                 // Software based gyro filter in hz
 } gyroConfig_t;
 
-extern gyroConfig_t gyroConfig;
+PG_DECLARE(gyroConfig_t, gyroConfig);
 
 void gyroSetCalibrationCycles(uint16_t calibrationCyclesRequired);
 void gyroUpdate(void);

--- a/src/main/sensors/initialisation.c
+++ b/src/main/sensors/initialisation.c
@@ -59,6 +59,7 @@
 #include "drivers/sonar_hcsr04.h"
 
 #include "config/runtime_config.h"
+#include "config/parameter_group.h"
 
 #include "sensors/sensors.h"
 #include "sensors/acceleration.h"

--- a/src/main/sensors/sensors.c
+++ b/src/main/sensors/sensors.c
@@ -29,33 +29,6 @@
 
 #include "sensors/sensors.h"
 
-sensorSelectionConfig_t sensorSelectionConfig;
-sensorAlignmentConfig_t sensorAlignmentConfig;
-sensorTrims_t sensorTrims;
-
-static const pgRegistry_t sensorSelectionConfigRegistry PG_REGISTRY_SECTION =
-{
-    .base = (uint8_t *)&sensorSelectionConfig,
-    .size = sizeof(sensorSelectionConfig),
-    .pgn = PG_SENSOR_SELECTION_CONFIG,
-    .format = 0,
-    .flags = PGC_SYSTEM
-};
-
-static const pgRegistry_t sensorAlignmentConfigRegistry PG_REGISTRY_SECTION =
-{
-    .base = (uint8_t *)&sensorAlignmentConfig,
-    .size = sizeof(sensorAlignmentConfig),
-    .pgn = PG_SENSOR_ALIGNMENT_CONFIG,
-    .format = 0,
-    .flags = PGC_SYSTEM
-};
-
-static const pgRegistry_t sensorTrimsRegistry PG_REGISTRY_SECTION =
-{
-    .base = (uint8_t *)&sensorTrims,
-    .size = sizeof(sensorTrims),
-    .pgn = PG_SENSOR_TRIMS,
-    .format = 0,
-    .flags = PGC_SYSTEM
-};
+PG_REGISTER(sensorSelectionConfig_t, sensorSelectionConfig, PG_SENSOR_SELECTION_CONFIG, 0);
+PG_REGISTER(sensorAlignmentConfig_t, sensorAlignmentConfig, PG_SENSOR_ALIGNMENT_CONFIG, 0);
+PG_REGISTER(sensorTrims_t, sensorTrims, PG_SENSOR_TRIMS, 0);

--- a/src/main/sensors/sensors.h
+++ b/src/main/sensors/sensors.h
@@ -82,8 +82,7 @@ typedef struct sensorTrims_s {
     flightDynamicsTrims_t magZero;
 } sensorTrims_t;
 
-extern sensorSelectionConfig_t sensorSelectionConfig;
-extern sensorAlignmentConfig_t sensorAlignmentConfig;
-extern sensorTrims_t sensorTrims;
-
+PG_DECLARE(sensorSelectionConfig_t, sensorSelectionConfig);
+PG_DECLARE(sensorAlignmentConfig_t, sensorAlignmentConfig);
+PG_DECLARE(sensorTrims_t, sensorTrims);
 

--- a/src/main/sensors/sonar.c
+++ b/src/main/sensors/sonar.c
@@ -25,10 +25,12 @@
 #include "common/maths.h"
 #include "common/axis.h"
 
-#include "drivers/sonar_hcsr04.h"
-#include "drivers/gpio.h"
 #include "config/runtime_config.h"
 #include "config/config.h"
+#include "config/parameter_group.h"
+
+#include "drivers/sonar_hcsr04.h"
+#include "drivers/gpio.h"
 
 #include "io/rc_controls.h"
 

--- a/src/main/target/stm32_flash.ld
+++ b/src/main/target/stm32_flash.ld
@@ -84,10 +84,10 @@ SECTIONS
   } >FLASH
   .pg_registry :
   {
-    PROVIDE_HIDDEN (__pg_registry = .);
+    PROVIDE_HIDDEN (__pg_registry_start = .);
     KEEP (*(.pg_registry))
     KEEP (*(SORT(.pg_registry.*)))
-    KEEP (*(.pg_registry_tail))
+    PROVIDE_HIDDEN (__pg_registry_end = .);
   } >FLASH
 
   /* used by the startup to initialize data */

--- a/src/main/telemetry/frsky.c
+++ b/src/main/telemetry/frsky.c
@@ -30,6 +30,10 @@
 #include "common/maths.h"
 #include "common/axis.h"
 
+#include "config/parameter_group.h"
+#include "config/runtime_config.h"
+#include "config/config.h"
+
 #include "drivers/system.h"
 #include "drivers/sensor.h"
 #include "drivers/accgyro.h"
@@ -52,9 +56,6 @@
 #include "flight/pid.h"
 #include "flight/imu.h"
 #include "flight/altitudehold.h"
-
-#include "config/runtime_config.h"
-#include "config/config.h"
 
 #include "telemetry/telemetry.h"
 #include "telemetry/frsky.h"

--- a/src/main/telemetry/hott.c
+++ b/src/main/telemetry/hott.c
@@ -64,13 +64,14 @@
 
 #include "common/axis.h"
 
+#include "config/runtime_config.h"
+#include "config/parameter_group.h"
+
 #include "drivers/system.h"
 
 #include "drivers/serial.h"
 #include "io/serial.h"
 #include "io/rc_controls.h"
-
-#include "config/runtime_config.h"
 
 #include "sensors/sensors.h"
 #include "sensors/battery.h"

--- a/src/main/telemetry/telemetry.c
+++ b/src/main/telemetry/telemetry.c
@@ -23,6 +23,10 @@
 
 #ifdef TELEMETRY
 
+#include "config/runtime_config.h"
+#include "config/config.h"
+#include "config/parameter_group.h"
+
 #include "drivers/gpio.h"
 #include "drivers/timer.h"
 #include "drivers/serial.h"
@@ -31,9 +35,6 @@
 
 #include "rx/rx.h"
 #include "io/rc_controls.h"
-
-#include "config/runtime_config.h"
-#include "config/config.h"
 
 #include "telemetry/telemetry.h"
 #include "telemetry/frsky.h"

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -667,7 +667,7 @@ $(OBJECT_DIR)/serial_msp_unittest : \
 	$(OBJECT_DIR)/serial_msp_unittest.o \
 	$(OBJECT_DIR)/gtest_main.a
 
-	$(CXX) $(CXX_FLAGS) $^ -o $(OBJECT_DIR)/$@
+	$(CXX) $(CXX_FLAGS) -Wl,-T,$(TEST_DIR)/parameter_group.ld $^ -o $(OBJECT_DIR)/$@
 
 
 $(OBJECT_DIR)/scheduler_tasks.o : \
@@ -726,7 +726,7 @@ $(OBJECT_DIR)/config_unittest : \
 	$(OBJECT_DIR)/config_unittest.o \
 	$(OBJECT_DIR)/gtest_main.a
 
-	$(CXX) $(CXX_FLAGS) $^ -o $(OBJECT_DIR)/$@
+	$(CXX) $(CXX_FLAGS) -Wl,-T,$(TEST_DIR)/parameter_group.ld $^ -o $(OBJECT_DIR)/$@
 
 $(OBJECT_DIR)/config/config_eeprom.o : \
 	$(USER_DIR)/config/config_eeprom.c \
@@ -778,7 +778,7 @@ $(OBJECT_DIR)/config_eeprom_unittest : \
 	$(OBJECT_DIR)/config_eeprom_unittest.o \
 	$(OBJECT_DIR)/gtest_main.a
 
-	$(CXX) $(CXX_FLAGS) $^ -o $(OBJECT_DIR)/$@
+	$(CXX) $(CXX_FLAGS) -Wl,-T,$(TEST_DIR)/parameter_group.ld -Wl,-Map,$(OBJECT_DIR)/$@.map $^ -o $(OBJECT_DIR)/$@
 
 
 $(OBJECT_DIR)/config/config_streamer.o : \

--- a/src/test/unit/altitude_hold_unittest.cc
+++ b/src/test/unit/altitude_hold_unittest.cc
@@ -32,6 +32,8 @@ extern "C" {
     #include "common/axis.h"
     #include "common/maths.h"
 
+    #include "config/parameter_group.h"
+
     #include "drivers/sensor.h"
     #include "drivers/accgyro.h"
 

--- a/src/test/unit/battery_unittest.cc
+++ b/src/test/unit/battery_unittest.cc
@@ -21,6 +21,8 @@
 //#define DEBUG_BATTERY
 
 extern "C" {
+    #include "config/parameter_group.h"
+
     #include "io/rc_controls.h"
 
     #include "sensors/battery.h"

--- a/src/test/unit/config_eeprom_unittest.cc
+++ b/src/test/unit/config_eeprom_unittest.cc
@@ -98,42 +98,7 @@ extern "C" {
 #include "unittest_macros.h"
 #include "gtest/gtest.h"
 
-
-const pgRegistry_t __pg_registry[] =
-{
-    {
-        .base = (uint8_t *)&masterConfig,
-        .ptr = 0,
-        .size = sizeof(masterConfig),
-        .pgn = PG_MASTER,
-        .format = 0,
-        .flags = PGC_SYSTEM
-    },
-    {
-        .base = (uint8_t *)&profileStorage,
-        .ptr = (uint8_t **)&currentProfile,
-        .size = sizeof(profileStorage[0]),
-        .pgn = PG_PROFILE,
-        .format = 0,
-        .flags = PGC_PROFILE
-    },
-    {
-        .base = (uint8_t *)&someProfileSpecificDataStorage,
-        .ptr = (uint8_t **)&someProfileSpecificData,
-        .size = sizeof(someProfileSpecificDataStorage[0]),
-        .pgn = 1,
-        .format = 0,
-        .flags = PGC_PROFILE
-    },
-    {
-        .base = nullptr,
-        .ptr = 0,
-        .size = 0,
-        .pgn = 0,
-        .format = 0,
-        .flags = 0
-    },
-};
+PG_REGISTER(masterConfig, 0, 0);
 
 TEST(configTest, resetEEPROM)
 {

--- a/src/test/unit/config_eeprom_unittest.cc
+++ b/src/test/unit/config_eeprom_unittest.cc
@@ -20,7 +20,8 @@
 
 extern "C" {
     #include "platform.h"
-
+    #include "build_config.h"
+    
     #include "common/axis.h"
     #include "common/maths.h"
     #include "common/color.h"
@@ -62,15 +63,12 @@ extern "C" {
     #include "config/config_eeprom.h"
     #include "config/config_profile.h"
     #include "config/config_master.h"
+    #include "config/parameter_group_ids.h"
 
     #include "platform.h"
 
-    failsafeConfig_t failsafeConfig;
-
-    extern profile_t profileStorage[MAX_PROFILE_COUNT];
-
-    gimbalConfig_t testGimbalConfig[MAX_PROFILE_COUNT];
-    gimbalConfig_t *gimbalConfig = &testGimbalConfig[0];
+    PG_REGISTER(failsafeConfig_t, failsafeConfig, PG_FAILSAFE_CONFIG, 0);
+    PG_REGISTER_PROFILE(gimbalConfig_t, gimbalConfig, PG_GIMBAL_CONFIG, 0);
 
     pidProfile_t testPidProfile[MAX_PROFILE_COUNT];
     pidProfile_t *pidProfile = &testPidProfile[0];
@@ -81,24 +79,24 @@ extern "C" {
         uint32_t uint32;
     } PG_PACKED someProfileSpecificData_t;
 
-    someProfileSpecificData_t someProfileSpecificDataStorage[MAX_PROFILE_COUNT];
-    someProfileSpecificData_t *someProfileSpecificData;
+    PG_REGISTER_PROFILE(someProfileSpecificData_t, someProfileSpecificData, 1, 0);
 
-    escAndServoConfig_t escAndServoConfig;
-    gyroConfig_t gyroConfig;
-    sensorTrims_t sensorTrims;
-    batteryConfig_t batteryConfig;
-    controlRateConfig_t controlRateProfiles[MAX_CONTROL_RATE_PROFILE_COUNT];
-    serialConfig_t serialConfig;
-    pwmRxConfig_t pwmRxConfig;
-    armingConfig_t armingConfig;
-    transponderConfig_t transponderConfig;
+    PG_REGISTER(escAndServoConfig_t, escAndServoConfig, PG_ESC_AND_SERVO_CONFIG, 0);
+    PG_REGISTER(gyroConfig_t, gyroConfig, PG_GYRO_CONFIG, 0);
+    PG_REGISTER(sensorTrims_t, sensorTrims, PG_SENSOR_TRIMS, 0);
+    PG_REGISTER(batteryConfig_t, batteryConfig, PG_BATTERY_CONFIG, 0);
+    PG_REGISTER_ARR(controlRateConfig_t, MAX_CONTROL_RATE_PROFILE_COUNT, controlRateProfiles, PG_CONTROL_RATE_PROFILES, 0);
+    PG_REGISTER(serialConfig_t, serialConfig, PG_SERIAL_CONFIG, 0);
+    PG_REGISTER(pwmRxConfig_t, pwmRxConfig, PG_DRIVER_PWM_RX_CONFIG, 0);
+    PG_REGISTER(armingConfig_t, armingConfig, PG_ARMING_CONFIG, 0);
+    PG_REGISTER(transponderConfig_t, transponderConfig, PG_TRANSPONDER_CONFIG, 0);
+    
+    PG_REGISTER(master_t, masterConfig, 0, 0);
 }
 
 #include "unittest_macros.h"
 #include "gtest/gtest.h"
 
-PG_REGISTER(masterConfig, 0, 0);
 
 TEST(configTest, resetEEPROM)
 {

--- a/src/test/unit/flight_imu_unittest.cc
+++ b/src/test/unit/flight_imu_unittest.cc
@@ -29,6 +29,8 @@ extern "C" {
     #include "common/axis.h"
     #include "common/maths.h"
 
+    #include "config/parameter_group.h"
+
     #include "sensors/sensors.h"
 
     #include "drivers/sensor.h"

--- a/src/test/unit/flight_mixer_unittest.cc
+++ b/src/test/unit/flight_mixer_unittest.cc
@@ -29,6 +29,8 @@ extern "C" {
     #include "common/maths.h"
     #include "common/filter.h"
 
+    #include "config/parameter_group.h"
+
     #include "drivers/sensor.h"
     #include "drivers/accgyro.h"
     #include "drivers/pwm_mapping.h"

--- a/src/test/unit/ledstrip_unittest.cc
+++ b/src/test/unit/ledstrip_unittest.cc
@@ -27,11 +27,13 @@ extern "C" {
     #include "common/color.h"
     #include "common/axis.h"
 
+    #include "config/parameter_group.h"
+    #include "config/runtime_config.h"
+    #include "config/config.h"
+
     #include "io/rc_controls.h"
 
     #include "sensors/battery.h"
-    #include "config/runtime_config.h"
-    #include "config/config.h"
 
     #include "drivers/light_ws2811strip.h"
     #include "io/ledstrip.h"

--- a/src/test/unit/parameter_group.ld
+++ b/src/test/unit/parameter_group.ld
@@ -1,0 +1,16 @@
+
+SECTIONS {
+  /* BLOCK: on Windows (PE) output section must be page-aligned. Use 4-byte alignment otherwise */
+  /* SUBALIGN: force 4-byte alignment of input sections for pg_registry.
+     Gcc defaults to 32 bytes; padding is then inserted between object files, breaking the init structure. */
+  .pg_registry BLOCK( DEFINED(__section_alignment__) ? __section_alignment__ : 4 ) :   SUBALIGN(4)
+  {
+    PROVIDE_HIDDEN (__pg_registry_start = . );
+    PROVIDE_HIDDEN (___pg_registry_start = . );
+    KEEP (*(.pg_registry))
+    KEEP (*(SORT(.pg_registry.*)))
+    PROVIDE_HIDDEN (__pg_registry_end = . );
+    PROVIDE_HIDDEN (___pg_registry_end = . );
+  }
+}
+INSERT AFTER .text;

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -25,6 +25,10 @@ extern "C" {
     #include "common/axis.h"
     #include "common/maths.h"
 
+    #include "config/runtime_config.h"
+    #include "config/config_unittest.h"
+    #include "config/parameter_group.h"
+
     #include "drivers/sensor.h"
     #include "drivers/accgyro.h"
     #include "sensors/sensors.h"
@@ -35,9 +39,6 @@ extern "C" {
 
     #include "flight/pid.h"
     #include "flight/imu.h"
-
-    #include "config/runtime_config.h"
-    #include "config/config_unittest.h"
 
     pidProfile_t testPidProfile;
 }

--- a/src/test/unit/rc_controls_unittest.cc
+++ b/src/test/unit/rc_controls_unittest.cc
@@ -26,6 +26,8 @@ extern "C" {
     #include "common/maths.h"
     #include "common/axis.h"
 
+    #include "config/parameter_group.h"
+
     #include "drivers/sensor.h"
     #include "drivers/accgyro.h"
 

--- a/src/test/unit/rx_ranges_unittest.cc
+++ b/src/test/unit/rx_ranges_unittest.cc
@@ -23,6 +23,8 @@
 extern "C" {
     #include <platform.h>
 
+    #include "config/parameter_group.h"
+
     #include "rx/rx.h"
     #include "io/rc_controls.h"
     #include "common/maths.h"

--- a/src/test/unit/rx_rx_unittest.cc
+++ b/src/test/unit/rx_rx_unittest.cc
@@ -23,6 +23,8 @@
 extern "C" {
     #include <platform.h>
 
+    #include "config/parameter_group.h"
+
     #include "rx/rx.h"
     #include "io/rc_controls.h"
     #include "common/maths.h"

--- a/src/test/unit/serial_msp_unittest.cc
+++ b/src/test/unit/serial_msp_unittest.cc
@@ -104,36 +104,8 @@ extern "C" {
     armingConfig_t armingConfig;
     transponderConfig_t transponderConfig;
 
-    pidProfile_t testPidProfile[MAX_PROFILE_COUNT];
-    pidProfile_t *pidProfile = &testPidProfile[0];
-
-    const pgRegistry_t __pg_registry[] =
-    {
-        {
-            .base = (uint8_t *)&boardAlignment,
-            .ptr = 0,
-            .size = sizeof(boardAlignment),
-            .pgn = PG_BOARD_ALIGNMENT,
-            .format = 0,
-            .flags = PGC_SYSTEM,
-        },
-        {
-            .base = (uint8_t *)&failsafeConfig,
-            .ptr = 0,
-            .size = sizeof(failsafeConfig),
-            .pgn = PG_FAILSAFE_CONFIG,
-            .format = 0,
-            .flags = PGC_SYSTEM,
-        },
-        {
-            .base = nullptr,
-            .ptr = 0,
-            .size = 0,
-            .pgn = 0,
-            .format = 0,
-            .flags = PGC_SYSTEM
-        },
-    };
+    PG_REGISTER(boardAlignment, PG_BOARD_ALIGNMENT, 0);
+    PG_REGISTER(failsafeConfig, PG_FAILSAFE_CONFIG, 0);
 }
 
 profile_t profile;

--- a/src/test/unit/telemetry_hott_unittest.cc
+++ b/src/test/unit/telemetry_hott_unittest.cc
@@ -28,6 +28,9 @@ extern "C" {
 
     #include "common/axis.h"
 
+    #include "config/parameter_group.h"
+    #include "config/runtime_config.h"
+
     #include "drivers/system.h"
     #include "drivers/serial.h"
 
@@ -43,8 +46,6 @@ extern "C" {
 
     #include "flight/pid.h"
     #include "flight/gps_conversion.h"
-
-    #include "config/runtime_config.h"
 }
 
 #include "unittest_macros.h"


### PR DESCRIPTION
- use `__pg_registry_start` and  `__pg_registry_end` to find registered
  config structures
- hide config registration into macro
- use inserted gnu ld section on unittests