### PR TITLE
Documentation of CC3D PPM input is out of date

### DIFF
--- a/docs/Board - CC3D.md
+++ b/docs/Board - CC3D.md
@@ -18,6 +18,8 @@ Tricopter & Airplane support is untested, please report success or failure if yo
 
 The 8 pin RC_Input connector has the following pinouts when used in RX_PPM/RX_SERIAL mode
 
+This was not true for me! Actually PPM Input was on channel 8 not 3! Nut sure if this only applies to me or everyone...
+
 | Pin | Function  | Notes                            |
 | --- | --------- | -------------------------------- |
 | 1   | Ground    |                                  |


### PR DESCRIPTION
If my assumption is correct, I will update the docs

I found out about this via: https://www.reddit.com/r/Multicopter/comments/3gny25/cc3d_cleanflight_ppm_no_receiver_input/

and can confirm that it's channel 8 for me and not 3