### PR TITLE
For discussion - should accelerometer, barometer and compass configs be in profile?

### DIFF
--- a/src/main/sensors/acceleration.c
+++ b/src/main/sensors/acceleration.c
@@ -44,7 +44,7 @@
 
 #include "sensors/acceleration.h"
 
-PG_REGISTER_PROFILE_WITH_RESET_FN(accelerometerConfig_t, accelerometerConfig, PG_ACCELEROMETER_CONFIG, 0);
+PG_REGISTER_WITH_RESET_FN(accelerometerConfig_t, accelerometerConfig, PG_ACCELEROMETER_CONFIG, 0);
 
 void resetRollAndPitchTrims(rollAndPitchTrims_t *rollAndPitchTrims)
 {

--- a/src/main/sensors/acceleration.h
+++ b/src/main/sensors/acceleration.h
@@ -63,7 +63,7 @@ typedef struct accelerometerConfig_s {
     uint8_t acc_unarmedcal;                 // turn automatic acc compensation on/off
 } accelerometerConfig_t;
 
-PG_DECLARE_PROFILE(accelerometerConfig_t, accelerometerConfig);
+PG_DECLARE(accelerometerConfig_t, accelerometerConfig);
 
 bool isAccelerationCalibrationComplete(void);
 void accSetCalibrationCycles(uint16_t calibrationCyclesRequired);

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -45,7 +45,7 @@ int32_t BaroAlt = 0;
 
 #ifdef BARO
 
-PG_REGISTER_PROFILE_WITH_RESET_TEMPLATE(barometerConfig_t, barometerConfig, PG_BAROMETER_CONFIG, 0);
+PG_REGISTER_WITH_RESET_TEMPLATE(barometerConfig_t, barometerConfig, PG_BAROMETER_CONFIG, 0);
 
 static int32_t baroGroundAltitude = 0;
 static int32_t baroGroundPressure = 0;

--- a/src/main/sensors/barometer.h
+++ b/src/main/sensors/barometer.h
@@ -40,7 +40,7 @@ typedef struct barometerConfig_s {
     float baro_cf_alt;                      // apply CF to use ACC for height estimation
 } barometerConfig_t;
 
-PG_DECLARE_PROFILE(barometerConfig_t, barometerConfig);
+PG_DECLARE(barometerConfig_t, barometerConfig);
 
 bool isBaroCalibrationComplete(void);
 void baroSetCalibrationCycles(uint16_t calibrationCyclesRequired);

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -44,7 +44,7 @@
 #include "hardware_revision.h"
 #endif
 
-PG_REGISTER_PROFILE_WITH_RESET_TEMPLATE(compassConfig_t, compassConfig, PG_COMPASS_CONFIGURATION, 0);
+PG_REGISTER_WITH_RESET_TEMPLATE(compassConfig_t, compassConfig, PG_COMPASS_CONFIGURATION, 0);
 
 PG_RESET_TEMPLATE(compassConfig_t, compassConfig,
     .mag_declination = 0,

--- a/src/main/sensors/compass.h
+++ b/src/main/sensors/compass.h
@@ -33,7 +33,7 @@ typedef struct compassConfig_s {
                                             // For example, -6deg 37min, = -637 Japan, format is [sign]dddmm (degreesminutes) default is zero.
 } compassConfig_t;
 
-PG_DECLARE_PROFILE(compassConfig_t, compassConfig);
+PG_DECLARE(compassConfig_t, compassConfig);
 
 
 #ifdef MAG

--- a/src/test/unit/config_eeprom_unittest.cc
+++ b/src/test/unit/config_eeprom_unittest.cc
@@ -80,11 +80,11 @@ extern "C" {
     PG_REGISTER_PROFILE(gimbalConfig_t, gimbalConfig, PG_GIMBAL_CONFIG, 0);
     PG_REGISTER_PROFILE(rcControlsConfig_t, rcControlsConfig, PG_RC_CONTROLS_CONFIG, 0);
     PG_REGISTER_PROFILE(pidProfile_t, pidProfile, PG_PID_PROFILE, 0);
-    PG_REGISTER_PROFILE(accelerometerConfig_t, accelerometerConfig, PG_ACCELEROMETER_CONFIG, 0);
+    PG_REGISTER(accelerometerConfig_t, accelerometerConfig, PG_ACCELEROMETER_CONFIG, 0);
     PG_REGISTER_PROFILE(rateProfileSelection_t, rateProfileSelection, PG_RATE_PROFILE_SELECTION, 0);
-    PG_REGISTER_PROFILE(barometerConfig_t, barometerConfig, PG_BAROMETER_CONFIG, 0);
+    PG_REGISTER(barometerConfig_t, barometerConfig, PG_BAROMETER_CONFIG, 0);
     PG_REGISTER_PROFILE(throttleCorrectionConfig_t, throttleCorrectionConfig, PG_THROTTLE_CORRECTION_CONFIG, 0);
-    PG_REGISTER_PROFILE(compassConfig_t, compassConfig, PG_COMPASS_CONFIGURATION, 0);
+    PG_REGISTER(compassConfig_t, compassConfig, PG_COMPASS_CONFIGURATION, 0);
     PG_REGISTER_PROFILE(gpsProfile_t, gpsProfile, PG_NAVIGATION_CONFIG, 0);
     PG_REGISTER_PROFILE(modeActivationProfile_t, modeActivationProfile, PG_MODE_ACTIVATION_PROFILE, 0);
     PG_REGISTER_PROFILE(servoProfile_t, servoProfile, PG_SERVO_PROFILE, 0);

--- a/src/test/unit/flight_altitudehold_unittest.cc
+++ b/src/test/unit/flight_altitudehold_unittest.cc
@@ -59,8 +59,8 @@ extern "C" {
 
     PG_REGISTER_PROFILE(pidProfile_t, pidProfile, PG_PID_PROFILE, 0);
     PG_REGISTER_PROFILE(rcControlsConfig_t, rcControlsConfig, PG_RC_CONTROLS_CONFIG, 0);
-    PG_REGISTER_PROFILE(barometerConfig_t, barometerConfig, PG_BAROMETER_CONFIG, 0);
 
+    PG_REGISTER(barometerConfig_t, barometerConfig, PG_BAROMETER_CONFIG, 0);
     PG_REGISTER(motorAndServoConfig_t, motorAndServoConfig, PG_MOTOR_AND_SERVO_CONFIG, 0);
 
     extern uint32_t rcModeActivationMask;

--- a/src/test/unit/flight_imu_unittest.cc
+++ b/src/test/unit/flight_imu_unittest.cc
@@ -61,8 +61,8 @@ extern "C" {
 
     PG_REGISTER_PROFILE(pidProfile_t, pidProfile, PG_PID_PROFILE, 0);
     PG_REGISTER_PROFILE(rcControlsConfig_t, rcControlsConfig, PG_RC_CONTROLS_CONFIG, 0);
-    PG_REGISTER_PROFILE(barometerConfig_t, barometerConfig, PG_BAROMETER_CONFIG, 0);
-    PG_REGISTER_PROFILE(compassConfig_t, compassConfig, PG_COMPASS_CONFIGURATION, 0);
+    PG_REGISTER(barometerConfig_t, barometerConfig, PG_BAROMETER_CONFIG, 0);
+    PG_REGISTER(compassConfig_t, compassConfig, PG_COMPASS_CONFIGURATION, 0);
     PG_REGISTER(motorAndServoConfig_t, motorAndServoConfig, PG_MOTOR_AND_SERVO_CONFIG, 0);
 
 }

--- a/src/test/unit/msp_unittest.cc
+++ b/src/test/unit/msp_unittest.cc
@@ -113,9 +113,9 @@ extern "C" {
     void pgResetFn_pidProfile(pidProfile_t *) {}
 
     PG_REGISTER_PROFILE(rcControlsConfig_t, rcControlsConfig, PG_RC_CONTROLS_CONFIG, 0);
-    PG_REGISTER_PROFILE(accelerometerConfig_t, accelerometerConfig, PG_ACCELEROMETER_CONFIG, 0);
+    PG_REGISTER(accelerometerConfig_t, accelerometerConfig, PG_ACCELEROMETER_CONFIG, 0);
     PG_REGISTER_PROFILE(adjustmentProfile_t, adjustmentProfile, PG_ADJUSTMENT_PROFILE, 0);
-    PG_REGISTER_PROFILE(compassConfig_t, compassConfig, PG_COMPASS_CONFIGURATION, 0);
+    PG_REGISTER(compassConfig_t, compassConfig, PG_COMPASS_CONFIGURATION, 0);
     PG_REGISTER_PROFILE(modeActivationProfile_t, modeActivationProfile, PG_MODE_ACTIVATION_PROFILE, 0);
     PG_REGISTER_PROFILE(servoProfile_t, servoProfile, PG_SERVO_PROFILE, 0);
 }


### PR DESCRIPTION
This is a "for discussion" PR.

Should `accelerometerConfig_t`, `barometerConfig_t` and `compassConfig_t` be part of the profile? I think not, but others may disagree, hence this is raised for discussion.

If there is consensus that any or all of these should be removed from the profile, then this PR provides @hydra with an easy way to cherry pick the items to remove.

(And isn't it great that the new `PG` macros make it so easy to change this?)
