### PR TITLE
Simplifies call to sonarGetHardwareConfiguration

### DIFF
--- a/src/main/main.c
+++ b/src/main/main.c
@@ -117,7 +117,7 @@ void mixerUsePWMIOConfiguration(pwmIOConfiguration_t *pwmIOConfiguration);
 void rxInit(modeActivationCondition_t *modeActivationConditions);
 
 void navigationInit(pidProfile_t *pidProfile);
-const sonarHardware_t *sonarGetHardwareConfiguration(batteryConfig_t *batteryConfig);
+const sonarHardware_t *sonarGetHardwareConfiguration(currentSensor_e  currentMeterType);
 void sonarInit(const sonarHardware_t *sonarHardware);
 
 #ifdef STM32F303xC
@@ -328,7 +328,7 @@ void init(void)
     const sonarHardware_t *sonarHardware = NULL;
 
     if (feature(FEATURE_SONAR)) {
-        sonarHardware = sonarGetHardwareConfiguration(batteryConfig());
+        sonarHardware = sonarGetHardwareConfiguration(batteryConfig()->currentMeterType);
         sonarGPIOConfig_t sonarGPIOConfig = {
             .gpio = SONAR_GPIO,
             .triggerPin = sonarHardware->echo_pin,

--- a/src/main/sensors/sonar.c
+++ b/src/main/sensors/sonar.c
@@ -87,10 +87,10 @@ const sonarHardware_t *sonarGetHardwareConfiguration(currentSensor_e  currentMet
         return &sonarRC;
     }
 #elif defined(SONAR_TRIGGER_PIN)
-    UNUSED(batteryConfig);
+    UNUSED(currentMeterType);
     return &sonarRC;
 #elif defined(UNIT_TEST)
-    UNUSED(batteryConfig);
+    UNUSED(currentMeterType);
     return 0;
 #else
 #error Sonar not defined for target

--- a/src/main/sensors/sonar.c
+++ b/src/main/sensors/sonar.c
@@ -53,7 +53,7 @@ float sonarMaxTiltCos;
 
 static int32_t calculatedAltitude;
 
-const sonarHardware_t *sonarGetHardwareConfiguration(batteryConfig_t *batteryConfig)
+const sonarHardware_t *sonarGetHardwareConfiguration(currentSensor_e  currentMeterType)
 {
 #if defined(SONAR_PWM_TRIGGER_PIN)
     static const sonarHardware_t const sonarPWM = {
@@ -81,7 +81,7 @@ const sonarHardware_t *sonarGetHardwareConfiguration(batteryConfig_t *batteryCon
     // If we are using softserial, parallel PWM or ADC current sensor, then use motor pins 5 and 6 for sonar, otherwise use RC pins 7 and 8
     if (feature(FEATURE_SOFTSERIAL)
             || feature(FEATURE_RX_PARALLEL_PWM )
-            || (feature(FEATURE_CURRENT_METER) && batteryConfig->currentMeterType == CURRENT_SENSOR_ADC)) {
+            || (feature(FEATURE_CURRENT_METER) && currentMeterType == CURRENT_SENSOR_ADC)) {
         return &sonarPWM;
     } else {
         return &sonarRC;


### PR DESCRIPTION
Simplifies call to `sonarGetHardwareConfiguration` by just passing `currentMeterType` since that is all that is used.