### PR TITLE
MSP: do not scale mag_declination value by 10

### DIFF
--- a/src/main/io/msp_protocol.h
+++ b/src/main/io/msp_protocol.h
@@ -60,7 +60,7 @@
 #define MSP_PROTOCOL_VERSION                0
 
 #define API_VERSION_MAJOR                   1 // increment when major changes are made
-#define API_VERSION_MINOR                   17 // increment when any change is made, reset to zero when major changes are released after changing API_VERSION_MAJOR
+#define API_VERSION_MINOR                   18 // increment when any change is made, reset to zero when major changes are released after changing API_VERSION_MAJOR
 
 #define API_VERSION_LENGTH                  2
 

--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -950,7 +950,7 @@ static bool processOutCommand(uint8_t cmdMSP)
         serialize8(rxConfig()->rssi_channel);
         serialize8(0);
 
-        serialize16(compassConfig()->mag_declination / 10);
+        serialize16(compassConfig()->mag_declination);
 
         serialize8(batteryConfig()->vbatscale);
         serialize8(batteryConfig()->vbatmincellvoltage);
@@ -1400,7 +1400,7 @@ static bool processInCommand(void)
         rxConfig()->rssi_channel = read8();
         read8();
 
-        compassConfig()->mag_declination = read16() * 10;
+        compassConfig()->mag_declination = read16();
 
         batteryConfig()->vbatscale = read8();           // actual vbatscale as intended
         batteryConfig()->vbatmincellvoltage = read8();  // vbatlevel_warn1 in MWC2.3 GUI


### PR DESCRIPTION
Related to CF cfg issue 153
Requires the corresponding patch in cleanflight-configurator