### PR TITLE
exotic mixers disabled on F1 targets with fallback to QuadX

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -360,6 +360,13 @@ void validateAndFixConfig(void)
         pgReset_serialConfig(serialConfig());
     }
 
+    /*
+     * If provided predefined mixer setup is disabled, fallback to default one
+     */
+     if (!isMixerEnabled(mixerConfig()->mixerMode)) {
+         mixerConfig()->mixerMode = DEFAULT_MIXER;
+     }
+
 #if defined(USE_VCP)
     serialConfig()->portConfigs[0].functionMask = FUNCTION_MSP;
 #endif

--- a/src/main/config/config_master.h
+++ b/src/main/config/config_master.h
@@ -1,0 +1,119 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// System-wide
+typedef struct master_t {
+    uint8_t version;
+    uint16_t size;
+    uint8_t magic_be;                       // magic number, should be 0xBE
+
+    uint8_t mixerMode;
+    uint32_t enabledFeatures;
+    uint16_t looptime;                      // imu loop time in us
+    uint8_t emf_avoidance;                   // change pll settings to avoid noise in the uhf band
+    uint8_t i2c_highspeed;                  // Overclock i2c Bus for faster IMU readings
+    uint8_t gyroSync;                       // Enable interrupt based loop
+    uint8_t gyroSyncDenominator;            // Gyro sync Denominator
+
+    motorMixer_t customMotorMixer[MAX_SUPPORTED_MOTORS];
+#ifdef USE_SERVOS
+    servoMixer_t customServoMixer[MAX_SERVO_RULES];
+#endif
+    // motor/esc/servo related stuff
+    escAndServoConfig_t escAndServoConfig;
+    flight3DConfig_t flight3DConfig;
+
+    uint16_t motor_pwm_rate;                // The update rate of motor outputs (50-498Hz)
+    uint16_t servo_pwm_rate;                // The update rate of servo outputs (50-498Hz)
+
+    // global sensor-related stuff
+
+    sensorAlignmentConfig_t sensorAlignmentConfig;
+    boardAlignment_t boardAlignment;
+
+    int8_t yaw_control_direction;           // change control direction of yaw (inverted, normal)
+    uint8_t acc_hardware;                   // Which acc hardware to use on boards with more than one device
+
+    uint16_t dcm_kp;                        // DCM filter proportional gain ( x 10000)
+    uint16_t dcm_ki;                        // DCM filter integral gain ( x 10000)
+    uint8_t gyro_lpf;                       // gyro LPF setting - values are driver specific, in case of invalid number, a reasonable default ~30-40HZ is chosen.
+    float soft_gyro_lpf_hz;                 // Software based gyro filter in hz
+
+    gyroConfig_t gyroConfig;
+
+    uint8_t mag_hardware;                   // Which mag hardware to use on boards with more than one device
+    uint8_t baro_hardware;                  // Barometer hardware to use
+
+    uint16_t max_angle_inclination;         // max inclination allowed in angle (level) mode. default 500 (50 degrees).
+    flightDynamicsTrims_t accZero;
+    flightDynamicsTrims_t magZero;
+
+    batteryConfig_t batteryConfig;
+
+    rxConfig_t rxConfig;
+    inputFilteringMode_e inputFilteringMode;  // Use hardware input filtering, e.g. for OrangeRX PPM/PWM receivers.
+
+    failsafeConfig_t failsafeConfig;
+
+    uint8_t retarded_arm;                   // allow disarm/arm on throttle down + roll left/right
+    uint8_t disarm_kill_switch;             // allow disarm via AUX switch regardless of throttle value
+    uint8_t auto_disarm_delay;              // allow automatically disarming multicopters after auto_disarm_delay seconds of zero throttle. Disabled when 0
+    uint8_t small_angle;
+
+    // mixer-related configuration
+    mixerConfig_t mixerConfig;
+
+    airplaneConfig_t airplaneConfig;
+
+#ifdef GPS
+    gpsConfig_t gpsConfig;
+#endif
+
+    serialConfig_t serialConfig;
+
+#ifdef TELEMETRY
+    telemetryConfig_t telemetryConfig;
+#endif
+
+#ifdef LED_STRIP
+    ledConfig_t ledConfigs[MAX_LED_STRIP_LENGTH];
+    hsvColor_t colors[CONFIGURABLE_COLOR_COUNT];
+#endif
+
+#ifdef TRANSPONDER
+    uint8_t transponderData[6];
+#endif
+
+    profile_t profile[MAX_PROFILE_COUNT];
+    uint8_t current_profile_index;
+    controlRateConfig_t controlRateProfiles[MAX_CONTROL_RATE_PROFILE_COUNT];
+
+#ifdef BLACKBOX
+    uint8_t blackbox_rate_num;
+    uint8_t blackbox_rate_denom;
+    uint8_t blackbox_device;
+#endif
+
+    uint8_t magic_ef;                       // magic number, should be 0xEF
+    uint8_t chk;                            // XOR checksum
+} master_t;
+
+extern master_t masterConfig;
+extern profile_t *currentProfile;
+extern controlRateConfig_t *currentControlRateProfile;

--- a/src/main/config/config_profile.h
+++ b/src/main/config/config_profile.h
@@ -1,0 +1,62 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+typedef struct profile_s {
+    pidProfile_t pidProfile;
+
+    uint8_t defaultRateProfileIndex;
+
+    int16_t mag_declination;                // Get your magnetic decliniation from here : http://magnetic-declination.com/
+                                            // For example, -6deg 37min, = -637 Japan, format is [sign]dddmm (degreesminutes) default is zero.
+
+    rollAndPitchTrims_t accelerometerTrims; // accelerometer trim
+
+    // sensor-related stuff
+    uint8_t acc_cut_hz;                     // Set the Low Pass Filter factor for ACC. Reducing this value would reduce ACC noise (visible in GUI), but would increase ACC lag time. Zero = no filter
+    float accz_lpf_cutoff;                  // cutoff frequency for the low pass filter used on the acc z-axis for althold in Hz
+    accDeadband_t accDeadband;
+
+#ifdef BARO
+    barometerConfig_t barometerConfig;
+#endif
+
+    uint8_t acc_unarmedcal;                 // turn automatic acc compensation on/off
+
+    modeActivationCondition_t modeActivationConditions[MAX_MODE_ACTIVATION_CONDITION_COUNT];
+
+    adjustmentRange_t adjustmentRanges[MAX_ADJUSTMENT_RANGE_COUNT];
+
+    // Radio/ESC-related configuration
+
+    rcControlsConfig_t rcControlsConfig;
+
+    uint16_t throttle_correction_angle;     // the angle when the throttle correction is maximal. in 0.1 degres, ex 225 = 22.5 ,30.0, 450 = 45.0 deg
+    uint8_t throttle_correction_value;      // the correction that will be applied at throttle_correction_angle.
+
+#ifdef USE_SERVOS
+    // Servo-related stuff
+    servoParam_t servoConf[MAX_SUPPORTED_SERVOS]; // servo configuration
+    // gimbal-related configuration
+    gimbalConfig_t gimbalConfig;
+#endif
+
+#ifdef GPS
+    gpsProfile_t gpsProfile;
+#endif
+} profile_t;

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -150,6 +150,7 @@ static const motorMixer_t mixerTricopter[] = {
     { 1.0f,  1.0f, -0.666667f,  0.0f },     // LEFT
 };
 
+#ifndef DISABLE_UNCOMMON_MIXERS
 static const motorMixer_t mixerQuadP[] = {
     { 1.0f,  0.0f,  1.0f, -1.0f },          // REAR
     { 1.0f, -1.0f,  0.0f,  1.0f },          // RIGHT
@@ -160,6 +161,34 @@ static const motorMixer_t mixerQuadP[] = {
 static const motorMixer_t mixerBicopter[] = {
     { 1.0f,  1.0f,  0.0f,  0.0f },          // LEFT
     { 1.0f, -1.0f,  0.0f,  0.0f },          // RIGHT
+};
+
+static const motorMixer_t mixerVtail4[] = {
+    { 1.0f,  -0.58f,  0.58f, 1.0f },        // REAR_R
+    { 1.0f,  -0.46f, -0.39f, -0.5f },       // FRONT_R
+    { 1.0f,  0.58f,  0.58f, -1.0f },        // REAR_L
+    { 1.0f,  0.46f, -0.39f, 0.5f },         // FRONT_L
+};
+
+static const motorMixer_t mixerAtail4[] = {
+    { 1.0f,  0.0f,  1.0f,  1.0f },          // REAR_R
+    { 1.0f, -1.0f, -1.0f,  0.0f },          // FRONT_R
+    { 1.0f,  0.0f,  1.0f, -1.0f },          // REAR_L
+    { 1.0f,  1.0f, -1.0f, -0.0f },          // FRONT_L
+};
+
+static const motorMixer_t mixerDualcopter[] = {
+    { 1.0f,  0.0f,  0.0f, -1.0f },          // LEFT
+    { 1.0f,  0.0f,  0.0f,  1.0f },          // RIGHT
+};
+
+static const motorMixer_t mixerHex6H[] = {
+    { 1.0f, -1.0f,  1.0f, -1.0f },     // REAR_R
+    { 1.0f, -1.0f, -1.0f,  1.0f },     // FRONT_R
+    { 1.0f,  1.0f,  1.0f,  1.0f },     // REAR_L
+    { 1.0f,  1.0f, -1.0f, -1.0f },     // FRONT_L
+    { 1.0f,  0.0f,  0.0f,  0.0f },     // RIGHT
+    { 1.0f,  0.0f,  0.0f,  0.0f },     // LEFT
 };
 
 static const motorMixer_t mixerY6[] = {
@@ -187,26 +216,6 @@ static const motorMixer_t mixerY4[] = {
     { 1.0f,  1.0f, -1.0f,  0.0f },          // FRONT_L CW
 };
 
-static const motorMixer_t mixerHex6X[] = {
-    { 1.0f, -0.5f,  0.866025f,  1.0f },     // REAR_R
-    { 1.0f, -0.5f, -0.866025f,  1.0f },     // FRONT_R
-    { 1.0f,  0.5f,  0.866025f, -1.0f },     // REAR_L
-    { 1.0f,  0.5f, -0.866025f, -1.0f },     // FRONT_L
-    { 1.0f, -1.0f,  0.0f,      -1.0f },     // RIGHT
-    { 1.0f,  1.0f,  0.0f,       1.0f },     // LEFT
-};
-
-static const motorMixer_t mixerOctoX8[] = {
-    { 1.0f, -1.0f,  1.0f, -1.0f },          // REAR_R
-    { 1.0f, -1.0f, -1.0f,  1.0f },          // FRONT_R
-    { 1.0f,  1.0f,  1.0f,  1.0f },          // REAR_L
-    { 1.0f,  1.0f, -1.0f, -1.0f },          // FRONT_L
-    { 1.0f, -1.0f,  1.0f,  1.0f },          // UNDER_REAR_R
-    { 1.0f, -1.0f, -1.0f, -1.0f },          // UNDER_FRONT_R
-    { 1.0f,  1.0f,  1.0f, -1.0f },          // UNDER_REAR_L
-    { 1.0f,  1.0f, -1.0f,  1.0f },          // UNDER_FRONT_L
-};
-
 static const motorMixer_t mixerOctoFlatP[] = {
     { 1.0f,  0.707107f, -0.707107f,  1.0f },    // FRONT_L
     { 1.0f, -0.707107f, -0.707107f,  1.0f },    // FRONT_R
@@ -229,32 +238,26 @@ static const motorMixer_t mixerOctoFlatX[] = {
     { 1.0f,  1.0f,  0.414178f, -1.0f },      // MIDREAR_L
 };
 
-static const motorMixer_t mixerVtail4[] = {
-    { 1.0f,  -0.58f,  0.58f, 1.0f },        // REAR_R
-    { 1.0f,  -0.46f, -0.39f, -0.5f },       // FRONT_R
-    { 1.0f,  0.58f,  0.58f, -1.0f },        // REAR_L
-    { 1.0f,  0.46f, -0.39f, 0.5f },         // FRONT_L
+#endif
+
+static const motorMixer_t mixerHex6X[] = {
+    { 1.0f, -0.5f,  0.866025f,  1.0f },     // REAR_R
+    { 1.0f, -0.5f, -0.866025f,  1.0f },     // FRONT_R
+    { 1.0f,  0.5f,  0.866025f, -1.0f },     // REAR_L
+    { 1.0f,  0.5f, -0.866025f, -1.0f },     // FRONT_L
+    { 1.0f, -1.0f,  0.0f,      -1.0f },     // RIGHT
+    { 1.0f,  1.0f,  0.0f,       1.0f },     // LEFT
 };
 
-static const motorMixer_t mixerAtail4[] = {
-    { 1.0f,  0.0f,  1.0f,  1.0f },          // REAR_R
-    { 1.0f, -1.0f, -1.0f,  0.0f },          // FRONT_R
-    { 1.0f,  0.0f,  1.0f, -1.0f },          // REAR_L
-    { 1.0f,  1.0f, -1.0f, -0.0f },          // FRONT_L
-};
-
-static const motorMixer_t mixerHex6H[] = {
-    { 1.0f, -1.0f,  1.0f, -1.0f },     // REAR_R
-    { 1.0f, -1.0f, -1.0f,  1.0f },     // FRONT_R
-    { 1.0f,  1.0f,  1.0f,  1.0f },     // REAR_L
-    { 1.0f,  1.0f, -1.0f, -1.0f },     // FRONT_L
-    { 1.0f,  0.0f,  0.0f,  0.0f },     // RIGHT
-    { 1.0f,  0.0f,  0.0f,  0.0f },     // LEFT
-};
-
-static const motorMixer_t mixerDualcopter[] = {
-    { 1.0f,  0.0f,  0.0f, -1.0f },          // LEFT
-    { 1.0f,  0.0f,  0.0f,  1.0f },          // RIGHT
+static const motorMixer_t mixerOctoX8[] = {
+    { 1.0f, -1.0f,  1.0f, -1.0f },          // REAR_R
+    { 1.0f, -1.0f, -1.0f,  1.0f },          // FRONT_R
+    { 1.0f,  1.0f,  1.0f,  1.0f },          // REAR_L
+    { 1.0f,  1.0f, -1.0f, -1.0f },          // FRONT_L
+    { 1.0f, -1.0f,  1.0f,  1.0f },          // UNDER_REAR_R
+    { 1.0f, -1.0f, -1.0f, -1.0f },          // UNDER_FRONT_R
+    { 1.0f,  1.0f,  1.0f, -1.0f },          // UNDER_REAR_L
+    { 1.0f,  1.0f, -1.0f,  1.0f },          // UNDER_FRONT_L
 };
 
 static const motorMixer_t mixerSingleProp[] = {
@@ -264,32 +267,65 @@ static const motorMixer_t mixerSingleProp[] = {
 // Keep synced with mixerMode_e
 const mixer_t mixers[] = {
     // motors, use servo, motor mixer
-    { 0, false, NULL },                // entry 0
-    { 3, true,  mixerTricopter },      // MIXER_TRI
-    { 4, false, mixerQuadP },          // MIXER_QUADP
-    { 4, false, mixerQuadX },          // MIXER_QUADX
-    { 2, true,  mixerBicopter },       // MIXER_BICOPTER
-    { 0, true,  NULL },                // * MIXER_GIMBAL
-    { 6, false, mixerY6 },             // MIXER_Y6
-    { 6, false, mixerHex6P },          // MIXER_HEX6
-    { 1, true,  mixerSingleProp },     // * MIXER_FLYING_WING
-    { 4, false, mixerY4 },             // MIXER_Y4
-    { 6, false, mixerHex6X },          // MIXER_HEX6X
-    { 8, false, mixerOctoX8 },         // MIXER_OCTOX8
-    { 8, false, mixerOctoFlatP },      // MIXER_OCTOFLATP
-    { 8, false, mixerOctoFlatX },      // MIXER_OCTOFLATX
-    { 1, true,  mixerSingleProp },     // * MIXER_AIRPLANE
-    { 0, true,  NULL },                // * MIXER_HELI_120_CCPM
-    { 0, true,  NULL },                // * MIXER_HELI_90_DEG
-    { 4, false, mixerVtail4 },         // MIXER_VTAIL4
-    { 6, false, mixerHex6H },          // MIXER_HEX6H
-    { 0, true,  NULL },                // * MIXER_PPM_TO_SERVO
-    { 2, true,  mixerDualcopter },     // MIXER_DUALCOPTER
-    { 1, true,  NULL },                // MIXER_SINGLECOPTER
-    { 4, false, mixerAtail4 },         // MIXER_ATAIL4
-    { 0, false, NULL },                // MIXER_CUSTOM
-    { 2, true,  NULL },                // MIXER_CUSTOM_AIRPLANE
-    { 3, true,  NULL },                // MIXER_CUSTOM_TRI
+    { 0, false, NULL, true },                // entry 0
+    { 3, true,  mixerTricopter, true },      // MIXER_TRI
+    #ifndef DISABLE_UNCOMMON_MIXERS
+        { 4, false, mixerQuadP, true },      // MIXER_QUADP
+    #else
+        { 0, false, NULL, false },           // MIXER_QUADP
+    #endif
+    { 4, false, mixerQuadX, true },          // MIXER_QUADX
+    #ifndef DISABLE_UNCOMMON_MIXERS
+        { 2, true,  mixerBicopter, true },   // MIXER_BICOPTER
+    #else
+        { 0, false, NULL, false },           // MIXER_BICOPTER
+    #endif
+    { 0, true,  NULL, true },                // * MIXER_GIMBAL
+    #ifndef DISABLE_UNCOMMON_MIXERS
+        { 6, false, mixerY6, true },         // MIXER_Y6
+        { 6, false, mixerHex6P, true },      // MIXER_HEX6
+    #else
+        { 0, false, NULL, false },           // MIXER_Y6
+        { 0, false, NULL, false },           // MIXER_HEX6
+    #endif
+    { 1, true,  mixerSingleProp, true },     // * MIXER_FLYING_WING
+    #ifndef DISABLE_UNCOMMON_MIXERS
+        { 4, false, mixerY4, true },         // MIXER_Y4
+    #else
+        { 0, false, NULL, false },           // MIXER_Y4
+    #endif
+    { 6, false, mixerHex6X, true },          // MIXER_HEX6X
+    { 8, false, mixerOctoX8, true },         // MIXER_OCTOX8
+    #ifndef DISABLE_UNCOMMON_MIXERS
+        { 8, false, mixerOctoFlatP, true },  // MIXER_OCTOFLATP
+        { 8, false, mixerOctoFlatX, true },  // MIXER_OCTOFLATX
+    #else
+        { 0, false, NULL, false },           // MIXER_OCTOFLATP
+        { 0, false, NULL, false },           // MIXER_OCTOFLATX
+    #endif
+    { 1, true,  mixerSingleProp, true },     // * MIXER_AIRPLANE
+    { 0, true,  NULL, false },               // * MIXER_HELI_120_CCPM -> disabled, never fully implemented in CF
+    { 0, true,  NULL, false },               // * MIXER_HELI_90_DEG -> disabled, never fully implemented in CF
+    #ifndef DISABLE_UNCOMMON_MIXERS
+        { 4, false, mixerVtail4, true },     // MIXER_VTAIL4
+        { 6, false, mixerHex6H, true },      // MIXER_HEX6H
+    #else
+        { 0, false, NULL, false },           // MIXER_VTAIL4
+        { 0, false, NULL, false },           // MIXER_HEX6H
+    #endif
+    { 0, true,  NULL, true },                // * MIXER_PPM_TO_SERVO -> looks like this is not implemented at all
+    #ifndef DISABLE_UNCOMMON_MIXERS
+        { 2, true,  mixerDualcopter, true }, // MIXER_DUALCOPTER
+        { 1, true,  NULL, true },            // MIXER_SINGLECOPTER
+        { 4, false, mixerAtail4, true },     // MIXER_ATAIL4
+    #else
+        { 0, false, NULL, false },           // MIXER_DUALCOPTER
+        { 0, false, NULL, false },           // MIXER_SINGLECOPTER
+        { 0, false, NULL, false },           // MIXER_ATAIL4
+    #endif
+    { 0, false, NULL, true },                // MIXER_CUSTOM
+    { 2, true,  NULL, true },                // MIXER_CUSTOM_AIRPLANE
+    { 3, true,  NULL, true },                // MIXER_CUSTOM_TRI
 };
 #endif
 
@@ -313,15 +349,12 @@ static const servoMixer_t servoMixerFlyingWing[] = {
     { SERVO_THROTTLE, INPUT_STABILIZED_THROTTLE, 100, 0, 0, 100, 0 },
 };
 
+#ifndef DISABLE_UNCOMMON_MIXERS
 static const servoMixer_t servoMixerBI[] = {
     { SERVO_BICOPTER_LEFT, INPUT_STABILIZED_YAW,   100, 0, 0, 100, 0 },
     { SERVO_BICOPTER_LEFT, INPUT_STABILIZED_PITCH, 100, 0, 0, 100, 0 },
     { SERVO_BICOPTER_RIGHT, INPUT_STABILIZED_YAW,   100, 0, 0, 100, 0 },
     { SERVO_BICOPTER_RIGHT, INPUT_STABILIZED_PITCH, 100, 0, 0, 100, 0 },
-};
-
-static const servoMixer_t servoMixerTri[] = {
-    { SERVO_RUDDER, INPUT_STABILIZED_YAW,   100, 0, 0, 100, 0 },
 };
 
 static const servoMixer_t servoMixerDual[] = {
@@ -339,6 +372,11 @@ static const servoMixer_t servoMixerSingle[] = {
     { SERVO_SINGLECOPTER_4, INPUT_STABILIZED_YAW,   100, 0, 0, 100, 0 },
     { SERVO_SINGLECOPTER_4, INPUT_STABILIZED_ROLL,  100, 0, 0, 100, 0 },
 };
+#endif
+
+static const servoMixer_t servoMixerTri[] = {
+    { SERVO_RUDDER, INPUT_STABILIZED_YAW,   100, 0, 0, 100, 0 },
+};
 
 static const servoMixer_t servoMixerGimbal[] = {
     { SERVO_GIMBAL_PITCH, INPUT_GIMBAL_PITCH, 125, 0, 0, 100, 0 },
@@ -351,7 +389,11 @@ const mixerRules_t servoMixers[] = {
     { COUNT_SERVO_RULES(servoMixerTri), servoMixerTri },       // MULTITYPE_TRI
     { 0, NULL },                // MULTITYPE_QUADP
     { 0, NULL },                // MULTITYPE_QUADX
-    { COUNT_SERVO_RULES(servoMixerBI), servoMixerBI },        // MULTITYPE_BI
+    #ifndef DISABLE_UNCOMMON_MIXERS
+        { COUNT_SERVO_RULES(servoMixerBI), servoMixerBI },        // MULTITYPE_BI
+    #else
+        { 0, NULL },                                              // MULTITYPE_BI
+    #endif
     { COUNT_SERVO_RULES(servoMixerGimbal), servoMixerGimbal },    // * MULTITYPE_GIMBAL
     { 0, NULL },                // MULTITYPE_Y6
     { 0, NULL },                // MULTITYPE_HEX6
@@ -362,13 +404,18 @@ const mixerRules_t servoMixers[] = {
     { 0, NULL },                // MULTITYPE_OCTOFLATP
     { 0, NULL },                // MULTITYPE_OCTOFLATX
     { COUNT_SERVO_RULES(servoMixerAirplane), servoMixerAirplane },  // * MULTITYPE_AIRPLANE
-    { 0, NULL },                // * MULTITYPE_HELI_120_CCPM
-    { 0, NULL },                // * MULTITYPE_HELI_90_DEG
+    { 0, NULL },                // * MIXER_HELI_120_CCPM -> disabled, never fully implemented in CF
+    { 0, NULL },                // * MIXER_HELI_90_DEG -> disabled, never fully implemented in CF
     { 0, NULL },                // MULTITYPE_VTAIL4
     { 0, NULL },                // MULTITYPE_HEX6H
     { 0, NULL },                // * MULTITYPE_PPM_TO_SERVO
-    { COUNT_SERVO_RULES(servoMixerDual), servoMixerDual },      // MULTITYPE_DUALCOPTER
-    { COUNT_SERVO_RULES(servoMixerSingle), servoMixerSingle },    // MULTITYPE_SINGLECOPTER
+    #ifndef DISABLE_UNCOMMON_MIXERS
+        { COUNT_SERVO_RULES(servoMixerDual), servoMixerDual },        // MULTITYPE_DUALCOPTER
+        { COUNT_SERVO_RULES(servoMixerSingle), servoMixerSingle },    // MULTITYPE_SINGLECOPTER
+    #else
+        { 0, NULL }, // MULTITYPE_DUALCOPTER
+        { 0, NULL }, // MULTITYPE_SINGLECOPTER
+    #endif
     { 0, NULL },                // MULTITYPE_ATAIL4
     { 0, NULL },                // MULTITYPE_CUSTOM
     { 0, NULL },                // MULTITYPE_CUSTOM_PLANE
@@ -427,6 +474,11 @@ int servoDirection(int servoIndex, int inputSource)
 }
 #endif
 
+bool isMixerEnabled(mixerMode_e mixerMode)
+{
+    return mixers[mixerMode].enabled;
+}
+
 #ifdef USE_SERVOS
 void mixerInit(motorMixer_t *initialCustomMotorMixers, servoMixer_t *initialCustomServoMixers)
 {
@@ -484,7 +536,7 @@ void mixerUsePWMIOConfiguration(pwmIOConfiguration_t *pwmIOConfiguration)
                 currentServoMixer[i] = servoMixers[mixerConfig()->mixerMode].rule[i];
         }
     }
-    
+
     // in 3D mode, mixer gain has to be halved
     if (feature(FEATURE_3D)) {
         if (motorCount > 1) {
@@ -502,7 +554,7 @@ void mixerUsePWMIOConfiguration(pwmIOConfiguration_t *pwmIOConfiguration)
         mixerConfig()->mixerMode == MIXER_CUSTOM_AIRPLANE
     ) {
         ENABLE_STATE(FIXED_WING);
-        
+
         if (mixerConfig()->mixerMode == MIXER_CUSTOM_AIRPLANE) {
             loadCustomServoMixer();
         }
@@ -621,10 +673,12 @@ void writeServos(void)
     uint8_t servoIndex = 0;
 
     switch (mixerConfig()->mixerMode) {
+        #ifndef DISABLE_UNCOMMON_MIXERS
         case MIXER_BICOPTER:
             pwmWriteServo(servoIndex++, servo[SERVO_BICOPTER_LEFT]);
             pwmWriteServo(servoIndex++, servo[SERVO_BICOPTER_RIGHT]);
             break;
+        #endif
 
         case MIXER_TRI:
         case MIXER_CUSTOM_TRI:
@@ -645,10 +699,12 @@ void writeServos(void)
             pwmWriteServo(servoIndex++, servo[SERVO_FLAPPERON_2]);
             break;
 
+        #ifndef DISABLE_UNCOMMON_MIXERS
         case MIXER_DUALCOPTER:
             pwmWriteServo(servoIndex++, servo[SERVO_DUALCOPTER_LEFT]);
             pwmWriteServo(servoIndex++, servo[SERVO_DUALCOPTER_RIGHT]);
             break;
+        #endif
 
         case MIXER_CUSTOM_AIRPLANE:
         case MIXER_AIRPLANE:
@@ -657,11 +713,13 @@ void writeServos(void)
             }
             break;
 
+        #ifndef DISABLE_UNCOMMON_MIXERS
         case MIXER_SINGLECOPTER:
             for (int i = SERVO_SINGLECOPTER_INDEX_MIN; i <= SERVO_SINGLECOPTER_INDEX_MAX; i++) {
                 pwmWriteServo(servoIndex++, servo[i]);
             }
             break;
+        #endif
 
         default:
             break;
@@ -976,12 +1034,14 @@ void mixTable(void)
         case MIXER_CUSTOM_AIRPLANE:
         case MIXER_FLYING_WING:
         case MIXER_AIRPLANE:
-        case MIXER_BICOPTER:
         case MIXER_CUSTOM_TRI:
         case MIXER_TRI:
-        case MIXER_DUALCOPTER:
-        case MIXER_SINGLECOPTER:
         case MIXER_GIMBAL:
+        #ifndef DISABLE_UNCOMMON_MIXERS
+            case MIXER_SINGLECOPTER:
+            case MIXER_DUALCOPTER:
+            case MIXER_BICOPTER:
+        #endif
             servoMixer();
             break;
 
@@ -1050,4 +1110,3 @@ void filterServos(void)
 
 #endif
 }
-

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -57,6 +57,8 @@ typedef enum mixerMode
     MIXER_CUSTOM_TRI = 25
 } mixerMode_e;
 
+#define DEFAULT_MIXER MIXER_QUADX
+
 // Custom mixer data per motor
 typedef struct motorMixer_s {
     float throttle;
@@ -72,6 +74,7 @@ typedef struct mixer_s {
     uint8_t motorCount;
     uint8_t useServo;
     const motorMixer_t *motor;
+    bool enabled;
 } mixer_t;
 
 typedef struct mixerConfig_s {
@@ -239,3 +242,4 @@ void writeMotors(void);
 void stopMotors(void);
 void StopPwmAllMotors(void);
 void mixerInitialiseServoFiltering(uint32_t targetLooptime);
+bool isMixerEnabled(mixerMode_e mixerMode);

--- a/src/main/io/escservo.h
+++ b/src/main/io/escservo.h
@@ -1,0 +1,27 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+typedef struct escAndServoConfig_s {
+
+    // PWM values, in milliseconds, common range is 1000-2000 (1 to 2ms)
+    uint16_t minthrottle;                   // Set the minimum throttle command sent to the ESC (Electronic Speed Controller). This is the minimum value that allow motors to run at a idle speed.
+    uint16_t maxthrottle;                   // This is the maximum value for the ESCs at full power this value can be increased up to 2000
+    uint16_t mincommand;                    // This is the value for the ESCs when they are not armed. In some cases, this value must be lowered down to 900 for some specific ESCs
+    uint16_t servoCenterPulse;              // This is the value for servos when they should be in the middle. e.g. 1500.
+} escAndServoConfig_t;

--- a/src/main/target/CC3D/target.h
+++ b/src/main/target/CC3D/target.h
@@ -133,3 +133,6 @@
 // UART3, PB11 (Flexport)
 #define BIND_PORT  GPIOB
 #define BIND_PIN   Pin_11
+
+//Disables uncommon predefined mixer settings like BiCopter, H6 and similar exotics
+#define DISABLE_UNCOMMON_MIXERS

--- a/src/main/target/CJMCU/target.h
+++ b/src/main/target/CJMCU/target.h
@@ -80,3 +80,5 @@
 //#undef USE_CLI
 //#define GTUNE
 //#define BLACKBOX
+
+#define DISABLE_UNCOMMON_MIXERS

--- a/src/main/target/EUSTM32F103RC/target.h
+++ b/src/main/target/EUSTM32F103RC/target.h
@@ -138,3 +138,5 @@
 // UART2, PA3
 #define BIND_PORT  GPIOA
 #define BIND_PIN   Pin_3
+
+#define DISABLE_UNCOMMON_MIXERS

--- a/src/main/target/NAZE/target.h
+++ b/src/main/target/NAZE/target.h
@@ -208,3 +208,5 @@
 #define BINDPLUG_PORT  GPIOB
 #define BINDPLUG_PIN   Pin_5
 #endif
+
+#define DISABLE_UNCOMMON_MIXERS

--- a/src/main/target/OLIMEXINO/target.h
+++ b/src/main/target/OLIMEXINO/target.h
@@ -115,3 +115,5 @@
 #define BLACKBOX
 #define USE_SERVOS
 #define USE_CLI
+
+#define DISABLE_UNCOMMON_MIXERS

--- a/src/main/target/PORT103R/target.h
+++ b/src/main/target/PORT103R/target.h
@@ -167,3 +167,5 @@
 #define S1W_TX_PIN          GPIO_Pin_9
 #define S1W_RX_GPIO         GPIOA
 #define S1W_RX_PIN          GPIO_Pin_10
+
+#define DISABLE_UNCOMMON_MIXERS

--- a/src/test/unit/altitude_hold_unittest.cc
+++ b/src/test/unit/altitude_hold_unittest.cc
@@ -1,0 +1,170 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include <limits.h>
+
+#include <platform.h>
+
+//#define DEBUG_ALTITUDE_HOLD
+
+#define BARO
+
+extern "C" {
+    #include "debug.h"
+
+    #include "common/axis.h"
+    #include "common/maths.h"
+
+    #include "drivers/sensor.h"
+    #include "drivers/accgyro.h"
+
+    #include "sensors/sensors.h"
+    #include "sensors/acceleration.h"
+    #include "sensors/barometer.h"
+
+    #include "io/escservo.h"
+    #include "io/rc_controls.h"
+
+    #include "rx/rx.h"
+
+    #include "flight/mixer.h"
+    #include "flight/pid.h"
+    #include "flight/imu.h"
+    #include "flight/altitudehold.h"
+
+    #include "config/runtime_config.h"
+
+}
+
+#include "unittest_macros.h"
+#include "gtest/gtest.h"
+
+#define DOWNWARDS_THRUST true
+#define UPWARDS_THRUST false
+
+
+extern "C" {
+    bool isThrustFacingDownwards(attitudeEulerAngles_t * attitude);
+    uint16_t calculateTiltAngle(attitudeEulerAngles_t * attitude);
+}
+
+typedef struct inclinationExpectation_s {
+    attitudeEulerAngles_t attitude;
+    bool expectDownwardsThrust;
+} inclinationExpectation_t;
+
+TEST(AltitudeHoldTest, IsThrustFacingDownwards)
+{
+    // given
+
+    inclinationExpectation_t inclinationExpectations[] = {
+            { {{    0,    0,    0 }}, DOWNWARDS_THRUST },
+            { {{  799,  799,    0 }}, DOWNWARDS_THRUST },
+            { {{  800,  799,    0 }}, UPWARDS_THRUST },
+            { {{  799,  800,    0 }}, UPWARDS_THRUST },
+            { {{  800,  800,    0 }}, UPWARDS_THRUST },
+            { {{  801,  801,    0 }}, UPWARDS_THRUST },
+            { {{ -799, -799,    0 }}, DOWNWARDS_THRUST },
+            { {{ -800, -799,    0 }}, UPWARDS_THRUST },
+            { {{ -799, -800,    0 }}, UPWARDS_THRUST },
+            { {{ -800, -800,    0 }}, UPWARDS_THRUST },
+            { {{ -801, -801,    0 }}, UPWARDS_THRUST }
+    };
+    uint8_t testIterationCount = sizeof(inclinationExpectations) / sizeof(inclinationExpectation_t);
+
+    // expect
+
+    for (uint8_t index = 0; index < testIterationCount; index ++) {
+        inclinationExpectation_t *angleInclinationExpectation = &inclinationExpectations[index];
+#ifdef DEBUG_ALTITUDE_HOLD
+        printf("iteration: %d\n", index);
+#endif
+        bool result = isThrustFacingDownwards(&angleInclinationExpectation->attitude);
+        EXPECT_EQ(angleInclinationExpectation->expectDownwardsThrust, result);
+    }
+}
+
+// STUBS
+
+extern "C" {
+uint32_t rcModeActivationMask;
+int16_t rcCommand[4];
+int16_t rcData[MAX_SUPPORTED_RC_CHANNEL_COUNT];
+
+uint32_t accTimeSum ;        // keep track for integration of acc
+int accSumCount;
+float accVelScale;
+
+attitudeEulerAngles_t attitude;
+
+//uint16_t acc_1G;
+//int16_t heading;
+//gyro_t gyro;
+int32_t accSum[XYZ_AXIS_COUNT];
+//int16_t magADC[XYZ_AXIS_COUNT];
+int32_t BaroAlt;
+int16_t debug[DEBUG16_VALUE_COUNT];
+
+uint8_t stateFlags;
+uint16_t flightModeFlags;
+uint8_t armingFlags;
+
+int32_t sonarAlt;
+int16_t sonarCfAltCm;
+int16_t sonarMaxAltWithTiltCm;
+
+
+uint16_t enableFlightMode(flightModeFlags_e mask)
+{
+    return flightModeFlags |= (mask);
+}
+
+uint16_t disableFlightMode(flightModeFlags_e mask)
+{
+    return flightModeFlags &= ~(mask);
+}
+
+void gyroUpdate(void) {};
+bool sensors(uint32_t mask)
+{
+    UNUSED(mask);
+    return false;
+};
+void updateAccelerationReadings(rollAndPitchTrims_t *rollAndPitchTrims)
+{
+    UNUSED(rollAndPitchTrims);
+}
+
+void imuResetAccelerationSum(void) {};
+
+int32_t applyDeadband(int32_t, int32_t) { return 0; }
+uint32_t micros(void) { return 0; }
+bool isBaroCalibrationComplete(void) { return true; }
+void performBaroCalibrationCycle(void) {}
+int32_t baroCalculateAltitude(void) { return 0; }
+int constrain(int amt, int low, int high)
+{
+    UNUSED(amt);
+    UNUSED(low);
+    UNUSED(high);
+    return 0;
+}
+
+}

--- a/src/test/unit/config_unittest.cc
+++ b/src/test/unit/config_unittest.cc
@@ -1,0 +1,201 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+
+extern "C" {
+    #include <platform.h>
+    #include "config/config.h"
+    #include "common/axis.h"
+    #include "common/color.h"
+    #include "common/maths.h"
+    #include "drivers/sensor.h"
+    #include "drivers/timer.h"
+    #include "drivers/accgyro.h"
+    #include "drivers/compass.h"
+    #include "drivers/pwm_rx.h"
+    #include "drivers/serial.h"
+    #include "io/escservo.h"
+    #include "io/gimbal.h"
+    #include "io/gps.h"
+    #include "io/ledstrip.h"
+    #include "io/rc_controls.h"
+    #include "io/serial.h"
+    #include "telemetry/telemetry.h"
+    #include "sensors/sensors.h"
+    #include "sensors/acceleration.h"
+    #include "sensors/boardalignment.h"
+    #include "sensors/barometer.h"
+    #include "sensors/battery.h"
+    #include "sensors/compass.h"
+    #include "sensors/gyro.h"
+    #include "flight/pid.h"
+    #include "flight/failsafe.h"
+    #include "flight/imu.h"
+    #include "flight/mixer.h"
+    #include "flight/navigation.h"
+    #include "rx/rx.h"
+    #include "config/config_profile.h"
+    #include "config/config_master.h"
+}
+
+#include "unittest_macros.h"
+#include "gtest/gtest.h"
+
+extern "C" {
+    void resetConf(void);
+    extern master_t masterConfig;
+}
+
+/*
+ * Test that the config items whose default values are zero are indeed set to zero by resetConf().
+ */
+TEST(ConfigUnittest, TestResetConfigZeroValues)
+{
+    memset(&masterConfig, 0xa5, sizeof(master_t));
+    resetConf();
+
+    EXPECT_EQ(0, masterConfig.current_profile_index); // default profile
+    EXPECT_EQ(0, masterConfig.dcm_ki); // 0.003 * 10000
+
+//resetAccelerometerTrims(&masterConfig.accZero);
+    EXPECT_EQ(0, masterConfig.accZero.values.pitch);
+    EXPECT_EQ(0, masterConfig.accZero.values.roll);
+    EXPECT_EQ(0, masterConfig.accZero.values.yaw);
+
+//resetSensorAlignment(&masterConfig.sensorAlignmentConfig);
+    EXPECT_EQ(ALIGN_DEFAULT, masterConfig.sensorAlignmentConfig.gyro_align);
+    EXPECT_EQ(ALIGN_DEFAULT, masterConfig.sensorAlignmentConfig.acc_align);
+    EXPECT_EQ(ALIGN_DEFAULT, masterConfig.sensorAlignmentConfig.mag_align);
+
+    EXPECT_EQ(0, masterConfig.boardAlignment.rollDegrees);
+    EXPECT_EQ(0, masterConfig.boardAlignment.pitchDegrees);
+    EXPECT_EQ(0, masterConfig.boardAlignment.yawDegrees);
+
+    EXPECT_EQ(ACC_DEFAULT, masterConfig.acc_hardware);   // default/autodetect
+    EXPECT_EQ(MAG_DEFAULT, masterConfig.mag_hardware);   // default/autodetect
+    EXPECT_EQ(BARO_DEFAULT, masterConfig.baro_hardware); // default/autodetect
+
+    EXPECT_EQ(0, masterConfig.batteryConfig.currentMeterOffset);
+    EXPECT_EQ(0, masterConfig.batteryConfig.batteryCapacity);
+
+    EXPECT_EQ(0, masterConfig.telemetryConfig.telemetry_inversion);
+    EXPECT_EQ(0, masterConfig.telemetryConfig.telemetry_switch);
+    EXPECT_EQ(0, masterConfig.telemetryConfig.gpsNoFixLatitude);
+    EXPECT_EQ(0, masterConfig.telemetryConfig.gpsNoFixLongitude);
+    EXPECT_EQ(FRSKY_FORMAT_DMS, masterConfig.telemetryConfig.frsky_coordinate_format);
+    EXPECT_EQ(FRSKY_UNIT_METRICS, masterConfig.telemetryConfig.frsky_unit);
+    EXPECT_EQ(0, masterConfig.telemetryConfig.frsky_vfas_precision);
+
+    EXPECT_EQ(0, masterConfig.rxConfig.serialrx_provider);
+    EXPECT_EQ(0, masterConfig.rxConfig.spektrum_sat_bind);
+
+    EXPECT_EQ(0, masterConfig.rxConfig.rssi_channel);
+    EXPECT_EQ(0, masterConfig.rxConfig.rssi_ppm_invert);
+    EXPECT_EQ(0, masterConfig.rxConfig.rcSmoothing);
+
+    EXPECT_EQ(INPUT_FILTERING_DISABLED, masterConfig.inputFilteringMode);
+
+    EXPECT_EQ(0, masterConfig.retarded_arm);
+
+//    resetMixerConfig(&masterConfig.mixerConfig);
+    EXPECT_EQ(0, masterConfig.mixerConfig.servo_lowpass_enable);
+
+    EXPECT_EQ(GPS_NMEA, masterConfig.gpsConfig.provider);
+    EXPECT_EQ(SBAS_AUTO, masterConfig.gpsConfig.sbasMode);
+    EXPECT_EQ(GPS_AUTOBAUD_OFF, masterConfig.gpsConfig.autoBaud);
+
+    EXPECT_EQ(0, masterConfig.emf_avoidance);
+
+// resetControlRateConfig(&masterConfig.controlRateProfiles[0]);
+    EXPECT_EQ(0, masterConfig.controlRateProfiles[0].thrExpo8);
+    EXPECT_EQ(0, masterConfig.controlRateProfiles[0].dynThrPID);
+    EXPECT_EQ(0, masterConfig.controlRateProfiles[0].rcYawExpo8);
+    for (uint8_t axis = 0; axis < FD_INDEX_COUNT; axis++) {
+        EXPECT_EQ(0, masterConfig.controlRateProfiles[0].rates[axis]);
+    }
+
+    EXPECT_EQ(0, masterConfig.failsafeConfig.failsafe_kill_switch); // default failsafe switch action is identical to rc link loss
+    EXPECT_EQ(0, masterConfig.failsafeConfig.failsafe_procedure);   // default full failsafe procedure is 0: auto-landing
+
+    // custom mixer. clear by defaults.
+    for (int i = 0; i < MAX_SUPPORTED_MOTORS; i++) {
+        EXPECT_EQ(0.0f, masterConfig.customMotorMixer[i].throttle);
+    }
+}
+
+// STUBS
+extern "C" {
+
+void applyDefaultLedStripConfig(ledConfig_t *) {}
+void applyDefaultColors(hsvColor_t *, uint8_t) {}
+void beeperConfirmationBeeps(uint8_t) {}
+void StopPwmAllMotors(void) {}
+void useRxConfig(rxConfig_t *) {}
+void useRcControlsConfig(modeActivationCondition_t *, escAndServoConfig_t *, pidProfile_t *) {}
+void useGyroConfig(gyroConfig_t *, float) {}
+void useFailsafeConfig(failsafeConfig_t *) {}
+void useBarometerConfig(barometerConfig_t *) {}
+void telemetryUseConfig(telemetryConfig_t *) {}
+void suspendRxSignal(void) {}
+void setAccelerationTrims(flightDynamicsTrims_t *) {}
+void resumeRxSignal(void) {}
+void resetRollAndPitchTrims(rollAndPitchTrims_t *) {}
+void resetAllRxChannelRangeConfigurations(rxChannelRangeConfiguration_t *) {}
+void resetAdjustmentStates(void) {}
+void pidSetController(pidControllerType_e) {}
+void parseRcChannels(const char *, rxConfig_t *) {}
+#ifdef USE_SERVOS
+void mixerUseConfigs(servoParam_t *, gimbalConfig_t *, flight3DConfig_t *, escAndServoConfig_t *, mixerConfig_t *, airplaneConfig_t *, rxConfig_t *) {}
+#else
+void mixerUseConfigs(flight3DConfig_t *, escAndServoConfig_t *, mixerConfig_t *, airplaneConfig_t *, rxConfig_t *) {}
+#endif
+bool isSerialConfigValid(serialConfig_t *) {return true;}
+void imuConfigure(imuRuntimeConfig_t *, pidProfile_t *,accDeadband_t *,float ,uint16_t) {}
+void gpsUseProfile(gpsProfile_t *) {}
+void gpsUsePIDs(pidProfile_t *) {}
+void generateYawCurve(controlRateConfig_t *) {}
+void generatePitchRollCurve(controlRateConfig_t *) {}
+void generateThrottleCurve(controlRateConfig_t *) {}
+void delay(uint32_t) {}
+void configureAltitudeHold(pidProfile_t *, barometerConfig_t *, rcControlsConfig_t *, escAndServoConfig_t *) {}
+void failureMode(uint8_t) {}
+
+const serialPortIdentifier_e serialPortIdentifiers[SERIAL_PORT_COUNT] = {
+#ifdef USE_VCP
+    SERIAL_PORT_USB_VCP,
+#endif
+#ifdef USE_UART1
+    SERIAL_PORT_UART1,
+#endif
+#ifdef USE_UART2
+    SERIAL_PORT_UART2,
+#endif
+#ifdef USE_UART3
+    SERIAL_PORT_UART3,
+#endif
+#ifdef USE_SOFTSERIAL1
+    SERIAL_PORT_SOFTSERIAL1,
+#endif
+#ifdef USE_SOFTSERIAL2
+    SERIAL_PORT_SOFTSERIAL2,
+#endif
+};
+}
+


### PR DESCRIPTION
This PR has following functions:

1. Introduces a way to disable predefined mixers. Specially those inherited from MultiWii and never really implemented or not used.
2. Allows to save some flash space on F1 targets by disabling uncommon mixers that still can be implemented using custom mixers. Approx. flash reduction: 700 bytes 
3. It's a first step of servo handling refactoring that allows for more structurized, flexible and simpler servo approach

Disabled predefined mixers on F1:
* MIXER_QUADP
* MIXER_BICOPTER
* MIXER_Y6
* MIXER_HEX6 (Plus)
* MIXER_Y4
* MIXER_OCTOFLATP
* MIXER_OCTOFLATX
* MIXER_VTAIL4
* MIXER_HEX6H
* MIXER_DUALCOPTER
* MIXER_SINGLECOPTER
* MIXER_ATAIL4

Following mixers are always disabled since were never implemented:
* MIXER_HELI_120_CCPM
* MIXER_HELI_90_DEG

If user selects disabled mixer in Configurator or CLI, default MIXER_QUADX is loaded