### PR TITLE
Remove PG_REGISTRY_TAIL_SECTION from configuration storage

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -96,8 +96,6 @@ static uint32_t activeFeaturesLatch = 0;
 static uint8_t currentControlRateProfileIndex = 0;
 controlRateConfig_t *currentControlRateProfile;
 
-static const void *pg_registry_tail PG_REGISTRY_TAIL_SECTION;
-
 static const pgRegistry_t masterRegistry PG_REGISTRY_SECTION = {
     .base = (uint8_t *)&masterConfig,
     .size = sizeof(masterConfig),

--- a/src/main/config/parameter_group.h
+++ b/src/main/config/parameter_group.h
@@ -48,15 +48,15 @@ typedef struct pgRegistry_s {
 } pgRegistry_t;
 
 #define PG_REGISTRY_SECTION __attribute__((section(".pg_registry"), used))
-#define PG_REGISTRY_TAIL_SECTION __attribute__((section(".pg_registry_tail"), used))
 
 #define PG_PACKED __attribute__((packed))
 
 extern const pgRegistry_t __pg_registry[];
+extern const pgRegistry_t __pg_registry_end[];
 
 // Helper to iterate over the PG register.  Cheaper than a visitor style callback.
 #define PG_FOREACH(_name) \
-    for (const pgRegistry_t *(_name) = __pg_registry; (_name)->base != NULL; (_name)++)
+        for (const pgRegistry_t *(_name) = __pg_registry; (_name) < __pg_registry_end; (_name)++)
 
 typedef uint8_t (*pgMatcherFuncPtr)(const pgRegistry_t *candidate, const void *criteria);
 

--- a/src/main/target/stm32_flash.ld
+++ b/src/main/target/stm32_flash.ld
@@ -68,6 +68,7 @@ SECTIONS
     KEEP (*(.preinit_array*))
     PROVIDE_HIDDEN (__preinit_array_end = .);
   } >FLASH
+  
   .init_array :
   {
     PROVIDE_HIDDEN (__init_array_start = .);
@@ -75,6 +76,7 @@ SECTIONS
     KEEP (*(.init_array*))
     PROVIDE_HIDDEN (__init_array_end = .);
   } >FLASH
+  
   .fini_array :
   {
     PROVIDE_HIDDEN (__fini_array_start = .);
@@ -82,12 +84,13 @@ SECTIONS
     KEEP (*(SORT(.fini_array.*)))
     PROVIDE_HIDDEN (__fini_array_end = .);
   } >FLASH
+  
   .pg_registry :
   {
     PROVIDE_HIDDEN (__pg_registry = .);
     KEEP (*(.pg_registry))
     KEEP (*(SORT(.pg_registry.*)))
-    KEEP (*(.pg_registry_tail))
+    PROVIDE_HIDDEN (__pg_registry_end = .);
   } >FLASH
 
   /* used by the startup to initialize data */

--- a/src/test/unit/config_eeprom_unittest.cc
+++ b/src/test/unit/config_eeprom_unittest.cc
@@ -24,6 +24,7 @@ extern "C" {
     #include "common/axis.h"
     #include "common/maths.h"
     #include "common/color.h"
+    #include "common/utils.h"
 
     #include "config/parameter_group.h"
 
@@ -99,16 +100,16 @@ const pgRegistry_t __pg_registry[] =
         .pgn = 1,
         .format = 0,
         .flags = PGC_PROFILE
-    },
-    {
-        .base = nullptr,
-        .ptr = 0,
-        .size = 0,
-        .pgn = 0,
-        .format = 0,
-        .flags = 0
-    },
+    }
 };
+
+const pgRegistry_t __pg_registry_end[] = {}; // FIXME enforce the location of this somehow.
+
+TEST(configTest, pgRegistryEndMarkerValid)
+{
+    // if this fails then __pg_registry_end does not follow __pg_registry in the resulting binary.
+    EXPECT_EQ(__pg_registry + ARRAYLEN(__pg_registry), __pg_registry_end);
+}
 
 TEST(configTest, resetEEPROM)
 {


### PR DESCRIPTION
@ledvinap This is a solution to your comment regarding the registry tail section.

https://github.com/cleanflight/cleanflight/pull/1976#discussion_r57434804

Please review and comment.

I don't like it from a unit test perspective.  is there a better way to do it?