### PR TITLE
Fixes to Spektrum serial remote receiver implementation

### DIFF
--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -242,7 +242,7 @@ uint8_t serialRxFrameStatus(rxConfig_t *rxConfig)
     switch (rxConfig->serialrx_provider) {
         case SERIALRX_SPEKTRUM1024:
         case SERIALRX_SPEKTRUM2048:
-            return spektrumFrameStatus();
+            return spektrumFrameStatus(rxConfig, &rxRuntimeConfig);
         case SERIALRX_SBUS:
             return sbusFrameStatus();
         case SERIALRX_SUMD:
@@ -558,12 +558,12 @@ void updateRSSIPWM(void)
     int16_t pwmRssi = 0;
     // Read value of AUX channel as rssi
     pwmRssi = rcData[rxConfig->rssi_channel - 1];
-	
-	// RSSI_Invert option	
+
+	// RSSI_Invert option
 	if (rxConfig->rssi_ppm_invert) {
 	    pwmRssi = ((2000 - pwmRssi) + 1000);
 	}
-	
+
     // Range of rawPwmRssi is [1000;2000]. rssi should be in [0;1023];
     rssi = (uint16_t)((constrain(pwmRssi - 1000, 0, 1000) / 1000.0f) * 1023.0f);
 }

--- a/src/main/rx/spektrum.c
+++ b/src/main/rx/spektrum.c
@@ -47,6 +47,8 @@
 
 #define SPEKTRUM_BAUDRATE 115200
 
+static uint8_t initialPacket = 0;
+static uint8_t frameLoss = 0;
 static uint8_t spek_chan_shift;
 static uint8_t spek_chan_mask;
 static bool rcFrameComplete = false;
@@ -120,7 +122,7 @@ static void spektrumDataReceive(uint16_t c)
 
 static uint32_t spekChannelData[SPEKTRUM_MAX_SUPPORTED_CHANNEL_COUNT];
 
-uint8_t spektrumFrameStatus(void)
+uint8_t spektrumFrameStatus(rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig)
 {
     uint8_t b;
 
@@ -129,6 +131,51 @@ uint8_t spektrumFrameStatus(void)
     }
 
     rcFrameComplete = false;
+
+	//Check for bind type in the first packet after startup. This is provided in the second byte in a data packet from the internal remote.
+    //This packet wont contain any data if the remote was bound using a separate receiver (bound as external remote)
+    if(!initialPacket){
+
+        switch (spekFrame[1]){
+            case 0xb2:       //11MS 2048 DSMX
+                rxConfig->serialrx_provider = SERIALRX_SPEKTRUM2048;
+                saveConfigAndNotify();
+                break;
+            case 0xa2:  //22MS 2048 DSMX
+                rxConfig->serialrx_provider = SERIALRX_SPEKTRUM2048;
+                saveConfigAndNotify();
+                break;
+            case 0x12:  //11MS 2048 DSM2
+                rxConfig->serialrx_provider = SERIALRX_SPEKTRUM2048;
+                saveConfigAndNotify();
+                break;
+            case 0x01:  //22MS 1024 DSM2
+                rxConfig->serialrx_provider = SERIALRX_SPEKTRUM1024;
+                saveConfigAndNotify();
+                break;
+        }
+        //Immediately set the resolution settings so that a reboot isn't required after binding.
+        switch (rxConfig->serialrx_provider) {
+            case SERIALRX_SPEKTRUM2048:
+                // 11 bit frames
+                spek_chan_shift = 3;
+                spek_chan_mask = 0x07;
+                spekHiRes = true;
+                rxRuntimeConfig->channelCount = SPEKTRUM_2048_CHANNEL_COUNT;
+                break;
+            case SERIALRX_SPEKTRUM1024:
+                // 10 bit frames
+                spek_chan_shift = 2;
+                spek_chan_mask = 0x03;
+                spekHiRes = false;
+                rxRuntimeConfig->channelCount = SPEKTRUM_1024_CHANNEL_COUNT;
+                break;
+        }
+
+        initialPacket=1;    //prevent this byte from being read every packet. It's only necessary to determine bind type at startup.
+    }
+
+    frameLoss = spekFrame[0];   //fades (or frame loss if single sat rx) is provided in the first byte of a sat rx packet
 
     for (b = 3; b < SPEK_FRAME_SIZE; b += 2) {
         uint8_t spekChannel = 0x0F & (spekFrame[b - 1] >> spek_chan_shift);
@@ -149,9 +196,9 @@ static uint16_t spektrumReadRawRC(rxRuntimeConfig_t *rxRuntimeConfig, uint8_t ch
     }
 
     if (spekHiRes)
-        data = 988 + (spekChannelData[chan] >> 1);   // 2048 mode
+        data = 903 + (spekChannelData[chan]*.583);      // 2048 mode
     else
-        data = 988 + spekChannelData[chan];          // 1024 mode
+        data = 903 + (spekChannelData[chan]*1.166);     // 1024 mode
 
     return data;
 }

--- a/src/main/rx/spektrum.h
+++ b/src/main/rx/spektrum.h
@@ -20,5 +20,5 @@
 #define SPEKTRUM_SAT_BIND_DISABLED 0
 #define SPEKTRUM_SAT_BIND_MAX 10
 
-uint8_t spektrumFrameStatus(void);
+uint8_t spektrumFrameStatus(rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig);
 bool spektrumInit(rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig, rcReadRawDataPtr *callback);


### PR DESCRIPTION
These are some fixes and additions we've made to the current implementation of Spektrum serial receivers.

Data scaling modified to match intended PWM channel value. This will provide consistency in channel output values between spektrum receivers using serial, PPM, or PWM to send channel data to the flight controller. This should also an increase resolution and will  cause an increase in travel (People currently using 150% travel on cleanflight with a spektrum transmitter should reduce to 125%).

Antenna fade data is now read from remote receivers and is stored in variable "frameLoss". Currently there is nothing being done with this data, but it can be made available for things such as telemetry.

Bind type is now read from remote receivers if bound as an "internal" receiver (bound through either autobind or bound from flight controller). If so, the bind type is read and the resolution setting will automatically be set to 1024 or 2048.