### PR TITLE
Configuration storage

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -349,7 +349,7 @@ STATIC_UNIT_TESTED void resetConf(void)
     hottTelemetryConfig()->hottAlarmSoundInterval = 5;
 #endif
 
-    RESET_CONFIG(rxConfig_t, rxConfig(),
+    RESET_CONFIG_2(rxConfig_t, rxConfig(),
         .sbus_inversion = 1,
         .midrc = 1500,
         .mincheck = 1100,

--- a/src/main/config/config_reset.h
+++ b/src/main/config/config_reset.h
@@ -23,15 +23,18 @@
 # define __UNIQL(x) __UNIQL_CONCAT(x,__LINE__)
 #endif
 
+// overwrite _name with data passed as arguments. This version forces GCC to really copy data
+// It is not possible to use multiple RESET_CONFIGs on single line (__UNIQL limitation)
 #define RESET_CONFIG(_type, _name, ...)                                 \
     static const _type __UNIQL(_reset_template_) = {                    \
         __VA_ARGS__                                                     \
     };                                                                  \
-    memcpy(_name, &__UNIQL(_reset_template_), sizeof(*_name));         \
+    memcpy((_name), &__UNIQL(_reset_template_), sizeof(*(_name)));      \
     /**/
 
-#define RESET_CONFIG_2(_type, _name, ...)                  \
-    *_name = (_type) {                                    \
+// overwrite _name with data passed as arguments. GCC is alloved to set structure field-by-field
+#define RESET_CONFIG_2(_type, _name, ...)                 \
+    *(_name) = (_type) {                                  \
         __VA_ARGS__                                       \
     };                                                    \
     /**/


### PR DESCRIPTION
Improved memory - rxConfig_t contains failsafe_channel_configurations and channelRanges thet were allocated in RESET_CONFIG

