### PR TITLE
Configurable armed led colors #2047

### DIFF
--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -621,7 +621,7 @@ void applyLedModeLayer(void)
                 if (!ARMING_FLAG(ARMED)) {
                     setLedHsv(ledIndex, &hsv_green);
                 } else {
-                    setLedHsv(ledIndex, &hsv_blue);
+                    setLedHsv(ledIndex, colors(ledConfig->color));
                 }
             }
             continue;

--- a/src/main/io/msp_protocol.h
+++ b/src/main/io/msp_protocol.h
@@ -60,7 +60,7 @@
 #define MSP_PROTOCOL_VERSION                0
 
 #define API_VERSION_MAJOR                   1 // increment when major changes are made
-#define API_VERSION_MINOR                   17 // increment when any change is made, reset to zero when major changes are released after changing API_VERSION_MAJOR
+#define API_VERSION_MINOR                   18 // increment when any change is made, reset to zero when major changes are released after changing API_VERSION_MAJOR
 
 #define API_VERSION_LENGTH                  2
 

--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -966,7 +966,8 @@ static bool processOutCommand(uint8_t cmdMSP)
         break;
 #ifdef GPS
     case MSP_RAW_GPS:
-        headSerialReply(16);
+        headSerialReply(18);
+
         serialize8(STATE(GPS_FIX));
         serialize8(GPS_numSat);
         serialize32(GPS_coord[LAT]);
@@ -974,6 +975,7 @@ static bool processOutCommand(uint8_t cmdMSP)
         serialize16(GPS_altitude);
         serialize16(GPS_speed);
         serialize16(GPS_ground_course);
+        serialize16(GPS_hdop);
         break;
     case MSP_COMP_GPS:
         headSerialReply(5);

--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -950,7 +950,7 @@ static bool processOutCommand(uint8_t cmdMSP)
         serialize8(rxConfig()->rssi_channel);
         serialize8(0);
 
-        serialize16(compassConfig()->mag_declination / 10);
+        serialize16(compassConfig()->mag_declination);
 
         serialize8(batteryConfig()->vbatscale);
         serialize8(batteryConfig()->vbatmincellvoltage);
@@ -1402,7 +1402,7 @@ static bool processInCommand(void)
         rxConfig()->rssi_channel = read8();
         read8();
 
-        compassConfig()->mag_declination = read16() * 10;
+        compassConfig()->mag_declination = read16();
 
         batteryConfig()->vbatscale = read8();           // actual vbatscale as intended
         batteryConfig()->vbatmincellvoltage = read8();  // vbatlevel_warn1 in MWC2.3 GUI

--- a/src/test/unit/serial_msp_unittest.cc
+++ b/src/test/unit/serial_msp_unittest.cc
@@ -713,6 +713,7 @@ uint16_t GPS_altitude;              // altitude in 0.1m
 uint16_t GPS_speed;                 // speed in 0.1m/s
 uint16_t GPS_ground_course = 0;     // degrees * 10
 uint8_t GPS_numCh;                          // Number of channels
+uint16_t GPS_hdop;                          // HDOP value
 uint8_t GPS_svinfo_chn[GPS_SV_MAXSATS];     // Channel number
 uint8_t GPS_svinfo_svid[GPS_SV_MAXSATS];    // Satellite ID
 uint8_t GPS_svinfo_quality[GPS_SV_MAXSATS]; // Bitfield Qualtity


### PR DESCRIPTION
Armed status lights up LEDs using the user-defined color parameter instead of static blue