### PR TITLE
Winbond 25Q16CV support in Cleanflight

### DIFF
--- a/src/main/drivers/flash_m25p16.c
+++ b/src/main/drivers/flash_m25p16.c
@@ -42,6 +42,7 @@
 
 // Format is manufacturer, memory type, then capacity
 #define JEDEC_ID_MICRON_M25P16         0x202015
+#define JEDEC_ID_WINBOND_W25Q16        0xEF4015
 #define JEDEC_ID_MICRON_N25Q064        0x20BA17
 #define JEDEC_ID_WINBOND_W25Q64        0xEF4017
 #define JEDEC_ID_MICRON_N25Q128        0x20ba18
@@ -156,6 +157,7 @@ static bool m25p16_readIdentification()
 
     switch (chipID) {
         case JEDEC_ID_MICRON_M25P16:
+	case JEDEC_ID_WINBOND_W25Q16:
             geometry.sectors = 32;
             geometry.pagesPerSector = 256;
         break;

--- a/src/main/drivers/flash_m25p16.c
+++ b/src/main/drivers/flash_m25p16.c
@@ -157,7 +157,7 @@ static bool m25p16_readIdentification()
 
     switch (chipID) {
         case JEDEC_ID_MICRON_M25P16:
-	case JEDEC_ID_WINBOND_W25Q16:
+        case JEDEC_ID_WINBOND_W25Q16:
             geometry.sectors = 32;
             geometry.pagesPerSector = 256;
         break;


### PR DESCRIPTION
Banggood sells a naze32 rev6 board that uses this chip. It's currently unsupported in cleanflight. I've made this modification and tested it - it works on those boards.