### PR TITLE
Changes to reduce ROM footprint of parameter groups.

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -573,7 +573,7 @@ STATIC_UNIT_TESTED void resetConf(void)
     // copy first profile into remaining profile
     PG_FOREACH_PROFILE(reg) {
         for (int i = 1; i < MAX_PROFILE_COUNT; i++) {
-            memcpy(reg->address + i * reg->size, reg->address, reg->size);
+            memcpy(reg->address + i * pgSize(reg), reg->address, pgSize(reg));
         }
     }
 

--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -610,7 +610,7 @@ uint8_t pgMatcherForMSPSet(const pgRegistry_t *candidate, const void *criteria)
 
     for (index = 0; index < ARRAYLEN(pgToMSPMap); index++) {
         const pgToMSPMapEntry_t *entry = &pgToMSPMap[index];
-        if (entry->pgn == candidate->pgn && entry->mspIdForSet == mspIdForSet) {
+        if (entry->pgn == pgN(candidate) && entry->mspIdForSet == mspIdForSet) {
             return true;
         }
     }
@@ -624,7 +624,7 @@ uint8_t pgMatcherForMSP(const pgRegistry_t *candidate, const void *criteria)
 
     for (index = 0; index < ARRAYLEN(pgToMSPMap); index++) {
         const pgToMSPMapEntry_t *entry = &pgToMSPMap[index];
-        if (entry->pgn == candidate->pgn && entry->mspId == mspId) {
+        if (entry->pgn == pgN(candidate) && entry->mspId == mspId) {
             return true;
         }
     }
@@ -642,7 +642,7 @@ static bool processOutCommand(uint8_t cmdMSP)
     const pgRegistry_t *reg = pgMatcher(pgMatcherForMSP, (void*)&cmdMSP);
 
     if (reg != NULL) {
-        s_struct(reg->address, reg->size);
+        s_struct(reg->address, pgSize(reg));
         return true;
     }
 


### PR DESCRIPTION
Spare bits in the `pgRegistry_t` `pgn` and `size` fields have been used to store the old `flags` and `version` fields.