### PR TITLE
Cleanup 4way interface

### DIFF
--- a/src/main/io/serial_4way.c
+++ b/src/main/io/serial_4way.c
@@ -347,12 +347,11 @@ static uint8_t currentInterfaceMode;
 
 static uint8_t Connect(deviceInfo_t *pDeviceInfo)
 {
-    for (int i = 0; i < 3; i++) {    // TODO - probaly useless
+    for (int try = 0; try < 3; try++) {
 #if defined(USE_SERIAL_4WAY_SK_BOOTLOADER)
-        if (Stk_ConnectEx(pDeviceInfo)) {
+        if (Stk_ConnectEx(pDeviceInfo) && signatureMatch(pDeviceInfo->signature, signaturesAtmel)) {
             currentInterfaceMode = imSK;
-            if(signatureMatch(pDeviceInfo->signature, signaturesAtmel))
-                return 1;
+            return 1;
         }
 #endif
 #if defined(USE_SERIAL_4WAY_BLHELI_BOOTLOADER)

--- a/src/main/io/serial_4way.c
+++ b/src/main/io/serial_4way.c
@@ -181,12 +181,10 @@ void DeInitialize4WayInterface(void)
 }
 
 // Interface related only
-// establish and test connection to the Interface
-
 // Send Structure
-// ESC CMD ADDR_H ADDR_L PARAM_LEN [PARAM (if len > 0)] CRC16_Hi CRC16_Lo
+// ESC CMD ADDR_H ADDR_L PARAM_LEN PARAM (256B if len == 0) CRC16_Hi CRC16_Lo
 // Return
-// ESC CMD ADDR_H ADDR_L PARAM_LEN [PARAM (if len > 0)] + ACK (uint8_t OK or ERR) + CRC16_Hi CRC16_Lo
+// ESC CMD ADDR_H ADDR_L PARAM_LEN PARAM (256B if len == 0) + ACK (uint8_t OK or ERR) + CRC16_Hi CRC16_Lo
 
 typedef enum {
     cmd_Remote_Escape       = 0x2E, // '.'
@@ -401,7 +399,7 @@ static void WriteByteCrc(uint8_t b)
 
 void Process4WayInterface(serialPort_t *serial) {
     uint8_t paramBuf[256];
-    uint8_t paramInLen;
+    int paramInLen;
     uint8_t CMD;
     uint8_t ACK_OUT;
     uint8_16_u Dummy;
@@ -430,11 +428,13 @@ void Process4WayInterface(serialPort_t *serial) {
 
         Dummy.word = 0;
         O_PARAM = &Dummy.bytes[0];
-        O_PARAM_LEN = 1;
+        O_PARAM_LEN = 1;                       // must always return non-zero length
         CMD = ReadByteCrc();
         ioMem.D_FLASH_ADDR_H = ReadByteCrc();
         ioMem.D_FLASH_ADDR_L = ReadByteCrc();
         paramInLen = ReadByteCrc();
+        if(!paramInLen)
+            paramInLen = 0x100;                // len ==0 -> param is 256B
 
         for(int i = 0; i < paramInLen; i++)
             paramBuf[i] = ReadByteCrc();
@@ -452,8 +452,6 @@ void Process4WayInterface(serialPort_t *serial) {
         }
 
         if (ACK_OUT == ACK_OK) {
-            // wtf.D_FLASH_ADDR_H=Adress_H;
-            // wtf.D_FLASH_ADDR_L=Adress_L;
             ioMem.D_PTR_I = paramBuf;
 
             switch(CMD) {
@@ -701,9 +699,9 @@ void Process4WayInterface(serialPort_t *serial) {
         WriteByteCrc(CMD);
         WriteByteCrc(ioMem.D_FLASH_ADDR_H);
         WriteByteCrc(ioMem.D_FLASH_ADDR_L);
-        WriteByteCrc(O_PARAM_LEN);
+        WriteByteCrc(O_PARAM_LEN & 0xff);
 
-        for(int i = 0; i < O_PARAM_LEN; i++)
+        for(int i = 0; i < O_PARAM_LEN ? O_PARAM_LEN : 0x100; i++)  // TODO
             WriteByteCrc(O_PARAM[i]);
 
         WriteByteCrc(ACK_OUT);

--- a/src/main/io/serial_4way.c
+++ b/src/main/io/serial_4way.c
@@ -23,17 +23,17 @@
 #include <stdarg.h>
 
 #include <platform.h>
+
 #ifdef  USE_SERIAL_4WAY_BLHELI_INTERFACE
+
 #include "config/parameter_group.h"
 #include "drivers/serial.h"
-#include "drivers/buf_writer.h"
 #include "drivers/gpio.h"
 #include "drivers/timer.h"
 #include "drivers/pwm_mapping.h"
 #include "drivers/pwm_output.h"
 #include "drivers/light_led.h"
 #include "drivers/system.h"
-#include "drivers/buf_writer.h"
 #include "flight/mixer.h"
 #include "io/beeper.h"
 #include "io/serial_msp.h"
@@ -41,97 +41,98 @@
 #include "io/serial_4way.h"
 
 #ifdef USE_SERIAL_4WAY_BLHELI_BOOTLOADER
-#include "io/serial_4way_avrootloader.h"
+# include "io/serial_4way_avrootloader.h"
 #endif
-#if defined(USE_SERIAL_4WAY_SK_BOOTLOADER)
-#include "io/serial_4way_stk500v2.h"
+#ifdef USE_SERIAL_4WAY_SK_BOOTLOADER
+# include "io/serial_4way_stk500v2.h"
 #endif
 
 #define USE_TXRX_LED
 
-#ifdef  USE_TXRX_LED
-#define RX_LED_OFF LED0_OFF
-#define RX_LED_ON LED0_ON
-#ifdef  LED1
-#define TX_LED_OFF LED1_OFF
-#define TX_LED_ON LED1_ON
+#if defined(USE_TXRX_LED) && defined(LED0)
+# define RX_LED_OFF   LED0_OFF
+# define RX_LED_ON    LED0_ON
+# ifdef  LED1
+#  define TX_LED_OFF  LED1_OFF
+#  define TX_LED_ON   LED1_ON
+# else
+#  define TX_LED_OFF  LED0_OFF
+#  define TX_LED_ON   LED0_ON
+# endif
 #else
-#define TX_LED_OFF LED0_OFF
-#define TX_LED_ON LED0_ON
-#endif
-#else
-#define RX_LED_OFF
-#define RX_LED_ON
-#define TX_LED_OFF
-#define TX_LED_ON
+# define RX_LED_OFF   do {} while(0)
+# define RX_LED_ON    do {} while(0)
+# define TX_LED_OFF   do {} while(0)
+# define TX_LED_ON    do {} while(0)
 #endif
 
 #define SERIAL_4WAY_INTERFACE_NAME_STR "m4wFCIntf"
 // *** change to adapt Revision
-#define SERIAL_4WAY_VER_MAIN 14
-#define SERIAL_4WAY_VER_SUB_1 (uint8_t) 4
-#define SERIAL_4WAY_VER_SUB_2 (uint8_t) 04
+#define SERIAL_4WAY_VER_MAIN  14
+#define SERIAL_4WAY_VER_SUB_1 ((uint8_t)4)
+#define SERIAL_4WAY_VER_SUB_2 ((uint8_t)4)
 
 #define SERIAL_4WAY_PROTOCOL_VER 106
 // *** end
 
 #if (SERIAL_4WAY_VER_MAIN > 24)
-#error "beware of SERIAL_4WAY_VER_SUB_1 is uint8_t"
+# error "beware of SERIAL_4WAY_VER_SUB_1 is uint8_t"
 #endif
 
-#define SERIAL_4WAY_VERSION (uint16_t) ((SERIAL_4WAY_VER_MAIN * 1000) + (SERIAL_4WAY_VER_SUB_1 * 100) + SERIAL_4WAY_VER_SUB_2)
+#define SERIAL_4WAY_VERSION ((uint16_t)((SERIAL_4WAY_VER_MAIN * 1000) + (SERIAL_4WAY_VER_SUB_1 * 100) + SERIAL_4WAY_VER_SUB_2))
 
 #define SERIAL_4WAY_VERSION_HI (uint8_t) (SERIAL_4WAY_VERSION / 100)
 #define SERIAL_4WAY_VERSION_LO (uint8_t) (SERIAL_4WAY_VERSION % 100)
 
 static uint8_t escCount;
+uint8_t escSelected;
 
 escHardware_t escHardware[MAX_PWM_MOTORS];
 
-uint8_t selected_esc;
+static deviceInfo_t deviceInfo;
 
-uint8_32_u DeviceInfo;
-
-#define DeviceInfoSize 4
-
-inline bool isMcuConnected(void)
+bool isMcuConnected(void)
 {
-    return (DeviceInfo.bytes[0] > 0);
+    return deviceInfo.signature != 0;
 }
 
-inline bool isEscHi(uint8_t selEsc)
+static void setDisconnected(void) {
+    deviceInfo.signature = 0;
+}
+
+bool isEscHi(uint8_t selEsc)
 {
     return (digitalIn(escHardware[selEsc].gpio, escHardware[selEsc].pin) != Bit_RESET);
 }
-inline bool isEscLo(uint8_t selEsc)
+
+bool isEscLo(uint8_t selEsc)
 {
     return (digitalIn(escHardware[selEsc].gpio, escHardware[selEsc].pin) == Bit_RESET);
 }
 
-inline void setEscHi(uint8_t selEsc)
+void setEscHi(uint8_t selEsc)
 {
     digitalHi(escHardware[selEsc].gpio, escHardware[selEsc].pin);
 }
 
-inline void setEscLo(uint8_t selEsc)
+void setEscLo(uint8_t selEsc)
 {
     digitalLo(escHardware[selEsc].gpio, escHardware[selEsc].pin);
 }
 
-inline void setEscInput(uint8_t selEsc)
+void setEscInput(uint8_t selEsc)
 {
     gpioInit(escHardware[selEsc].gpio, &escHardware[selEsc].gpio_config_INPUT);
 }
 
-inline void setEscOutput(uint8_t selEsc)
+void setEscOutput(uint8_t selEsc)
 {
     gpioInit(escHardware[selEsc].gpio, &escHardware[selEsc].gpio_config_OUTPUT);
 }
 
 static uint32_t GetPinPos(uint32_t pin)
 {
-    uint32_t pinPos;
-    for (pinPos = 0; pinPos < 16; pinPos++) {
+    for (int pinPos = 0; pinPos < 16; pinPos++) {
         uint32_t pinMask = (0x1 << pinPos);
         if (pin & pinMask) {
             return pinPos;
@@ -140,148 +141,146 @@ static uint32_t GetPinPos(uint32_t pin)
     return 0;
 }
 
-uint8_t Initialize4WayInterface(void)
+int Initialize4WayInterface(void)
 {
     // StopPwmAllMotors();
     pwmDisableMotors();
-    escCount = 0;
     memset(&escHardware, 0, sizeof(escHardware));
     pwmIOConfiguration_t *pwmIOConfiguration = pwmGetOutputConfiguration();
-    for (volatile uint8_t i = 0; i < pwmIOConfiguration->ioCount; i++) {
+    int escIdx = 0;
+    for (int i = 0; i < pwmIOConfiguration->ioCount; i++) {
         if ((pwmIOConfiguration->ioConfigurations[i].flags & PWM_PF_MOTOR) == PWM_PF_MOTOR) {
             if(motor[pwmIOConfiguration->ioConfigurations[i].index] > 0) {
-                escHardware[escCount].gpio = pwmIOConfiguration->ioConfigurations[i].timerHardware->gpio;
-                escHardware[escCount].pin = pwmIOConfiguration->ioConfigurations[i].timerHardware->pin;
-                escHardware[escCount].pinpos = GetPinPos(escHardware[escCount].pin);
-                escHardware[escCount].gpio_config_INPUT.pin = escHardware[escCount].pin;
-                escHardware[escCount].gpio_config_INPUT.speed = Speed_2MHz; // see pwmOutConfig()
-                escHardware[escCount].gpio_config_INPUT.mode = Mode_IPU;
-                escHardware[escCount].gpio_config_OUTPUT = escHardware[escCount].gpio_config_INPUT;
-                escHardware[escCount].gpio_config_OUTPUT.mode = Mode_Out_PP;
-                setEscInput(escCount);
-                setEscHi(escCount);
-                escCount++;
+                escHardware[escIdx].gpio = pwmIOConfiguration->ioConfigurations[i].timerHardware->gpio;
+                escHardware[escIdx].pin = pwmIOConfiguration->ioConfigurations[i].timerHardware->pin;
+                escHardware[escIdx].pinpos = GetPinPos(escHardware[escIdx].pin);
+                escHardware[escIdx].gpio_config_INPUT.pin = escHardware[escIdx].pin;
+                escHardware[escIdx].gpio_config_INPUT.speed = Speed_2MHz; // see pwmOutConfig()
+                escHardware[escIdx].gpio_config_INPUT.mode = Mode_IPU;
+                escHardware[escIdx].gpio_config_OUTPUT = escHardware[escIdx].gpio_config_INPUT;
+                escHardware[escIdx].gpio_config_OUTPUT.mode = Mode_Out_PP;
+                setEscInput(escIdx);
+                setEscHi(escIdx);
+                escIdx++;
             }
         }
     }
+    escCount = escIdx;
     return escCount;
 }
 
 void DeInitialize4WayInterface(void)
 {
-    while (escCount > 0) {
-        escCount--;
-        escHardware[escCount].gpio_config_OUTPUT.mode = Mode_AF_PP; // see pwmOutConfig()
-        setEscOutput(escCount);
-        setEscLo(escCount);
+    for(int i = 0; i < escCount; i++) {
+        escHardware[i].gpio_config_OUTPUT.mode = Mode_AF_PP; // see pwmOutConfig() // TODO
+        setEscOutput(i);
+        setEscLo(i);
     }
+    escCount = 0;
     pwmEnableMotors();
 }
-
-
-#define SET_DISCONNECTED DeviceInfo.words[0] = 0
-
-#define INTF_MODE_IDX 3  // index for DeviceInfostate
 
 // Interface related only
 // establish and test connection to the Interface
 
 // Send Structure
-// ESC + CMD PARAM_LEN [PARAM (if len > 0)] CRC16_Hi CRC16_Lo
+// ESC CMD ADDR_H ADDR_L PARAM_LEN [PARAM (if len > 0)] CRC16_Hi CRC16_Lo
 // Return
-// ESC CMD PARAM_LEN [PARAM (if len > 0)] + ACK (uint8_t OK or ERR) + CRC16_Hi CRC16_Lo
+// ESC CMD ADDR_H ADDR_L PARAM_LEN [PARAM (if len > 0)] + ACK (uint8_t OK or ERR) + CRC16_Hi CRC16_Lo
 
-#define cmd_Remote_Escape 0x2E // '.'
-#define cmd_Local_Escape  0x2F // '/'
+typedef enum {
+    cmd_Remote_Escape       = 0x2E, // '.'
+    cmd_Local_Escape        = 0x2F, // '/'
+} esc_4way_e;
+
+typedef enum {
 
 // Test Interface still present
-#define cmd_InterfaceTestAlive 0x30 // '0' alive
+    cmd_InterfaceTestAlive  = 0x30,  // '0' alive
 // RETURN: ACK
 
 // get Protocol Version Number 01..255
-#define cmd_ProtocolGetVersion 0x31  // '1' version
+    cmd_ProtocolGetVersion  = 0x31,  // '1' version
 // RETURN: uint8_t VersionNumber + ACK
 
 // get Version String
-#define cmd_InterfaceGetName 0x32 // '2' name
+    cmd_InterfaceGetName    = 0x32,  // '2' name
 // RETURN: String + ACK
 
 //get Version Number 01..255
-#define cmd_InterfaceGetVersion 0x33  // '3' version
-// RETURN: uint8_t AVersionNumber + ACK
-
+    cmd_InterfaceGetVersion = 0x33,  // '3' version
+// RETURN: uint16_t VersionNumber + ACK
 
 // Exit / Restart Interface - can be used to switch to Box Mode
-#define cmd_InterfaceExit 0x34       // '4' exit
+    cmd_InterfaceExit       = 0x34,  // '4' exit
 // RETURN: ACK
 
 // Reset the Device connected to the Interface
-#define cmd_DeviceReset 0x35        // '5' reset
+    cmd_DeviceReset         = 0x35,  // '5' reset
+// PARAM: uint8_t escId
 // RETURN: ACK
 
 // Get the Device ID connected
-// #define cmd_DeviceGetID 0x36      //'6' device id removed since 06/106
+//     cmd_DeviceGetID      = 0x36,  // '6' device id removed since 06/106
 // RETURN: uint8_t DeviceID + ACK
 
 // Initialize Flash Access for Device connected
-#define cmd_DeviceInitFlash 0x37    // '7' init flash access
-// RETURN: ACK
+    cmd_DeviceInitFlash     = 0x37,  // '7' init flash access
+// PARAM: uint8_t escId
+// RETURN: uint8_t deviceInfo[4] + ACK
 
 // Erase the whole Device Memory of connected Device
-#define cmd_DeviceEraseAll 0x38     // '8' erase all
+    cmd_DeviceEraseAll      = 0x38,  // '8' erase all
 // RETURN: ACK
 
 // Erase one Page of Device Memory of connected Device
-#define cmd_DevicePageErase 0x39    // '9' page erase
-// PARAM: uint8_t APageNumber
+    cmd_DevicePageErase     = 0x39,  // '9' page erase
+// PARAM: uint8_t APageNumber (512B pages)
+// RETURN: APageNumber ACK
+
+// Read to Buffer from Device Memory of connected Device
+// Buffer Len is Max 256 Bytes, 0 means 256 Bytes
+    cmd_DeviceRead          = 0x3A,  // ':' read Device
+// PARAM: [ADRESS] uint8_t BuffLen
+// RETURN: [ADRESS, len] Buffer[0..256] ACK
+
+// Write to Buffer for Device Memory of connected Device
+// Buffer Len is Max 256 Bytes, 0 means 256 Bytes
+    cmd_DeviceWrite         = 0x3B,  // ';' write
+// PARAM: [ADRESS + BuffLen] Buffer[1..256]
 // RETURN: ACK
 
-// Read to Buffer from Device Memory of connected Device // Buffer Len is Max 256 Bytes
-// BuffLen = 0 means 256 Bytes
-#define cmd_DeviceRead 0x3A  // ':' read Device
-// PARAM: uint8_t ADRESS_Hi + ADRESS_Lo + BuffLen[0..255]
-// RETURN: PARAM: uint8_t ADRESS_Hi + ADRESS_Lo + BUffLen + Buffer[0..255] ACK
-
-// Write to Buffer for Device Memory of connected Device // Buffer Len is Max 256 Bytes
-// BuffLen = 0 means 256 Bytes
-#define cmd_DeviceWrite 0x3B    // ';' write
-// PARAM: uint8_t ADRESS_Hi + ADRESS_Lo + BUffLen + Buffer[0..255]
+// Set C2CK low infinite ) permanent Reset state (unimplemented)
+    cmd_DeviceC2CK_LOW      = 0x3C,  // '<'
 // RETURN: ACK
 
-// Set C2CK low infinite ) permanent Reset state
-#define cmd_DeviceC2CK_LOW 0x3C // '<'
-// RETURN: ACK
+// Read to Buffer from Device Memory of connected Device
+// Buffer Len is Max 256 Bytes, 0 means 256 Bytes
+    cmd_DeviceReadEEprom    = 0x3D,  // '=' read Device
+// PARAM: [ADRESS] uint8_t BuffLen
+// RETURN: [ADRESS + BuffLen] + Buffer[1..256] ACK
 
-// Read to Buffer from Device Memory of connected Device //Buffer Len is Max 256 Bytes
-// BuffLen = 0 means 256 Bytes
-#define cmd_DeviceReadEEprom 0x3D  // '=' read Device
-// PARAM: uint8_t ADRESS_Hi + ADRESS_Lo + BuffLen[0..255]
-// RETURN: PARAM: uint8_t ADRESS_Hi + ADRESS_Lo + BUffLen + Buffer[0..255] ACK
-
-// Write to Buffer for Device Memory of connected Device // Buffer Len is Max 256 Bytes
-// BuffLen = 0 means 256 Bytes
-#define cmd_DeviceWriteEEprom 0x3E  // '>' write
-// PARAM: uint8_t ADRESS_Hi + ADRESS_Lo + BUffLen + Buffer[0..255]
+// Write to Buffer for Device Memory of connected Device
+// Buffer Len is Max 256 Bytes, 0 means 256 Bytes
+    cmd_DeviceWriteEEprom   = 0x3E,  // '>' write
+// PARAM: [ADRESS + BuffLen] Buffer[1..256]
 // RETURN: ACK
 
 // Set Interface Mode
-#define cmd_InterfaceSetMode 0x3F   // '?'
-// #define imC2 0
-// #define imSIL_BLB 1
-// #define imATM_BLB 2
-// #define imSK 3
-// PARAM: uint8_t Mode
-// RETURN: ACK or ACK_I_INVALID_CHANNEL
+    cmd_InterfaceSetMode   = 0x3F,   // '?'
+// PARAM: uint8_t Mode (interfaceMode_e)
+// RETURN: ACK or ACK_I_INVALID_PARAM
+} cmd_4way_e;
 
 // responses
 #define ACK_OK                  0x00
-// #define ACK_I_UNKNOWN_ERROR       0x01
+// #define ACK_I_UNKNOWN_ERROR   0x01
 #define ACK_I_INVALID_CMD       0x02
 #define ACK_I_INVALID_CRC       0x03
 #define ACK_I_VERIFY_ERROR      0x04
 // #define ACK_D_INVALID_COMMAND 0x05
 // #define ACK_D_COMMAND_FAILED  0x06
-// #define ACK_D_UNKNOWN_ERROR       0x07
+// #define ACK_D_UNKNOWN_ERROR   0x07
 
 #define ACK_I_INVALID_CHANNEL   0x08
 #define ACK_I_INVALID_PARAM     0x09
@@ -323,7 +322,7 @@ uint16_t _crc_xmodem_update (uint16_t crc, uint8_t data) {
         int i;
 
         crc = crc ^ ((uint16_t)data << 8);
-        for (i=0; i < 8; i++){
+        for (i = 0; i < 8; i++){
             if (crc & 0x8000)
                 crc = (crc << 1) ^ 0x1021;
             else
@@ -333,111 +332,99 @@ uint16_t _crc_xmodem_update (uint16_t crc, uint8_t data) {
 }
 // * End copyright
 
+static uint16_t signaturesAtmel[] =  {0x9307, 0x930A, 0x930F, 0x940B, 0};
+static uint16_t signaturesSilabs[] = {0xF310, 0xF330, 0xF410, 0xF390, 0xF850, 0xE8B1, 0xE8B2, 0};
 
-#define ATMEL_DEVICE_MATCH ((pDeviceInfo->words[0] == 0x9307) || (pDeviceInfo->words[0] == 0x930A) || \
-        (pDeviceInfo->words[0] == 0x930F) || (pDeviceInfo->words[0] == 0x940B))
-
-#define SILABS_DEVICE_MATCH ((pDeviceInfo->words[0] == 0xF310)||(pDeviceInfo->words[0] ==0xF330) || \
-        (pDeviceInfo->words[0] == 0xF410) || (pDeviceInfo->words[0] == 0xF390) || \
-        (pDeviceInfo->words[0] == 0xF850) || (pDeviceInfo->words[0] == 0xE8B1) || \
-        (pDeviceInfo->words[0] == 0xE8B2))
-
-static uint8_t CurrentInterfaceMode;
-
-static uint8_t Connect(uint8_32_u *pDeviceInfo)
+static bool signatureMatch(uint16_t signature, uint16_t *list)
 {
-    for (uint8_t I = 0; I < 3; ++I) {
-        #if (defined(USE_SERIAL_4WAY_BLHELI_BOOTLOADER) && defined(USE_SERIAL_4WAY_SK_BOOTLOADER))
-        if (Stk_ConnectEx(pDeviceInfo) && ATMEL_DEVICE_MATCH) {
-            CurrentInterfaceMode = imSK;
-            return 1;
-        } else {
-            if (BL_ConnectEx(pDeviceInfo)) {
-                if  SILABS_DEVICE_MATCH {
-                    CurrentInterfaceMode = imSIL_BLB;
-                    return 1;
-                } else if ATMEL_DEVICE_MATCH {
-                    CurrentInterfaceMode = imATM_BLB;
-                    return 1;
-                }
-            }
-        }
-        #elif defined(USE_SERIAL_4WAY_BLHELI_BOOTLOADER)
-        if (BL_ConnectEx(pDeviceInfo)) {
-            if SILABS_DEVICE_MATCH {
-                CurrentInterfaceMode = imSIL_BLB;
-                return 1;
-            } else if ATMEL_DEVICE_MATCH {
-                CurrentInterfaceMode = imATM_BLB;
-                return 1;
-            }
-        }
-        #elif defined(USE_SERIAL_4WAY_SK_BOOTLOADER)
+    for(; *list; list++)
+        if(signature == *list)
+            return true;
+    return false;
+}
+
+static uint8_t currentInterfaceMode;
+
+static uint8_t Connect(deviceInfo_t *pDeviceInfo)
+{
+    for (int i = 0; i < 3; i++) {    // TODO - probaly useless
+#if defined(USE_SERIAL_4WAY_SK_BOOTLOADER)
         if (Stk_ConnectEx(pDeviceInfo)) {
-            CurrentInterfaceMode = imSK;
-            if ATMEL_DEVICE_MATCH return 1;
+            currentInterfaceMode = imSK;
+            if(signatureMatch(pDeviceInfo->signature, signaturesAtmel))
+                return 1;
         }
-        #endif
+#endif
+#if defined(USE_SERIAL_4WAY_BLHELI_BOOTLOADER)
+        if (BL_ConnectEx(pDeviceInfo)) {
+            if(signatureMatch(pDeviceInfo->signature, signaturesSilabs)) {
+                currentInterfaceMode = imSIL_BLB;
+                return 1;
+            }
+            if(signatureMatch(pDeviceInfo->signature, signaturesAtmel)) {
+                currentInterfaceMode = imATM_BLB;
+                return 1;
+            }
+        }
+#endif
     }
     return 0;
 }
 
-static mspPort_t *_mspPort;
-static bufWriter_t *_writer;
+static serialPort_t *port;
+static uint16_t crcIn, crcOut;
 
-static uint8_t ReadByte(void) {
+static uint8_t ReadByte(void)
+{
     // need timeout?
-    while (!serialRxBytesWaiting(_mspPort->port));
-    return serialRead(_mspPort->port);
+    while (!serialRxBytesWaiting(port));
+    return serialRead(port);
 }
 
-static uint8_16_u CRC_in;
-static uint8_t ReadByteCrc(void) {
+static uint8_t ReadByteCrc(void)
+{
     uint8_t b = ReadByte();
-    CRC_in.word = _crc_xmodem_update(CRC_in.word, b);
+    crcIn = _crc_xmodem_update(crcIn, b);
     return b;
 }
-static void WriteByte(uint8_t b){
-    bufWriterAppend(_writer, b);
+
+static void WriteByte(uint8_t b)
+{
+    serialWrite(port, b);
 }
 
-static uint8_16_u CRCout;
-static void WriteByteCrc(uint8_t b){
+static void WriteByteCrc(uint8_t b)
+{
     WriteByte(b);
-    CRCout.word = _crc_xmodem_update(CRCout.word, b);
+    crcOut = _crc_xmodem_update(crcOut, b);
 }
 
-void Process4WayInterface(mspPort_t *mspPort, bufWriter_t *bufwriter) {
-
-    uint8_t ParamBuf[256];
-    uint8_t ESC;
-    uint8_t I_PARAM_LEN;
+void Process4WayInterface(serialPort_t *serial) {
+    uint8_t paramBuf[256];
+    uint8_t paramInLen;
     uint8_t CMD;
     uint8_t ACK_OUT;
-    uint8_16_u CRC_check;
     uint8_16_u Dummy;
     uint8_t O_PARAM_LEN;
     uint8_t *O_PARAM;
-    uint8_t *InBuff;
     ioMem_t ioMem;
 
-    _mspPort = mspPort;
-    _writer = bufwriter;
+    port = serial;
 
     // Start here  with UART Main loop
-    #ifdef BEEPER
+#ifdef BEEPER
     // fix for buzzer often starts beeping continuously when the ESCs are read
     // switch beeper silent here
     beeperSilence();
-    #endif
+#endif
     bool isExitScheduled = false;
 
     while(1) {
         // restart looking for new sequence from host
-        do {
-            CRC_in.word = 0;
-            ESC = ReadByteCrc();
-        } while (ESC != cmd_Local_Escape);
+        crcIn = 0;
+        uint8_t esc = ReadByteCrc();
+        if(esc != cmd_Local_Escape)
+            continue;  // wait for sync character
 
         RX_LED_ON;
 
@@ -447,397 +434,288 @@ void Process4WayInterface(mspPort_t *mspPort, bufWriter_t *bufwriter) {
         CMD = ReadByteCrc();
         ioMem.D_FLASH_ADDR_H = ReadByteCrc();
         ioMem.D_FLASH_ADDR_L = ReadByteCrc();
-        I_PARAM_LEN = ReadByteCrc();
+        paramInLen = ReadByteCrc();
 
-        InBuff = ParamBuf;
-        uint8_t i = I_PARAM_LEN;
-        do {
-          *InBuff = ReadByteCrc();
-          InBuff++;
-          i--;
-        } while (i != 0);
+        for(int i = 0; i < paramInLen; i++)
+            paramBuf[i] = ReadByteCrc();
 
-        CRC_check.bytes[1] = ReadByte();
-        CRC_check.bytes[0] = ReadByte();
+        uint16_t crc;
+        crc = ReadByte() << 8;
+        crc |= ReadByte();
 
         RX_LED_OFF;
 
-        if(CRC_check.word == CRC_in.word) {
-            ACK_OUT = ACK_OK;
-        } else {
+        ACK_OUT = ACK_OK;
+
+        if(crcIn != crc) {
             ACK_OUT = ACK_I_INVALID_CRC;
         }
 
-        if (ACK_OUT == ACK_OK)
-        {
+        if (ACK_OUT == ACK_OK) {
             // wtf.D_FLASH_ADDR_H=Adress_H;
             // wtf.D_FLASH_ADDR_L=Adress_L;
-            ioMem.D_PTR_I = ParamBuf;
+            ioMem.D_PTR_I = paramBuf;
 
             switch(CMD) {
                 // ******* Interface related stuff *******
                 case cmd_InterfaceTestAlive:
-                {
-                    if (isMcuConnected()){
-                        switch(CurrentInterfaceMode)
-                        {
-                            #ifdef USE_SERIAL_4WAY_BLHELI_BOOTLOADER
+                    if (isMcuConnected()) {
+                        switch(currentInterfaceMode) {
+#ifdef USE_SERIAL_4WAY_BLHELI_BOOTLOADER
                             case imATM_BLB:
                             case imSIL_BLB:
-                            {
                                 if (!BL_SendCMDKeepAlive()) { // SetStateDisconnected() included
                                     ACK_OUT = ACK_D_GENERAL_ERROR;
                                 }
                                 break;
-                            }
-                            #endif
-                            #ifdef USE_SERIAL_4WAY_SK_BOOTLOADER
+#endif
+#ifdef USE_SERIAL_4WAY_SK_BOOTLOADER
                             case imSK:
-                            {
                                 if (!Stk_SignOn()) { // SetStateDisconnected();
                                     ACK_OUT = ACK_D_GENERAL_ERROR;
                                 }
                                 break;
-                            }
-                            #endif
+#endif
                             default:
                                 ACK_OUT = ACK_D_GENERAL_ERROR;
                         }
-                        if ( ACK_OUT != ACK_OK) SET_DISCONNECTED;
+                        if (ACK_OUT != ACK_OK)
+                            setDisconnected();
                     }
                     break;
-                }
+
                 case cmd_ProtocolGetVersion:
-                {
                     // Only interface itself, no matter what Device
                     Dummy.bytes[0] = SERIAL_4WAY_PROTOCOL_VER;
                     break;
-                }
 
                 case cmd_InterfaceGetName:
-                {
                     // Only interface itself, no matter what Device
                     // O_PARAM_LEN=16;
                     O_PARAM_LEN = strlen(SERIAL_4WAY_INTERFACE_NAME_STR);
                     O_PARAM = (uint8_t *)SERIAL_4WAY_INTERFACE_NAME_STR;
                     break;
-                }
 
                 case cmd_InterfaceGetVersion:
-                {
                     // Only interface itself, no matter what Device
                     // Dummy = iUart_res_InterfVersion;
                     O_PARAM_LEN = 2;
                     Dummy.bytes[0] = SERIAL_4WAY_VERSION_HI;
                     Dummy.bytes[1] = SERIAL_4WAY_VERSION_LO;
                     break;
-                }
+
                 case cmd_InterfaceExit:
-                {
                     isExitScheduled = true;
                     break;
-                }
+
                 case cmd_InterfaceSetMode:
-                {
-                    #if defined(USE_SERIAL_4WAY_BLHELI_BOOTLOADER) && defined(USE_SERIAL_4WAY_SK_BOOTLOADER)
-                    if ((ParamBuf[0] <= imSK) && (ParamBuf[0] >= imSIL_BLB)) {
-                    #elif defined(USE_SERIAL_4WAY_BLHELI_BOOTLOADER)
-                    if ((ParamBuf[0] <= imATM_BLB) && (ParamBuf[0] >= imSIL_BLB)) {
-                    #elif defined(USE_SERIAL_4WAY_SK_BOOTLOADER)
-                    if (ParamBuf[0] == imSK) {
-                    #endif
-                        CurrentInterfaceMode = ParamBuf[0];
-                    } else {
-                        ACK_OUT = ACK_I_INVALID_PARAM;
+                    switch(paramBuf[0]) {
+#if defined(USE_SERIAL_4WAY_BLHELI_BOOTLOADER)
+                        case imSIL_BLB:
+                        case imATM_BLB:
+#endif
+#if defined(USE_SERIAL_4WAY_SK_BOOTLOADER)
+                        case imSK:
+#endif
+                            currentInterfaceMode = paramBuf[0];
+                            break;
+                        default:
+                            ACK_OUT = ACK_I_INVALID_PARAM;
                     }
                     break;
-                }
 
                 case cmd_DeviceReset:
-                {
-                    if (ParamBuf[0] < escCount) {
-                        // Channel may change here
-                        selected_esc = ParamBuf[0];
-                    }
-                    else {
+                    if(paramBuf[0] >= escCount) {
                         ACK_OUT = ACK_I_INVALID_CHANNEL;
                         break;
                     }
-                    switch (CurrentInterfaceMode)
-                    {
-                    case imSIL_BLB:
-                        #ifdef USE_SERIAL_4WAY_BLHELI_BOOTLOADER
+                    // Channel may change here
+                    escSelected = paramBuf[0];
+                    switch (currentInterfaceMode) {
+                        case imSIL_BLB:            // TODO!
+#ifdef USE_SERIAL_4WAY_BLHELI_BOOTLOADER
                         case imATM_BLB:
-                        {
-                            BL_SendCMDRunRestartBootloader(&DeviceInfo);
+                            BL_SendCMDRunRestartBootloader(&deviceInfo);
                             break;
-                        }
-                        #endif
-                        #ifdef USE_SERIAL_4WAY_SK_BOOTLOADER
+#endif
+#ifdef USE_SERIAL_4WAY_SK_BOOTLOADER
                         case imSK:
-                        {
                             break;
-                        }
-                        #endif
+#endif
                     }
-                    SET_DISCONNECTED;
+                    setDisconnected();
                     break;
-                }
+
                 case cmd_DeviceInitFlash:
-                {
-                    SET_DISCONNECTED;
-                    if (ParamBuf[0] < escCount) {
-                        //Channel may change here
-                        //ESC_LO or ESC_HI; Halt state for prev channel
-                        selected_esc = ParamBuf[0];
-                    } else {
+                    setDisconnected();
+                    if (paramBuf[0] >= escCount) {
                         ACK_OUT = ACK_I_INVALID_CHANNEL;
                         break;
                     }
-                    O_PARAM_LEN = DeviceInfoSize; //4
-                    O_PARAM = (uint8_t *)&DeviceInfo;
-                    if(Connect(&DeviceInfo)) {
-                        DeviceInfo.bytes[INTF_MODE_IDX] = CurrentInterfaceMode;
-                    } else {
-                        SET_DISCONNECTED;
+                    //Channel may change here
+                    //ESC_LO or ESC_HI; Halt state for prev channel
+                    escSelected = paramBuf[0];
+                    O_PARAM_LEN = sizeof(deviceInfo);
+                    O_PARAM = (uint8_t*)&deviceInfo;
+                    if(!Connect(&deviceInfo)) {
+                        setDisconnected();
                         ACK_OUT = ACK_D_GENERAL_ERROR;
                     }
+                    deviceInfo.interfaceMode = currentInterfaceMode;
                     break;
-                }
 
-                #ifdef USE_SERIAL_4WAY_SK_BOOTLOADER
+#ifdef USE_SERIAL_4WAY_SK_BOOTLOADER
                 case cmd_DeviceEraseAll:
-                {
-                    switch(CurrentInterfaceMode)
-                    {
+                    switch(currentInterfaceMode) {
                         case imSK:
-                        {
-                            if (!Stk_Chip_Erase()) ACK_OUT=ACK_D_GENERAL_ERROR;
+                            if (!Stk_Chip_Erase())
+                                ACK_OUT=ACK_D_GENERAL_ERROR;
                             break;
-                        }
                         default:
                             ACK_OUT = ACK_I_INVALID_CMD;
                     }
                     break;
-                }
-                #endif
+#endif
 
-                #ifdef USE_SERIAL_4WAY_BLHELI_BOOTLOADER
+#ifdef USE_SERIAL_4WAY_BLHELI_BOOTLOADER
                 case cmd_DevicePageErase:
-                {
-                    switch (CurrentInterfaceMode)
-                    {
+                    switch (currentInterfaceMode) {
                         case imSIL_BLB:
-                        {
-                            Dummy.bytes[0] = ParamBuf[0];
+                            Dummy.bytes[0] = paramBuf[0];
                             //Address = Page * 512
                             ioMem.D_FLASH_ADDR_H = (Dummy.bytes[0] << 1);
                             ioMem.D_FLASH_ADDR_L = 0;
-                            if (!BL_PageErase(&ioMem))  ACK_OUT = ACK_D_GENERAL_ERROR;
+                            if (!BL_PageErase(&ioMem))
+                                ACK_OUT = ACK_D_GENERAL_ERROR;
                             break;
-                        }
                         default:
                             ACK_OUT = ACK_I_INVALID_CMD;
                     }
                     break;
-                }
-                #endif
+#endif
 
-                //*** Device Memory Read Ops ***
+                    //*** Device Memory Read Ops ***
                 case cmd_DeviceRead:
-                {
-                    ioMem.D_NUM_BYTES = ParamBuf[0];
-                    /*
-                    wtf.D_FLASH_ADDR_H=Adress_H;
-                    wtf.D_FLASH_ADDR_L=Adress_L;
-                    wtf.D_PTR_I = BUF_I;
-                    */
-                    switch(CurrentInterfaceMode)
-                    {
-                        #ifdef USE_SERIAL_4WAY_BLHELI_BOOTLOADER
+                    ioMem.D_NUM_BYTES = paramBuf[0];
+                    switch(currentInterfaceMode) {
+#ifdef USE_SERIAL_4WAY_BLHELI_BOOTLOADER
                         case imSIL_BLB:
                         case imATM_BLB:
-                        {
-                            if(!BL_ReadFlash(CurrentInterfaceMode, &ioMem))
-                            {
+                            if(!BL_ReadFlash(currentInterfaceMode, &ioMem))
                                 ACK_OUT = ACK_D_GENERAL_ERROR;
-                            }
                             break;
-                        }
-                        #endif
-                        #ifdef USE_SERIAL_4WAY_SK_BOOTLOADER
+#endif
+#ifdef USE_SERIAL_4WAY_SK_BOOTLOADER
                         case imSK:
-                        {
                             if(!Stk_ReadFlash(&ioMem))
-                            {
                                 ACK_OUT = ACK_D_GENERAL_ERROR;
-                            }
                             break;
-                        }
-                        #endif
+#endif
                         default:
                             ACK_OUT = ACK_I_INVALID_CMD;
                     }
-                    if (ACK_OUT == ACK_OK)
-                    {
+                    if (ACK_OUT == ACK_OK) {
                         O_PARAM_LEN = ioMem.D_NUM_BYTES;
-                        O_PARAM = (uint8_t *)&ParamBuf;
+                        O_PARAM = (uint8_t *)&paramBuf;
                     }
                     break;
-                }
 
                 case cmd_DeviceReadEEprom:
-                {
-                    ioMem.D_NUM_BYTES = ParamBuf[0];
-                    /*
-                    wtf.D_FLASH_ADDR_H = Adress_H;
-                    wtf.D_FLASH_ADDR_L = Adress_L;
-                    wtf.D_PTR_I = BUF_I;
-                    */
-                    switch (CurrentInterfaceMode)
-                    {
-                        #ifdef USE_SERIAL_4WAY_BLHELI_BOOTLOADER
+                    ioMem.D_NUM_BYTES = paramBuf[0];
+                    switch (currentInterfaceMode) {
+#ifdef USE_SERIAL_4WAY_BLHELI_BOOTLOADER
                         case imATM_BLB:
-                        {
                             if (!BL_ReadEEprom(&ioMem))
-                            {
                                 ACK_OUT = ACK_D_GENERAL_ERROR;
-                            }
                             break;
-                        }
-                        #endif
-                        #ifdef USE_SERIAL_4WAY_SK_BOOTLOADER
+#endif
+#ifdef USE_SERIAL_4WAY_SK_BOOTLOADER
                         case imSK:
-                        {
                             if (!Stk_ReadEEprom(&ioMem))
-                            {
                                 ACK_OUT = ACK_D_GENERAL_ERROR;
-                            }
                             break;
-                        }
-                        #endif
+#endif
                         default:
                             ACK_OUT = ACK_I_INVALID_CMD;
                     }
-                    if(ACK_OUT == ACK_OK)
-                    {
+                    if(ACK_OUT == ACK_OK) {
                         O_PARAM_LEN = ioMem.D_NUM_BYTES;
-                        O_PARAM = (uint8_t *)&ParamBuf;
+                        O_PARAM = (uint8_t *)&paramBuf;
                     }
                     break;
-                }
 
-                //*** Device Memory Write Ops ***
+                    //*** Device Memory Write Ops ***
                 case cmd_DeviceWrite:
-                {
-                    ioMem.D_NUM_BYTES = I_PARAM_LEN;
-                    /*
-                    wtf.D_FLASH_ADDR_H=Adress_H;
-                    wtf.D_FLASH_ADDR_L=Adress_L;
-                    wtf.D_PTR_I = BUF_I;
-                    */
-                    switch (CurrentInterfaceMode)
-                    {
-                        #ifdef USE_SERIAL_4WAY_BLHELI_BOOTLOADER
+                    ioMem.D_NUM_BYTES = paramInLen;
+                    switch (currentInterfaceMode) {
+#ifdef USE_SERIAL_4WAY_BLHELI_BOOTLOADER
                         case imSIL_BLB:
                         case imATM_BLB:
-                        {
-                            if (!BL_WriteFlash(&ioMem)) {
+                            if (!BL_WriteFlash(&ioMem))
                                 ACK_OUT = ACK_D_GENERAL_ERROR;
-                            }
                             break;
-                        }
-                        #endif
-                        #ifdef USE_SERIAL_4WAY_SK_BOOTLOADER
+#endif
+#ifdef USE_SERIAL_4WAY_SK_BOOTLOADER
                         case imSK:
-                        {
                             if (!Stk_WriteFlash(&ioMem))
-                            {
                                 ACK_OUT = ACK_D_GENERAL_ERROR;
-                            }
                             break;
-                        }
-                        #endif
+#endif
+                        default:
+                            ACK_OUT = ACK_I_INVALID_CMD;
                     }
                     break;
-                }
 
                 case cmd_DeviceWriteEEprom:
-                {
-                    ioMem.D_NUM_BYTES = I_PARAM_LEN;
-                    ACK_OUT = ACK_D_GENERAL_ERROR;
-                    /*
-                    wtf.D_FLASH_ADDR_H=Adress_H;
-                    wtf.D_FLASH_ADDR_L=Adress_L;
-                    wtf.D_PTR_I = BUF_I;
-                    */
-                    switch (CurrentInterfaceMode)
-                    {
-                        #ifdef USE_SERIAL_4WAY_BLHELI_BOOTLOADER
+                    ioMem.D_NUM_BYTES = paramInLen;
+                    switch (currentInterfaceMode) {
+#ifdef USE_SERIAL_4WAY_BLHELI_BOOTLOADER
                         case imSIL_BLB:
-                        {
                             ACK_OUT = ACK_I_INVALID_CMD;
                             break;
-                        }
                         case imATM_BLB:
-                        {
-                            if (BL_WriteEEprom(&ioMem))
-                            {
-                                ACK_OUT = ACK_OK;
-                            }
+                            if (!BL_WriteEEprom(&ioMem))
+                                ACK_OUT = ACK_D_GENERAL_ERROR;
                             break;
-                        }
-                        #endif
-                        #ifdef USE_SERIAL_4WAY_SK_BOOTLOADER
+#endif
+#ifdef USE_SERIAL_4WAY_SK_BOOTLOADER
                         case imSK:
-                        {
-                            if (Stk_WriteEEprom(&ioMem))
-                            {
-                                ACK_OUT = ACK_OK;
-                            }
+                            if (!Stk_WriteEEprom(&ioMem))
+                                ACK_OUT = ACK_D_GENERAL_ERROR;
                             break;
-                        }
-                        #endif
+#endif
+                        default:
+                            ACK_OUT = ACK_I_INVALID_CMD;
                     }
                     break;
-                }
                 default:
-                {
                     ACK_OUT = ACK_I_INVALID_CMD;
-                }
             }
         }
 
-        CRCout.word = 0;
+        crcOut = 0;
 
         TX_LED_ON;
-        serialBeginWrite(_mspPort->port);
+        serialBeginWrite(port);
         WriteByteCrc(cmd_Remote_Escape);
         WriteByteCrc(CMD);
         WriteByteCrc(ioMem.D_FLASH_ADDR_H);
         WriteByteCrc(ioMem.D_FLASH_ADDR_L);
         WriteByteCrc(O_PARAM_LEN);
 
-        i=O_PARAM_LEN;
-        do {
-            WriteByteCrc(*O_PARAM);
-            O_PARAM++;
-            i--;
-        } while (i > 0);
+        for(int i = 0; i < O_PARAM_LEN; i++)
+            WriteByteCrc(O_PARAM[i]);
 
         WriteByteCrc(ACK_OUT);
-        WriteByte(CRCout.bytes[1]);
-        WriteByte(CRCout.bytes[0]);
-        serialEndWrite(_mspPort->port);
-        bufWriterFlush(_writer);
+        WriteByte(crcOut >> 8);
+        WriteByte(crcOut & 0xff);
+        serialEndWrite(port);
         TX_LED_OFF;
         if (isExitScheduled) {
             DeInitialize4WayInterface();
             return;
         }
-    };
+    }
 }
-
-
 
 #endif

--- a/src/main/io/serial_4way.c
+++ b/src/main/io/serial_4way.c
@@ -84,6 +84,8 @@
 #define SERIAL_4WAY_VERSION_HI (uint8_t) (SERIAL_4WAY_VERSION / 100)
 #define SERIAL_4WAY_VERSION_LO (uint8_t) (SERIAL_4WAY_VERSION % 100)
 
+static bool isExitScheduled;
+
 static uint8_t escCount;
 uint8_t escSelected;
 
@@ -187,9 +189,9 @@ void DeInitialize4WayInterface(void)
 // ESC CMD ADDR_H ADDR_L PARAM_LEN PARAM (256B if len == 0) + ACK (uint8_t OK or ERR) + CRC16_Hi CRC16_Lo
 
 typedef enum {
-    cmd_Remote_Escape       = 0x2E, // '.'
-    cmd_Local_Escape        = 0x2F, // '/'
-} esc_4way_e;
+    syn_Remote_Escape       = 0x2E, // '.'
+    syn_Local_Escape        = 0x2F, // '/'
+} syn_4way_e;
 
 typedef enum {
 
@@ -267,7 +269,7 @@ typedef enum {
 // Set Interface Mode
     cmd_InterfaceSetMode   = 0x3F,   // '?'
 // PARAM: uint8_t Mode (interfaceMode_e)
-// RETURN: ACK or ACK_I_INVALID_PARAM
+// RETURN: ACK
 } cmd_4way_e;
 
 // responses
@@ -397,15 +399,266 @@ static void WriteByteCrc(uint8_t b)
     crcOut = _crc_xmodem_update(crcOut, b);
 }
 
-void Process4WayInterface(serialPort_t *serial) {
-    uint8_t paramBuf[256];
-    int paramInLen;
-    uint8_t CMD;
-    uint8_t ACK_OUT;
-    uint8_16_u Dummy;
-    uint8_t O_PARAM_LEN;
-    uint8_t *O_PARAM;
+// handle 4Way interface command
+// command - received command, will be sent inreply
+// addr in received header, may be modified (erase)
+// data is buffer used both for received parameters and returned data
+// inLen - received input length
+// outLen - size of data to return, max 256, preinitialized to zero
+//  Single '\0' byte will be send if outLen is zero (protocol limitation)
+static int handle4WayPkt(int command, uint16_t* addr, uint8_t *data, int inLen, int* outLen)
+{
     ioMem_t ioMem;
+    ioMem.addr = *addr;                    // default flash operation address
+    ioMem.data = data;                     // command data buffer is used for read and write commands
+
+    switch(command) {
+        // ******* Interface related stuff *******
+        case cmd_InterfaceTestAlive: {
+            if (!isMcuConnected())
+                return ACK_OK;     // TODO - better return error here?
+
+            int replyAck = ACK_OK;
+            switch(currentInterfaceMode) {
+#ifdef USE_SERIAL_4WAY_BLHELI_BOOTLOADER
+                case imATM_BLB:
+                case imSIL_BLB:
+                    if (!BL_SendCMDKeepAlive())
+                        replyAck = ACK_D_GENERAL_ERROR;
+                    break;
+#endif
+#ifdef USE_SERIAL_4WAY_SK_BOOTLOADER
+                case imSK:
+                    if (!Stk_SignOn())
+                        replyAck = ACK_D_GENERAL_ERROR;
+                    break;
+#endif
+                default:
+                    replyAck = ACK_D_GENERAL_ERROR;
+            }
+            if (replyAck != ACK_OK)
+                setDisconnected();
+            return replyAck;
+        }
+
+        case cmd_ProtocolGetVersion:
+            // Only interface itself, no matter what Device
+            data[0] = SERIAL_4WAY_PROTOCOL_VER;
+            *outLen = 1;
+            return ACK_OK;
+
+        case cmd_InterfaceGetName:
+            // Only interface itself, no matter what Device
+            // outLen=16;
+            memcpy(data, SERIAL_4WAY_INTERFACE_NAME_STR, strlen(SERIAL_4WAY_INTERFACE_NAME_STR));
+            *outLen = strlen(SERIAL_4WAY_INTERFACE_NAME_STR);
+            return ACK_OK;
+
+        case cmd_InterfaceGetVersion:
+            // Only interface itself, no matter what Device
+            data[0] = SERIAL_4WAY_VERSION_HI;
+            data[1] = SERIAL_4WAY_VERSION_LO;
+            *outLen = 2;
+            return ACK_OK;
+
+        case cmd_InterfaceExit:
+            isExitScheduled = true;
+            return ACK_OK;
+
+        case cmd_InterfaceSetMode:
+            switch(data[0]) {
+#if defined(USE_SERIAL_4WAY_BLHELI_BOOTLOADER)
+                case imSIL_BLB:
+                case imATM_BLB:
+#endif
+#if defined(USE_SERIAL_4WAY_SK_BOOTLOADER)
+                case imSK:
+#endif
+                    currentInterfaceMode = data[0];
+                    break;
+                default:
+                    return ACK_I_INVALID_PARAM;
+            }
+            return ACK_OK;
+
+        case cmd_DeviceReset:
+            if(data[0] >= escCount)
+                return ACK_I_INVALID_CHANNEL;
+            // Channel may change here
+            escSelected = data[0];
+            switch (currentInterfaceMode) {
+#ifdef USE_SERIAL_4WAY_BLHELI_BOOTLOADER
+                case imSIL_BLB:
+                case imATM_BLB:
+                    BL_SendCMDRunRestartBootloader(&deviceInfo);
+                    break;
+#endif
+#ifdef USE_SERIAL_4WAY_SK_BOOTLOADER
+                case imSK:
+                    break;
+#endif
+            }
+            setDisconnected();
+            return ACK_OK;
+
+        case cmd_DeviceInitFlash: {
+            int replyAck = ACK_OK;
+            setDisconnected();
+            if (data[0] >= escCount)
+                return  ACK_I_INVALID_CHANNEL;
+            //Channel may change here
+            //ESC_LO or ESC_HI; Halt state for prev channel
+            escSelected = data[0];
+            if(!Connect(&deviceInfo)) {
+                setDisconnected();
+                replyAck = ACK_D_GENERAL_ERROR; // TODO - should we return deviceInfo on error?
+            }
+            deviceInfo.interfaceMode = currentInterfaceMode;
+            memcpy(data, &deviceInfo, sizeof(deviceInfo));
+            *outLen = sizeof(deviceInfo);
+            return replyAck;
+        }
+
+#ifdef USE_SERIAL_4WAY_SK_BOOTLOADER
+        case cmd_DeviceEraseAll:
+            switch(currentInterfaceMode) {
+                case imSK:
+                    if (!Stk_Chip_Erase())
+                        return ACK_D_GENERAL_ERROR;
+                    break;
+                default:
+                    return ACK_I_INVALID_CMD;
+            }
+            return ACK_OK;
+#endif
+
+#ifdef USE_SERIAL_4WAY_BLHELI_BOOTLOADER
+        case cmd_DevicePageErase:
+            switch (currentInterfaceMode) {
+                case imSIL_BLB:
+                    *outLen = 1;  // return block number (from incomming packet)
+                    // Address = Page * 512
+                    ioMem.addr = data[0] << 9;
+                    *addr = ioMem.addr;           // TODO - what address shall be returned?
+                    if (!BL_PageErase(&ioMem))
+                        return ACK_D_GENERAL_ERROR;
+                    break;
+                default:
+                    return ACK_I_INVALID_CMD;
+            }
+            return ACK_OK;
+#endif
+
+            //*** Device Memory Read Ops ***
+        case cmd_DeviceRead: {
+            int len = data[0];
+            if(len == 0)
+                len = 0x100;
+            ioMem.len = len;
+            switch(currentInterfaceMode) {
+#ifdef USE_SERIAL_4WAY_BLHELI_BOOTLOADER
+                case imSIL_BLB:
+                case imATM_BLB:
+                    if(!BL_ReadFlash(currentInterfaceMode, &ioMem))
+                        return ACK_D_GENERAL_ERROR;
+                    break;
+#endif
+#ifdef USE_SERIAL_4WAY_SK_BOOTLOADER
+                case imSK:
+                    if(!Stk_ReadFlash(&ioMem))
+                        return ACK_D_GENERAL_ERROR;
+                    break;
+#endif
+                default:
+                    return ACK_I_INVALID_CMD;
+            }
+            *outLen = ioMem.len;
+            return ACK_OK;
+        }
+
+        case cmd_DeviceReadEEprom: {
+            int len = data[0];
+            if(len == 0)
+                len = 0x100;
+            ioMem.len = len;
+            switch (currentInterfaceMode) {
+#ifdef USE_SERIAL_4WAY_BLHELI_BOOTLOADER
+                case imATM_BLB:
+                    if (!BL_ReadEEprom(&ioMem))
+                        return ACK_D_GENERAL_ERROR;
+                    break;
+#endif
+#ifdef USE_SERIAL_4WAY_SK_BOOTLOADER
+                case imSK:
+                    if (!Stk_ReadEEprom(&ioMem))
+                        return ACK_D_GENERAL_ERROR;
+                    break;
+#endif
+                default:
+                    return ACK_I_INVALID_CMD;
+            }
+            *outLen = ioMem.len;
+            return ACK_OK;
+        }
+
+            //*** Device Memory Write Ops ***
+        case cmd_DeviceWrite:
+            ioMem.len = inLen;
+            switch (currentInterfaceMode) {
+#ifdef USE_SERIAL_4WAY_BLHELI_BOOTLOADER
+                case imSIL_BLB:
+                case imATM_BLB:
+                    if (!BL_WriteFlash(&ioMem))
+                        return ACK_D_GENERAL_ERROR;
+                    break;
+#endif
+#ifdef USE_SERIAL_4WAY_SK_BOOTLOADER
+                case imSK:
+                    if (!Stk_WriteFlash(&ioMem))
+                        return ACK_D_GENERAL_ERROR;
+                    break;
+#endif
+                default:
+                    return ACK_I_INVALID_CMD;
+            }
+            return ACK_OK;
+
+        case cmd_DeviceWriteEEprom:
+            ioMem.len = inLen;
+            switch (currentInterfaceMode) {
+#ifdef USE_SERIAL_4WAY_BLHELI_BOOTLOADER
+                case imSIL_BLB:
+                    return ACK_I_INVALID_CMD;
+                case imATM_BLB:
+                    if (!BL_WriteEEprom(&ioMem))
+                        return ACK_D_GENERAL_ERROR;
+                    break;
+#endif
+#ifdef USE_SERIAL_4WAY_SK_BOOTLOADER
+                case imSK:
+                    if (!Stk_WriteEEprom(&ioMem))
+                        return ACK_D_GENERAL_ERROR;
+                    break;
+#endif
+                default:
+                    return ACK_I_INVALID_CMD;
+            }
+            return ACK_OK;
+
+        default:
+            return ACK_I_INVALID_CMD;
+    }
+    // should not get here
+}
+
+
+void Process4WayInterface(serialPort_t *serial) {
+    uint8_t command;
+    uint16_t addr;
+    int inLen;
+    int outLen;
+    uint8_t paramBuf[256];
+    uint8_t replyAck;
 
     port = serial;
 
@@ -415,28 +668,25 @@ void Process4WayInterface(serialPort_t *serial) {
     // switch beeper silent here
     beeperSilence();
 #endif
-    bool isExitScheduled = false;
-
+    isExitScheduled = false;
     while(1) {
         // restart looking for new sequence from host
         crcIn = 0;
         uint8_t esc = ReadByteCrc();
-        if(esc != cmd_Local_Escape)
-            continue;  // wait for sync character
+        if(esc != syn_Local_Escape)
+            continue;                          // wait for sync character
 
         RX_LED_ON;
 
-        Dummy.word = 0;
-        O_PARAM = &Dummy.bytes[0];
-        O_PARAM_LEN = 1;                       // must always return non-zero length
-        CMD = ReadByteCrc();
-        ioMem.D_FLASH_ADDR_H = ReadByteCrc();
-        ioMem.D_FLASH_ADDR_L = ReadByteCrc();
-        paramInLen = ReadByteCrc();
-        if(!paramInLen)
-            paramInLen = 0x100;                // len ==0 -> param is 256B
+        command = ReadByteCrc();
+        addr  = ReadByteCrc() << 8;
+        addr |= ReadByteCrc();
 
-        for(int i = 0; i < paramInLen; i++)
+        inLen = ReadByteCrc();
+        if(inLen == 0)
+            inLen = 0x100;                     // len ==0 -> param is 256B
+
+        for(int i = 0; i <inLen; i++)
             paramBuf[i] = ReadByteCrc();
 
         uint16_t crc;
@@ -445,266 +695,34 @@ void Process4WayInterface(serialPort_t *serial) {
 
         RX_LED_OFF;
 
-        ACK_OUT = ACK_OK;
+        outLen = 0;                           // output handling code will send signle zero byte if necessary
+        replyAck = ACK_OK;
 
-        if(crcIn != crc) {
-            ACK_OUT = ACK_I_INVALID_CRC;
-        }
+        if(crcIn != crc)
+            replyAck = ACK_I_INVALID_CRC;
 
-        if (ACK_OUT == ACK_OK) {
-            ioMem.D_PTR_I = paramBuf;
+        if (replyAck == ACK_OK)
+            replyAck = handle4WayPkt(command, &addr, paramBuf, inLen, &outLen);
 
-            switch(CMD) {
-                // ******* Interface related stuff *******
-                case cmd_InterfaceTestAlive:
-                    if (isMcuConnected()) {
-                        switch(currentInterfaceMode) {
-#ifdef USE_SERIAL_4WAY_BLHELI_BOOTLOADER
-                            case imATM_BLB:
-                            case imSIL_BLB:
-                                if (!BL_SendCMDKeepAlive()) { // SetStateDisconnected() included
-                                    ACK_OUT = ACK_D_GENERAL_ERROR;
-                                }
-                                break;
-#endif
-#ifdef USE_SERIAL_4WAY_SK_BOOTLOADER
-                            case imSK:
-                                if (!Stk_SignOn()) { // SetStateDisconnected();
-                                    ACK_OUT = ACK_D_GENERAL_ERROR;
-                                }
-                                break;
-#endif
-                            default:
-                                ACK_OUT = ACK_D_GENERAL_ERROR;
-                        }
-                        if (ACK_OUT != ACK_OK)
-                            setDisconnected();
-                    }
-                    break;
-
-                case cmd_ProtocolGetVersion:
-                    // Only interface itself, no matter what Device
-                    Dummy.bytes[0] = SERIAL_4WAY_PROTOCOL_VER;
-                    break;
-
-                case cmd_InterfaceGetName:
-                    // Only interface itself, no matter what Device
-                    // O_PARAM_LEN=16;
-                    O_PARAM_LEN = strlen(SERIAL_4WAY_INTERFACE_NAME_STR);
-                    O_PARAM = (uint8_t *)SERIAL_4WAY_INTERFACE_NAME_STR;
-                    break;
-
-                case cmd_InterfaceGetVersion:
-                    // Only interface itself, no matter what Device
-                    // Dummy = iUart_res_InterfVersion;
-                    O_PARAM_LEN = 2;
-                    Dummy.bytes[0] = SERIAL_4WAY_VERSION_HI;
-                    Dummy.bytes[1] = SERIAL_4WAY_VERSION_LO;
-                    break;
-
-                case cmd_InterfaceExit:
-                    isExitScheduled = true;
-                    break;
-
-                case cmd_InterfaceSetMode:
-                    switch(paramBuf[0]) {
-#if defined(USE_SERIAL_4WAY_BLHELI_BOOTLOADER)
-                        case imSIL_BLB:
-                        case imATM_BLB:
-#endif
-#if defined(USE_SERIAL_4WAY_SK_BOOTLOADER)
-                        case imSK:
-#endif
-                            currentInterfaceMode = paramBuf[0];
-                            break;
-                        default:
-                            ACK_OUT = ACK_I_INVALID_PARAM;
-                    }
-                    break;
-
-                case cmd_DeviceReset:
-                    if(paramBuf[0] >= escCount) {
-                        ACK_OUT = ACK_I_INVALID_CHANNEL;
-                        break;
-                    }
-                    // Channel may change here
-                    escSelected = paramBuf[0];
-                    switch (currentInterfaceMode) {
-                        case imSIL_BLB:            // TODO!
-#ifdef USE_SERIAL_4WAY_BLHELI_BOOTLOADER
-                        case imATM_BLB:
-                            BL_SendCMDRunRestartBootloader(&deviceInfo);
-                            break;
-#endif
-#ifdef USE_SERIAL_4WAY_SK_BOOTLOADER
-                        case imSK:
-                            break;
-#endif
-                    }
-                    setDisconnected();
-                    break;
-
-                case cmd_DeviceInitFlash:
-                    setDisconnected();
-                    if (paramBuf[0] >= escCount) {
-                        ACK_OUT = ACK_I_INVALID_CHANNEL;
-                        break;
-                    }
-                    //Channel may change here
-                    //ESC_LO or ESC_HI; Halt state for prev channel
-                    escSelected = paramBuf[0];
-                    O_PARAM_LEN = sizeof(deviceInfo);
-                    O_PARAM = (uint8_t*)&deviceInfo;
-                    if(!Connect(&deviceInfo)) {
-                        setDisconnected();
-                        ACK_OUT = ACK_D_GENERAL_ERROR;
-                    }
-                    deviceInfo.interfaceMode = currentInterfaceMode;
-                    break;
-
-#ifdef USE_SERIAL_4WAY_SK_BOOTLOADER
-                case cmd_DeviceEraseAll:
-                    switch(currentInterfaceMode) {
-                        case imSK:
-                            if (!Stk_Chip_Erase())
-                                ACK_OUT=ACK_D_GENERAL_ERROR;
-                            break;
-                        default:
-                            ACK_OUT = ACK_I_INVALID_CMD;
-                    }
-                    break;
-#endif
-
-#ifdef USE_SERIAL_4WAY_BLHELI_BOOTLOADER
-                case cmd_DevicePageErase:
-                    switch (currentInterfaceMode) {
-                        case imSIL_BLB:
-                            Dummy.bytes[0] = paramBuf[0];
-                            //Address = Page * 512
-                            ioMem.D_FLASH_ADDR_H = (Dummy.bytes[0] << 1);
-                            ioMem.D_FLASH_ADDR_L = 0;
-                            if (!BL_PageErase(&ioMem))
-                                ACK_OUT = ACK_D_GENERAL_ERROR;
-                            break;
-                        default:
-                            ACK_OUT = ACK_I_INVALID_CMD;
-                    }
-                    break;
-#endif
-
-                    //*** Device Memory Read Ops ***
-                case cmd_DeviceRead:
-                    ioMem.D_NUM_BYTES = paramBuf[0];
-                    switch(currentInterfaceMode) {
-#ifdef USE_SERIAL_4WAY_BLHELI_BOOTLOADER
-                        case imSIL_BLB:
-                        case imATM_BLB:
-                            if(!BL_ReadFlash(currentInterfaceMode, &ioMem))
-                                ACK_OUT = ACK_D_GENERAL_ERROR;
-                            break;
-#endif
-#ifdef USE_SERIAL_4WAY_SK_BOOTLOADER
-                        case imSK:
-                            if(!Stk_ReadFlash(&ioMem))
-                                ACK_OUT = ACK_D_GENERAL_ERROR;
-                            break;
-#endif
-                        default:
-                            ACK_OUT = ACK_I_INVALID_CMD;
-                    }
-                    if (ACK_OUT == ACK_OK) {
-                        O_PARAM_LEN = ioMem.D_NUM_BYTES;
-                        O_PARAM = (uint8_t *)&paramBuf;
-                    }
-                    break;
-
-                case cmd_DeviceReadEEprom:
-                    ioMem.D_NUM_BYTES = paramBuf[0];
-                    switch (currentInterfaceMode) {
-#ifdef USE_SERIAL_4WAY_BLHELI_BOOTLOADER
-                        case imATM_BLB:
-                            if (!BL_ReadEEprom(&ioMem))
-                                ACK_OUT = ACK_D_GENERAL_ERROR;
-                            break;
-#endif
-#ifdef USE_SERIAL_4WAY_SK_BOOTLOADER
-                        case imSK:
-                            if (!Stk_ReadEEprom(&ioMem))
-                                ACK_OUT = ACK_D_GENERAL_ERROR;
-                            break;
-#endif
-                        default:
-                            ACK_OUT = ACK_I_INVALID_CMD;
-                    }
-                    if(ACK_OUT == ACK_OK) {
-                        O_PARAM_LEN = ioMem.D_NUM_BYTES;
-                        O_PARAM = (uint8_t *)&paramBuf;
-                    }
-                    break;
-
-                    //*** Device Memory Write Ops ***
-                case cmd_DeviceWrite:
-                    ioMem.D_NUM_BYTES = paramInLen;
-                    switch (currentInterfaceMode) {
-#ifdef USE_SERIAL_4WAY_BLHELI_BOOTLOADER
-                        case imSIL_BLB:
-                        case imATM_BLB:
-                            if (!BL_WriteFlash(&ioMem))
-                                ACK_OUT = ACK_D_GENERAL_ERROR;
-                            break;
-#endif
-#ifdef USE_SERIAL_4WAY_SK_BOOTLOADER
-                        case imSK:
-                            if (!Stk_WriteFlash(&ioMem))
-                                ACK_OUT = ACK_D_GENERAL_ERROR;
-                            break;
-#endif
-                        default:
-                            ACK_OUT = ACK_I_INVALID_CMD;
-                    }
-                    break;
-
-                case cmd_DeviceWriteEEprom:
-                    ioMem.D_NUM_BYTES = paramInLen;
-                    switch (currentInterfaceMode) {
-#ifdef USE_SERIAL_4WAY_BLHELI_BOOTLOADER
-                        case imSIL_BLB:
-                            ACK_OUT = ACK_I_INVALID_CMD;
-                            break;
-                        case imATM_BLB:
-                            if (!BL_WriteEEprom(&ioMem))
-                                ACK_OUT = ACK_D_GENERAL_ERROR;
-                            break;
-#endif
-#ifdef USE_SERIAL_4WAY_SK_BOOTLOADER
-                        case imSK:
-                            if (!Stk_WriteEEprom(&ioMem))
-                                ACK_OUT = ACK_D_GENERAL_ERROR;
-                            break;
-#endif
-                        default:
-                            ACK_OUT = ACK_I_INVALID_CMD;
-                    }
-                    break;
-                default:
-                    ACK_OUT = ACK_I_INVALID_CMD;
-            }
+        // send single '\0' byte is output length is zero (len ==0 -> 256 bytes)
+        if(!outLen) {
+            paramBuf[0] = 0;
+            outLen = 1;
         }
 
         crcOut = 0;
-
         TX_LED_ON;
         serialBeginWrite(port);
-        WriteByteCrc(cmd_Remote_Escape);
-        WriteByteCrc(CMD);
-        WriteByteCrc(ioMem.D_FLASH_ADDR_H);
-        WriteByteCrc(ioMem.D_FLASH_ADDR_L);
-        WriteByteCrc(O_PARAM_LEN & 0xff);
+        WriteByteCrc(syn_Remote_Escape);
+        WriteByteCrc(command);
+        WriteByteCrc(addr >> 8);
+        WriteByteCrc(addr & 0xff);
+        WriteByteCrc(outLen & 0xff);          // only low byte is send, 0x00 -> 256B
 
-        for(int i = 0; i < O_PARAM_LEN ? O_PARAM_LEN : 0x100; i++)  // TODO
-            WriteByteCrc(O_PARAM[i]);
+        for(int i = 0; i < outLen; i++)
+            WriteByteCrc(paramBuf[i]);
 
-        WriteByteCrc(ACK_OUT);
+        WriteByteCrc(replyAck);
         WriteByte(crcOut >> 8);
         WriteByte(crcOut & 0xff);
         serialEndWrite(port);

--- a/src/main/io/serial_4way.h
+++ b/src/main/io/serial_4way.h
@@ -51,29 +51,15 @@ void setEscOutput(uint8_t selEsc);
 #define ESC_OUTPUT setEscOutput(escSelected)
 
 typedef struct ioMem_s {
-    uint8_t D_NUM_BYTES;
-    uint8_t D_FLASH_ADDR_H;
-    uint8_t D_FLASH_ADDR_L;
-    uint8_t *D_PTR_I;
+    uint16_t len;
+    uint16_t addr;
+    uint8_t *data;
 } ioMem_t;
 
-//extern ioMem_t ioMem;
-
-typedef union __attribute__ ((packed)) {
-    uint8_t bytes[2];
-    uint16_t word;
-} uint8_16_u;
-
-typedef union __attribute__ ((packed)) {
-    uint8_t bytes[4];
-    uint16_t words[2];
-    uint32_t dword;
-} uint8_32_u;
-
 typedef struct deviceInfo_s {
-    uint16_t signature;
+    uint16_t signature;        // lower 16 bit of signature, checked
+    uint8_t  signature2;       // upper 8 bit of signature, not used in current code
     uint8_t interfaceMode;
-    uint8_t pad;
 } deviceInfo_t;
 
 bool isMcuConnected(void);

--- a/src/main/io/serial_4way.h
+++ b/src/main/io/serial_4way.h
@@ -19,10 +19,12 @@
 #define USE_SERIAL_4WAY_BLHELI_BOOTLOADER
 #define USE_SERIAL_4WAY_SK_BOOTLOADER
 
-#define imC2 0
-#define imSIL_BLB 1
-#define imATM_BLB 2
-#define imSK 3
+typedef enum {
+    imC2      = 0,
+    imSIL_BLB = 1,
+    imATM_BLB = 2,
+    imSK      = 3,
+} interfaceMode_e;
 
 typedef struct {
     GPIO_TypeDef* gpio;
@@ -32,7 +34,7 @@ typedef struct {
     gpio_config_t gpio_config_OUTPUT;
 } escHardware_t;
 
-extern uint8_t selected_esc;
+extern uint8_t escSelected;
 
 bool isEscHi(uint8_t selEsc);
 bool isEscLo(uint8_t selEsc);
@@ -41,12 +43,12 @@ void setEscLo(uint8_t selEsc);
 void setEscInput(uint8_t selEsc);
 void setEscOutput(uint8_t selEsc);
 
-#define ESC_IS_HI isEscHi(selected_esc)
-#define ESC_IS_LO isEscLo(selected_esc)
-#define ESC_SET_HI setEscHi(selected_esc)
-#define ESC_SET_LO setEscLo(selected_esc)
-#define ESC_INPUT setEscInput(selected_esc)
-#define ESC_OUTPUT setEscOutput(selected_esc)
+#define ESC_IS_HI isEscHi(escSelected)
+#define ESC_IS_LO isEscLo(escSelected)
+#define ESC_SET_HI setEscHi(escSelected)
+#define ESC_SET_LO setEscLo(escSelected)
+#define ESC_INPUT setEscInput(escSelected)
+#define ESC_OUTPUT setEscOutput(escSelected)
 
 typedef struct ioMem_s {
     uint8_t D_NUM_BYTES;
@@ -55,7 +57,7 @@ typedef struct ioMem_s {
     uint8_t *D_PTR_I;
 } ioMem_t;
 
-extern ioMem_t ioMem;
+//extern ioMem_t ioMem;
 
 typedef union __attribute__ ((packed)) {
     uint8_t bytes[2];
@@ -68,9 +70,13 @@ typedef union __attribute__ ((packed)) {
     uint32_t dword;
 } uint8_32_u;
 
-//extern uint8_32_u DeviceInfo;
+typedef struct deviceInfo_s {
+    uint16_t signature;
+    uint8_t interfaceMode;
+    uint8_t pad;
+} deviceInfo_t;
 
 bool isMcuConnected(void);
-uint8_t Initialize4WayInterface(void);
-void Process4WayInterface(mspPort_t *mspPort, bufWriter_t *bufwriter);
+int Initialize4WayInterface(void);
+void Process4WayInterface(serialPort_t *port);
 void DeInitialize4WayInterface(void);

--- a/src/main/io/serial_4way_avrootloader.c
+++ b/src/main/io/serial_4way_avrootloader.c
@@ -24,7 +24,7 @@
 #include <stdlib.h>
 #include <platform.h>
 
-#ifdef  USE_SERIAL_4WAY_BLHELI_INTERFACE
+#include "common/utils.h"
 #include "config/parameter_group.h"
 #include "drivers/system.h"
 #include "drivers/serial.h"
@@ -35,280 +35,256 @@
 #include "io/serial_msp.h"
 #include "io/serial_4way.h"
 #include "io/serial_4way_avrootloader.h"
-#ifdef  USE_SERIAL_4WAY_BLHELI_BOOTLOADER
 
+#if defined(USE_SERIAL_4WAY_BLHELI_INTERFACE) && defined(USE_SERIAL_4WAY_BLHELI_BOOTLOADER)
 
 // Bootloader commands
 // RunCmd
 #define RestartBootloader 0
-#define ExitBootloader 1
+#define ExitBootloader    1
 
-#define CMD_RUN           0x00
-#define CMD_PROG_FLASH    0x01
-#define CMD_ERASE_FLASH   0x02
+#define CMD_RUN            0x00
+#define CMD_PROG_FLASH     0x01
+#define CMD_ERASE_FLASH    0x02
 #define CMD_READ_FLASH_SIL 0x03
-#define CMD_VERIFY_FLASH  0x03
-#define CMD_READ_EEPROM   0x04
-#define CMD_PROG_EEPROM   0x05
-#define CMD_READ_SRAM     0x06
+#define CMD_VERIFY_FLASH   0x03
+#define CMD_READ_EEPROM    0x04
+#define CMD_PROG_EEPROM    0x05
+#define CMD_READ_SRAM      0x06
 #define CMD_READ_FLASH_ATM 0x07
-#define CMD_KEEP_ALIVE    0xFD
-#define CMD_SET_ADDRESS   0xFF
-#define CMD_SET_BUFFER    0xFE
+#define CMD_KEEP_ALIVE     0xFD
+#define CMD_SET_ADDRESS    0xFF
+#define CMD_SET_BUFFER     0xFE
 
-#define CMD_BOOTINIT      0x07
-#define CMD_BOOTSIGN      0x08
+#define CMD_BOOTINIT       0x07
+#define CMD_BOOTSIGN       0x08
 
 // Bootloader result codes
 
-#define brSUCCESS         0x30
-#define brERRORCOMMAND    0xC1
-#define brERRORCRC        0xC2
-#define brNONE            0xFF
+#define BR_SUCCESS          0x30
+#define BR_ERRORCOMMAND     0xC1
+#define BR_ERRORCRC         0xC2
+#define BR_NONE             0xFF
 
+#define START_BIT_TIMEOUT 2000                     // 2ms
 
-#define START_BIT_TIMEOUT_MS 2
+#define BIT_TIME          52                       // 52uS
+#define BIT_TIME_HALVE    (BIT_TIME >> 1)          // 26uS
+#define START_BIT_TIME    (BIT_TIME_HALVE + 1)
 
-#define BIT_TIME (52)  //52uS
-#define BIT_TIME_HALVE (BIT_TIME >> 1) //26uS
-#define START_BIT_TIME (BIT_TIME_HALVE + 1)
-//#define STOP_BIT_TIME ((BIT_TIME * 9) + BIT_TIME_HALVE)
-
-static uint8_t suart_getc_(uint8_t *bt)
+static int suart_getc(void)
 {
     uint32_t btime;
     uint32_t start_time;
 
-    uint32_t wait_time = millis() + START_BIT_TIMEOUT_MS;
+    uint32_t wait_time = micros() + START_BIT_TIMEOUT;
     while (ESC_IS_HI) {
         // check for startbit begin
-        if (millis() >= wait_time) {
-            return 0;
+        if (micros() >= wait_time) {
+            return -1;
         }
     }
     // start bit
     start_time = micros();
     btime = start_time + START_BIT_TIME;
     uint16_t bitmask = 0;
-    uint8_t bit = 0;
-    while (micros() < btime);
-    while(1) {
+    for(int bit = 0; bit < 10; bit++) {
+        while (cmp32(micros(), btime) < 0);
         if (ESC_IS_HI)
-        {
             bitmask |= (1 << bit);
-        }
         btime = btime + BIT_TIME;
-        bit++;
-        if (bit == 10) break;
-        while (micros() < btime);
     }
     // check start bit and stop bit
-    if ((bitmask & 1) || (!(bitmask & (1 << 9)))) {
-        return 0;
+    if ((bitmask & (1 << 0)) || (!(bitmask & (1 << 9)))) {
+        return -1;
     }
-    *bt = bitmask >> 1;
-    return 1;
+    return bitmask >> 1;
 }
 
-static void suart_putc_(uint8_t *tx_b)
+static void suart_putc(uint8_t byte)
 {
     // shift out stopbit first
-    uint16_t bitmask = (*tx_b << 2) | 1 | (1 << 10);
+    uint16_t bitmask = (byte << 2) | (1  << 0) | (1 << 10);
     uint32_t btime = micros();
     while(1) {
-        if(bitmask & 1) {
+        if(bitmask & 1)
             ESC_SET_HI; // 1
-        }
-        else {
+        else
             ESC_SET_LO; // 0
-        }
         btime = btime + BIT_TIME;
-        bitmask = (bitmask >> 1);
+        bitmask >>= 1;
         if (bitmask == 0) break; // stopbit shifted out - but don't wait
-        while (micros() < btime);
+        while (cmp32(micros(), btime) < 0);
     }
 }
 
-static uint8_16_u CRC_16;
-static uint8_16_u LastCRC_16;
-
-static void ByteCrc(uint8_t *bt)
+static uint16_t crc16Byte(uint16_t from, uint8_t byte)
 {
-    uint8_t xb = *bt;
-    for (uint8_t i = 0; i < 8; i++)
-    {
-        if (((xb & 0x01) ^ (CRC_16.word & 0x0001)) !=0 ) {
-            CRC_16.word = CRC_16.word >> 1;
-            CRC_16.word = CRC_16.word ^ 0xA001;
+    uint16_t crc16 = from;
+    for (int i = 0; i < 8; i++) {
+        if (((byte & 0x01) ^ (crc16 & 0x0001)) !=0 ) {
+            crc16 >>= 1;
+            crc16 ^= 0xA001;
         } else {
-            CRC_16.word = CRC_16.word >> 1;
+            crc16 >>= 1;
         }
-        xb = xb >> 1;
+        byte >>= 1;
     }
+    return crc16;
 }
 
-static uint8_t BL_ReadBuf(uint8_t *pstring, uint8_t len)
+static uint8_t BL_ReadBuf(uint8_t *pstring, int len)
 {
-    // len 0 means 256
-    CRC_16.word = 0;
-    LastCRC_16.word = 0;
-    uint8_t  LastACK = brNONE;
-    do {
-        if(!suart_getc_(pstring)) goto timeout;
-        ByteCrc(pstring);
-        pstring++;
-        len--;
-    } while(len > 0);
+    int crc = 0;
+    int c;
+
+    uint8_t  lastACK = BR_NONE;
+    for(int i = 0; i < len; i++) {
+        int c;
+        if ((c = suart_getc()) < 0) goto timeout;
+        crc = crc16Byte(crc, c);
+        pstring[i] = c;
+    }
 
     if(isMcuConnected()) {
-        //With CRC read 3 more
-        if(!suart_getc_(&LastCRC_16.bytes[0])) goto timeout;
-        if(!suart_getc_(&LastCRC_16.bytes[1])) goto timeout;
-        if(!suart_getc_(&LastACK)) goto timeout;
-        if (CRC_16.word != LastCRC_16.word) {
-            LastACK = brERRORCRC;
-        }
+        // With CRC read 3 more
+        int16_t pktcrc;
+        if((c = suart_getc()) < 0) goto timeout;
+        pktcrc = c << 16;
+        if((c = suart_getc()) < 0) goto timeout;
+        pktcrc |= c;
+        if((c = suart_getc()) < 0) goto timeout;
+        lastACK = c;
+        if (crc != pktcrc)
+            lastACK = BR_ERRORCRC;
     } else {
-        if(!suart_getc_(&LastACK)) goto timeout;
+        if((c = suart_getc()) < 0) goto timeout;
+        lastACK = c;
     }
 timeout:
-    return (LastACK == brSUCCESS);
+    return (lastACK == BR_SUCCESS);
 }
 
-static void BL_SendBuf(uint8_t *pstring, uint8_t len)
+static void BL_SendBuf(uint8_t *pstring, int len)
 {
     ESC_OUTPUT;
-    CRC_16.word=0;
-    do {
-        suart_putc_(pstring);
-        ByteCrc(pstring);
-        pstring++;
-        len--;
-    } while (len > 0);
-    
+    uint16_t crc = 0;
+    for(int i = 0; i < len; i++) {
+        suart_putc(pstring[i]);
+        crc = crc16Byte(crc, pstring[i]);
+    }
     if (isMcuConnected()) {
-        suart_putc_(&CRC_16.bytes[0]);
-        suart_putc_(&CRC_16.bytes[1]);
+        suart_putc(crc >> 8);
+        suart_putc(crc & 0xff);
     }
     ESC_INPUT;
 }
 
-uint8_t BL_ConnectEx(uint8_32_u *pDeviceInfo)
+uint8_t BL_ConnectEx(deviceInfo_t *pDeviceInfo)
 {
-    #define BootMsgLen 4
-    #define DevSignHi (BootMsgLen)
-    #define DevSignLo (BootMsgLen+1)
+#define BOOT_MSG_LEN 4
+#define DevSignHi (BOOT_MSG_LEN)
+#define DevSignLo (BOOT_MSG_LEN + 1)
 
-    //DeviceInfo.dword=0; is set before
-    uint8_t BootInfo[9];
-    uint8_t BootMsg[BootMsgLen-1] = "471";
+    memset(pDeviceInfo, 0, sizeof(*pDeviceInfo));
+    uint8_t bootInfo[9];
+    static const uint8_t bootMsgCheck[BOOT_MSG_LEN - 1] = "471";
     // x * 0 + 9
 #if defined(USE_SERIAL_4WAY_SK_BOOTLOADER)
-    uint8_t BootInit[] = {0,0,0,0,0,0,0,0,0,0,0,0,0x0D,'B','L','H','e','l','i',0xF4,0x7D};
-    BL_SendBuf(BootInit, 21);
+    uint8_t bootInit[] = {0,0,0,0,0,0,0,0,0,0,0,0,0x0D,'B','L','H','e','l','i',0xF4,0x7D};
 #else
-    uint8_t BootInit[] = {0,0,0,0,0,0,0,0,0x0D,'B','L','H','e','l','i',0xF4,0x7D};
-    BL_SendBuf(BootInit, 17);
+    uint8_t bootInit[] = {        0,0,0,0,0,0,0,0,0x0D,'B','L','H','e','l','i',0xF4,0x7D};
 #endif
-    if (!BL_ReadBuf(BootInfo, BootMsgLen + 4)) {
+    BL_SendBuf(bootInit, sizeof(bootInit));
+    if (!BL_ReadBuf(bootInfo, BOOT_MSG_LEN + 4))
         return 0;
-    }
     // BootInfo has no CRC  (ACK byte already analyzed... )
     // Format = BootMsg("471c") SIGNATURE_001, SIGNATURE_002, BootVersion (always 6), BootPages (,ACK)
-    for (uint8_t i = 0; i < (BootMsgLen - 1); i++) { // Check only the first 3 letters -> 471x OK
-        if (BootInfo[i] != BootMsg[i]) {
-            return (0);
-        }
-    }
-
-    //only 2 bytes used $1E9307 -> 0x9307
-    pDeviceInfo->bytes[2] = BootInfo[BootMsgLen - 1];
-    pDeviceInfo->bytes[1] = BootInfo[DevSignHi];
-    pDeviceInfo->bytes[0] = BootInfo[DevSignLo];
-    return (1);
-}
-
-static uint8_t BL_GetACK(uint32_t Timeout)
-{
-    uint8_t LastACK = brNONE;
-    while (!(suart_getc_(&LastACK)) && (Timeout)) {
-        Timeout--;
-    } ;
-    return (LastACK);
-}
-
-uint8_t BL_SendCMDKeepAlive(void) 
-{
-    uint8_t sCMD[] = {CMD_KEEP_ALIVE, 0};
-    BL_SendBuf(sCMD, 2);
-    if (BL_GetACK(1) != brERRORCOMMAND) {
+    if(memcmp(bootInfo, bootMsgCheck, sizeof(bootMsgCheck)) != 0) // Check only the first 3 letters -> 471x OK
         return 0;
-    }
+
+    // only 2 bytes used $1E9307 -> 0x9307
+    // pDeviceInfo->bytes[2] = BootInfo[BOOT_MSG_LEN - 1]; used for interface in serial_4way
+    pDeviceInfo->signature = (bootInfo[DevSignHi] << 8) | bootInfo[DevSignLo];
     return 1;
 }
 
-void BL_SendCMDRunRestartBootloader(uint8_32_u *pDeviceInfo)
+static uint8_t BL_GetACK(int timeout)
+{
+    int c;
+    while ((c = suart_getc()) < 0)
+        if(--timeout < 0)    // timeout=1 -> 1 retry
+            return BR_NONE;
+    return c;
+}
+
+uint8_t BL_SendCMDKeepAlive(void)
+{
+    uint8_t sCMD[] = {CMD_KEEP_ALIVE, 0};
+    BL_SendBuf(sCMD, sizeof(sCMD));
+    if (BL_GetACK(1) != BR_ERRORCOMMAND)
+        return 0;
+    return 1;
+}
+
+void BL_SendCMDRunRestartBootloader(deviceInfo_t *pDeviceInfo)
 {
     uint8_t sCMD[] = {RestartBootloader, 0};
-    pDeviceInfo->bytes[0] = 1;
-    BL_SendBuf(sCMD, 2); //sends simply 4 x 0x00 (CRC =00)
+    pDeviceInfo->signature = 1;     // force connected state
+    BL_SendBuf(sCMD, sizeof(sCMD)); // sends simply 4 x 0x00 (CRC =00)
     return;
 }
 
 static uint8_t BL_SendCMDSetAddress(ioMem_t *pMem) //supports only 16 bit Adr
 {
     // skip if adr == 0xFFFF
-    if((pMem->D_FLASH_ADDR_H == 0xFF) && (pMem->D_FLASH_ADDR_L == 0xFF)) return 1;
+    if((pMem->D_FLASH_ADDR_H == 0xFF) && (pMem->D_FLASH_ADDR_L == 0xFF))
+        return 1;
     uint8_t sCMD[] = {CMD_SET_ADDRESS, 0, pMem->D_FLASH_ADDR_H, pMem->D_FLASH_ADDR_L };
-    BL_SendBuf(sCMD, 4);
-    return (BL_GetACK(2) == brSUCCESS);
+    BL_SendBuf(sCMD, sizeof(sCMD));
+    return BL_GetACK(2) == BR_SUCCESS;
 }
 
 static uint8_t BL_SendCMDSetBuffer(ioMem_t *pMem)
 {
-    uint8_t sCMD[] = {CMD_SET_BUFFER, 0, 0, pMem->D_NUM_BYTES};
-    if (pMem->D_NUM_BYTES == 0) {
-        // set high byte
-        sCMD[2] = 1;
-    }
-    BL_SendBuf(sCMD, 4);
-    if (BL_GetACK(2) != brNONE) return 0;
-    BL_SendBuf(pMem->D_PTR_I, pMem->D_NUM_BYTES);
-    return (BL_GetACK(40) == brSUCCESS);
+    unsigned len = (pMem->D_NUM_BYTES == 0) ? 0x100 : pMem->D_NUM_BYTES;
+    uint8_t sCMD[] = {CMD_SET_BUFFER, 0, len >> 8, len & 0xff};
+    BL_SendBuf(sCMD, sizeof(sCMD));
+    if (BL_GetACK(2) != BR_NONE)
+        return 0;
+    BL_SendBuf(pMem->D_PTR_I, len);
+    return BL_GetACK(40) == BR_SUCCESS;
 }
 
 static uint8_t BL_ReadA(uint8_t cmd, ioMem_t *pMem)
 {
-    if (BL_SendCMDSetAddress(pMem)) {
-        uint8_t sCMD[] = {cmd, pMem->D_NUM_BYTES};
-        BL_SendBuf(sCMD, 2);
-        return (BL_ReadBuf(pMem->D_PTR_I, pMem->D_NUM_BYTES ));
-    }
-    return 0;
+    if(!BL_SendCMDSetAddress(pMem))
+        return 0;
+    unsigned len = (pMem->D_NUM_BYTES == 0) ? 0x100 : pMem->D_NUM_BYTES;
+    uint8_t sCMD[] = {cmd, len & 0xff};    // 0x100 is sent a 0x00 here
+    BL_SendBuf(sCMD, sizeof(sCMD));
+    return BL_ReadBuf(pMem->D_PTR_I, len);
 }
 
 static uint8_t BL_WriteA(uint8_t cmd, ioMem_t *pMem, uint32_t timeout)
 {
-    if (BL_SendCMDSetAddress(pMem)) {
-        if (!BL_SendCMDSetBuffer(pMem)) return 0;
-        uint8_t sCMD[] = {cmd, 0x01};
-        BL_SendBuf(sCMD, 2);
-        return (BL_GetACK(timeout) == brSUCCESS);
-    }
-    return 0;
+    if(!BL_SendCMDSetAddress(pMem))
+        return 0;
+    if (!BL_SendCMDSetBuffer(pMem))
+        return 0;
+    uint8_t sCMD[] = {cmd, 0x01};
+    BL_SendBuf(sCMD, sizeof(sCMD));
+    return BL_GetACK(timeout) == BR_SUCCESS;
 }
 
 
 uint8_t BL_ReadFlash(uint8_t interface_mode, ioMem_t *pMem)
 {
-    if(interface_mode == imATM_BLB) {
-        return BL_ReadA(CMD_READ_FLASH_ATM, pMem);
-    } else {
-        return BL_ReadA(CMD_READ_FLASH_SIL, pMem);
-    }
+    uint8_t cmd = (interface_mode == imATM_BLB) ? CMD_READ_FLASH_ATM : CMD_READ_FLASH_SIL;
+    return BL_ReadA(cmd, pMem);
 }
- 
- 
+
+
 uint8_t BL_ReadEEprom(ioMem_t *pMem)
 {
     return BL_ReadA(CMD_READ_EEPROM, pMem);
@@ -316,23 +292,22 @@ uint8_t BL_ReadEEprom(ioMem_t *pMem)
 
 uint8_t BL_PageErase(ioMem_t *pMem)
 {
-    if (BL_SendCMDSetAddress(pMem)) {
-        uint8_t sCMD[] = {CMD_ERASE_FLASH, 0x01};
-        BL_SendBuf(sCMD, 2);
-        return (BL_GetACK((40 / START_BIT_TIMEOUT_MS)) == brSUCCESS);
-    }
-    return 0;
+    if(!BL_SendCMDSetAddress(pMem))
+        return 0;
+
+    uint8_t sCMD[] = {CMD_ERASE_FLASH, 0x01};
+    BL_SendBuf(sCMD, sizeof(sCMD));
+    return BL_GetACK(40 * 1000 / START_BIT_TIMEOUT) == BR_SUCCESS;
 }
 
 uint8_t BL_WriteEEprom(ioMem_t *pMem)
 {
-    return BL_WriteA(CMD_PROG_EEPROM, pMem, (3000 / START_BIT_TIMEOUT_MS));
+    return BL_WriteA(CMD_PROG_EEPROM, pMem, 3000 * 1000 / START_BIT_TIMEOUT);
 }
 
 uint8_t BL_WriteFlash(ioMem_t *pMem)
 {
-    return BL_WriteA(CMD_PROG_FLASH, pMem, (40 / START_BIT_TIMEOUT_MS));
+    return BL_WriteA(CMD_PROG_FLASH, pMem, 40 * 1000 / START_BIT_TIMEOUT);
 }
 
-#endif
 #endif

--- a/src/main/io/serial_4way_avrootloader.h
+++ b/src/main/io/serial_4way_avrootloader.h
@@ -21,11 +21,11 @@
 #pragma once
 
 void BL_SendBootInit(void);
-uint8_t BL_ConnectEx(uint8_32_u *pDeviceInfo);
+uint8_t BL_ConnectEx(deviceInfo_t *pDeviceInfo);
 uint8_t BL_SendCMDKeepAlive(void);
 uint8_t BL_PageErase(ioMem_t *pMem);
 uint8_t BL_ReadEEprom(ioMem_t *pMem);
 uint8_t BL_WriteEEprom(ioMem_t *pMem);
 uint8_t BL_WriteFlash(ioMem_t *pMem);
 uint8_t BL_ReadFlash(uint8_t interface_mode, ioMem_t *pMem);
-void BL_SendCMDRunRestartBootloader(uint8_32_u *pDeviceInfo);
+void BL_SendCMDRunRestartBootloader(deviceInfo_t *pDeviceInfo);

--- a/src/main/io/serial_4way_stk500v2.c
+++ b/src/main/io/serial_4way_stk500v2.c
@@ -16,43 +16,45 @@
  * Author: 4712
  * have a look at https://github.com/sim-/tgy/blob/master/boot.inc
  * for info about the stk500v2 implementation
- */ 
+ */
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
 #include <stdlib.h>
 
 #include <platform.h>
-#ifdef  USE_SERIAL_4WAY_BLHELI_INTERFACE
+#include "common/utils.h"
 #include "drivers/gpio.h"
 #include "drivers/buf_writer.h"
 #include "drivers/pwm_mapping.h"
 #include "drivers/serial.h"
+#include "drivers/system.h"
 #include "config/config.h"
 #include "config/parameter_group.h"
 #include "io/serial.h"
 #include "io/serial_msp.h"
 #include "io/serial_4way.h"
 #include "io/serial_4way_stk500v2.h"
-#include "drivers/system.h"
-#ifdef USE_SERIAL_4WAY_SK_BOOTLOADER
 
-#define BIT_LO_US (32) //32uS
-#define BIT_HI_US (2*BIT_LO_US)
+#if defined(USE_SERIAL_4WAY_BLHELI_INTERFACE) && defined(USE_SERIAL_4WAY_SK_BOOTLOADER)
 
-static uint8_t StkInBuf[16];
 
-#define STK_BIT_TIMEOUT 250 // micro seconds
+#define BIT_LO_US 32                               //32uS
+#define BIT_HI_US (2 * BIT_LO_US)
+
+static uint8_t stkInBuf[16];
+
+#define STK_BIT_TIMEOUT 250                        // micro seconds
 #define STK_WAIT_TICKS (1000 / STK_BIT_TIMEOUT)    // per ms
 #define STK_WAITCYLCES (STK_WAIT_TICKS * 35)       // 35ms
-#define STK_WAITCYLCES_START (STK_WAIT_TICKS / 2)  // 0.5 ms
-#define STK_WAITCYLCES_EXT (STK_WAIT_TICKS * 5000) //5 s
+#define STK_WAITCYLCES_START (STK_WAIT_TICKS / 2)  // 0.5ms
+#define STK_WAITCYLCES_EXT (STK_WAIT_TICKS * 5000) // 5s
 
-#define  WaitPinLo  while (ESC_IS_HI) {if (micros() > timeout_timer) goto timeout;}
-#define  WaitPinHi  while (ESC_IS_LO) {if (micros() > timeout_timer) goto timeout;}
+#define  WaitPinLo  while (ESC_IS_HI) { if (cmp32(micros(), timeout_timer) > 0) goto timeout; }
+#define  WaitPinHi  while (ESC_IS_LO) { if (cmp32(micros(), timeout_timer) > 0) goto timeout; }
 
-static uint32_t LastBitTime;
-static uint32_t HiLoTsh;
+static uint32_t lastBitTime;
+static uint32_t hiLoTsh;
 
 static uint8_t SeqNumber;
 static uint8_t StkCmd;
@@ -75,10 +77,10 @@ static uint8_t ckSumOut;
 
 #define STATUS_CMD_OK           0x00
 
-#define CmdFlashEepromRead 0xA0
-#define EnterIspCmd1 0xAC
-#define EnterIspCmd2 0x53
-#define signature_r  0x30
+#define CmdFlashEepromRead      0xA0
+#define EnterIspCmd1            0xAC
+#define EnterIspCmd2            0x53
+#define SIGNATURE_R             0x30
 
 #define delay_us(x) delayMicroseconds(x)
 #define IRQ_OFF // dummy
@@ -86,27 +88,27 @@ static uint8_t ckSumOut;
 
 static void StkSendByte(uint8_t dat)
 {
-	ckSumOut ^= dat;
-	for (uint8_t i = 0; i < 8; i++)	{
-		if (dat & 0x01) {
-			// 1-bits are encoded as 64.0us high, 72.8us low (135.8us total).
-		    ESC_SET_HI;
-		    delay_us(BIT_HI_US);
-			ESC_SET_LO;
-			delay_us(BIT_HI_US);
-		} else {
-			// 0-bits are encoded as 27.8us high, 34.5us low, 34.4us high, 37.9 low (134.6us total)
-		    ESC_SET_HI;
-		    delay_us(BIT_LO_US);
-			ESC_SET_LO;
-			delay_us(BIT_LO_US);
-			ESC_SET_HI;
-			delay_us(BIT_LO_US);
-			ESC_SET_LO;
-			delay_us(BIT_LO_US);
-		}
-		dat >>= 1;
-	}
+    ckSumOut ^= dat;
+    for (uint8_t i = 0; i < 8; i++)	{
+        if (dat & 0x01) {
+            // 1-bits are encoded as 64.0us high, 72.8us low (135.8us total).
+            ESC_SET_HI;
+            delay_us(BIT_HI_US);
+            ESC_SET_LO;
+            delay_us(BIT_HI_US);
+        } else {
+            // 0-bits are encoded as 27.8us high, 34.5us low, 34.4us high, 37.9 low (134.6us total)
+            ESC_SET_HI;
+            delay_us(BIT_LO_US);
+            ESC_SET_LO;
+            delay_us(BIT_LO_US);
+            ESC_SET_HI;
+            delay_us(BIT_LO_US);
+            ESC_SET_LO;
+            delay_us(BIT_LO_US);
+        }
+        dat >>= 1;
+    }
 }
 
 static void StkSendPacketHeader(void)
@@ -130,16 +132,14 @@ static void StkSendPacketFooter(void)
     IRQ_ON;
 }
 
-
-
 static int8_t ReadBit(void)
 {
     uint32_t btimer = micros();
     uint32_t timeout_timer = btimer + STK_BIT_TIMEOUT;
     WaitPinLo;
     WaitPinHi;
-    LastBitTime = micros() - btimer;
-    if (LastBitTime <= HiLoTsh) {
+    lastBitTime = micros() - btimer;
+    if (lastBitTime <= hiLoTsh) {
         timeout_timer = timeout_timer + STK_BIT_TIMEOUT;
         WaitPinLo;
         WaitPinHi;
@@ -152,30 +152,27 @@ timeout:
     return -1;
 }
 
-static uint8_t ReadByte(uint8_t *bt)
+static int ReadByte(void)
 {
-    *bt = 0;
-    for (uint8_t i = 0; i < 8; i++) {
+    uint8_t byte = 0;
+    for (int i = 0; i < 8; i++) {
         int8_t bit = ReadBit();
-        if (bit == -1) goto timeout;
-        if (bit == 1) {
-            *bt |= (1 << i);
-        }
+        if (bit < 0)
+            return -1;  // timeout
+        byte |= bit << i;
     }
-    ckSumIn ^=*bt;
-    return 1;
-timeout:
-    return 0;
+    ckSumIn ^= byte;
+    return byte;
 }
 
 static uint8_t StkReadLeader(void)
 {
 
     // Reset learned timing
-    HiLoTsh = BIT_HI_US + BIT_LO_US;
+    hiLoTsh = BIT_HI_US + BIT_LO_US;
 
     // Wait for the first bit
-    uint32_t waitcycl; //250uS each
+    int waitcycl; //250uS each
 
     if((StkCmd == CMD_PROGRAM_EEPROM_ISP) || (StkCmd == CMD_CHIP_ERASE_ISP)) {
          waitcycl = STK_WAITCYLCES_EXT;
@@ -184,28 +181,25 @@ static uint8_t StkReadLeader(void)
     } else {
         waitcycl= STK_WAITCYLCES;
     }
-    for ( ; waitcycl >0 ; waitcycl--) {
-        //check is not timeout
-        if (ReadBit() >- 1) break;
-    }
-
-    //Skip the first bits
-    if (waitcycl == 0){
+    while(ReadBit() < 0 && --waitcycl > 0);
+    if (waitcycl <= 0)
         goto timeout;
+
+    // Skip the first bits
+    for (int i = 0; i < 10; i++) {
+        if (ReadBit() < 0)
+            goto timeout;
     }
 
-    for (uint8_t i = 0; i < 10; i++) {
-        if (ReadBit() == -1) goto timeout;
-    }
-
-    // learn timing
-    HiLoTsh = (LastBitTime >> 1) + (LastBitTime >> 2);
+    // learn timing (0.75 * lastBitTime)
+    hiLoTsh = (lastBitTime >> 1) + (lastBitTime >> 2);
 
     // Read until we get a 0 bit
-    int8_t bit;
+    int bit;
     do {
         bit = ReadBit();
-        if (bit == -1) goto timeout;
+        if (bit < 0)
+            goto timeout;
     } while (bit > 0);
     return 1;
 timeout:
@@ -214,27 +208,26 @@ timeout:
 
 static uint8_t StkRcvPacket(uint8_t *pstring)
 {
-	uint8_t bt = 0;
-	uint8_16_u Len;
+    int byte;
+    int len;
 
-	IRQ_OFF;
-	if (!StkReadLeader()) goto Err;
+    IRQ_OFF;
+    if (!StkReadLeader()) goto Err;
     ckSumIn=0;
-    if (!ReadByte(&bt) || (bt != MESSAGE_START)) goto Err;
-    if (!ReadByte(&bt) || (bt != SeqNumber)) goto Err;
-    ReadByte(&Len.bytes[1]);
-    if (Len.bytes[1] > 1) goto Err;
-    ReadByte(&Len.bytes[0]);
-    if (Len.bytes[0] < 1) goto Err;
-    if (!ReadByte(&bt) || (bt != TOKEN)) goto Err;
-    if (!ReadByte(&bt) || (bt != StkCmd)) goto Err;
-    if (!ReadByte(&bt) || (bt != STATUS_CMD_OK)) goto Err;
-    for (uint16_t i = 0; i < (Len.word - 2); i++)
-    {
-         if (!ReadByte(pstring)) goto Err;
-         pstring++;
+    if ((byte = ReadByte()) < 0 || (byte != MESSAGE_START)) goto Err;
+    if ((byte = ReadByte()) < 0 || (byte != SeqNumber)) goto Err;
+    len = ReadByte() << 8;
+    len |= ReadByte();
+    if(len < 1 || len > 0x1ff)  // will catch timeout too (TODO - original code did not allow 0x100 (low byte has to be non-zero)
+        goto Err;
+    if ((byte = ReadByte()) < 0 || (byte != TOKEN)) goto Err;
+    if ((byte = ReadByte()) < 0 || (byte != StkCmd)) goto Err;
+    if ((byte = ReadByte()) < 0 || (byte != STATUS_CMD_OK)) goto Err;
+    for (int i = 0; i < len - 2; i++) {
+        if ((byte = ReadByte()) < 0) goto Err;
+        pstring[i] = byte;
     }
-    ReadByte(&bt);
+    ReadByte();                  // read checksum
     if (ckSumIn != 0) goto Err;
     IRQ_ON;
     return 1;
@@ -243,89 +236,79 @@ Err:
     return 0;
 }
 
-static uint8_t _CMD_SPI_MULTI_EX(volatile uint8_t * ResByte,uint8_t Cmd,uint8_t AdrHi,uint8_t AdrLo)
+static uint8_t _CMD_SPI_MULTI_EX(uint8_t * ResByte, uint8_t Cmd, uint16_t addr)
 {
-	StkCmd= CMD_SPI_MULTI;
-	StkSendPacketHeader();
-	StkSendByte(0); // hi byte Msg len
-	StkSendByte(8); // lo byte Msg len
-	StkSendByte(TOKEN);
-	StkSendByte(CMD_SPI_MULTI);
-	StkSendByte(4); // NumTX
-	StkSendByte(4); // NumRX
-	StkSendByte(0); // RxStartAdr
-	StkSendByte(Cmd);	// {TxData} Cmd
-	StkSendByte(AdrHi); // {TxData} AdrHi
-	StkSendByte(AdrLo);	// {TxData} AdrLoch
-	StkSendByte(0); // {TxData} 0
-	StkSendPacketFooter();
-	if (StkRcvPacket((void *)StkInBuf)) { // NumRX + 3
-		 if ((StkInBuf[0] == 0x00) && ((StkInBuf[1] == Cmd)||(StkInBuf[1] == 0x00)/* ignore  zero returns */) &&(StkInBuf[2] == 0x00)) {
-			*ResByte = StkInBuf[3];
-		 }
-		 return 1;
-	}
-	return 0;
+    StkCmd = CMD_SPI_MULTI;
+    StkSendPacketHeader();
+    StkSendByte(0);             // hi byte Msg len
+    StkSendByte(8);             // lo byte Msg len
+    StkSendByte(TOKEN);
+    StkSendByte(CMD_SPI_MULTI);
+    StkSendByte(4);             // NumTX
+    StkSendByte(4);             // NumRX
+    StkSendByte(0);             // RxStartAdr
+    StkSendByte(Cmd);    	// {TxData} Cmd
+    StkSendByte(addr >> 8);     // {TxData} AdrHi
+    StkSendByte(addr & 0xff);	// {TxData} AdrLoch
+    StkSendByte(0);             // {TxData} 0
+    StkSendPacketFooter();
+    if (StkRcvPacket(stkInBuf)) { // NumRX + 3
+        if ((stkInBuf[0] == 0x00)
+            && ((stkInBuf[1] == Cmd) || (stkInBuf[1] == 0x00 /* ignore  zero returns */))
+            && (stkInBuf[2] == 0x00)) {
+            *ResByte = stkInBuf[3];
+        }
+        return 1;
+    }
+    return 0;
 }
 
 static uint8_t _CMD_LOAD_ADDRESS(ioMem_t *pMem)
 {
-	// ignore 0xFFFF
-	// assume address is set before and we read or write the immediately following package
-	if((pMem->D_FLASH_ADDR_H == 0xFF) && (pMem->D_FLASH_ADDR_L == 0xFF)) return 1;
-	StkCmd = CMD_LOAD_ADDRESS;
-	StkSendPacketHeader();
-	StkSendByte(0); // hi byte Msg len
-	StkSendByte(5); // lo byte Msg len
-	StkSendByte(TOKEN);
-	StkSendByte(CMD_LOAD_ADDRESS);
-	StkSendByte(0);
-	StkSendByte(0);
-	StkSendByte(pMem->D_FLASH_ADDR_H);
-	StkSendByte(pMem->D_FLASH_ADDR_L);
-	StkSendPacketFooter();
-	return (StkRcvPacket((void *)StkInBuf));
+    // ignore 0xFFFF
+    // assume address is set before and we read or write the immediately following package
+    if((pMem->D_FLASH_ADDR_H == 0xFF) && (pMem->D_FLASH_ADDR_L == 0xFF))
+        return 1;
+    StkCmd = CMD_LOAD_ADDRESS;
+    StkSendPacketHeader();
+    StkSendByte(0); // hi byte Msg len
+    StkSendByte(5); // lo byte Msg len
+    StkSendByte(TOKEN);
+    StkSendByte(CMD_LOAD_ADDRESS);
+    StkSendByte(0);
+    StkSendByte(0);
+    StkSendByte(pMem->D_FLASH_ADDR_H);
+    StkSendByte(pMem->D_FLASH_ADDR_L);
+    StkSendPacketFooter();
+    return StkRcvPacket(stkInBuf);
 }
 
 static uint8_t _CMD_READ_MEM_ISP(ioMem_t *pMem)
 {
-	uint8_t LenHi;
-	if (pMem->D_NUM_BYTES>0) {
-		LenHi=0;
-	} else {
-		LenHi=1;
-	}
-	StkSendPacketHeader();
-	StkSendByte(0); // hi byte Msg len
-	StkSendByte(4); // lo byte Msg len
-	StkSendByte(TOKEN);
-	StkSendByte(StkCmd);
-	StkSendByte(LenHi);
-	StkSendByte(pMem->D_NUM_BYTES);
-	StkSendByte(CmdFlashEepromRead);
-	StkSendPacketFooter();
-	return (StkRcvPacket(pMem->D_PTR_I));
+    int len =  (pMem->D_NUM_BYTES == 0) ? 0x100 : pMem->D_NUM_BYTES;
+    StkSendPacketHeader();
+    StkSendByte(0); // hi byte Msg len
+    StkSendByte(4); // lo byte Msg len
+    StkSendByte(TOKEN);
+    StkSendByte(StkCmd);
+    StkSendByte(len >> 8);
+    StkSendByte(len & 0xff);
+    StkSendByte(CmdFlashEepromRead);
+    StkSendPacketFooter();
+    return StkRcvPacket(pMem->D_PTR_I);
 }
 
 static uint8_t _CMD_PROGRAM_MEM_ISP(ioMem_t *pMem)
 {
-    uint8_16_u Len;
-    uint8_t LenLo = pMem->D_NUM_BYTES;
-    uint8_t LenHi;
-    if (LenLo) {
-        LenHi = 0;
-        Len.word = LenLo + 10;
-    } else {
-        LenHi = 1;
-        Len.word = 256 + 10;
-    }
+    int len =  (pMem->D_NUM_BYTES == 0) ? 0x100 : pMem->D_NUM_BYTES;
+    int msgLen = len + 10;
     StkSendPacketHeader();
-    StkSendByte(Len.bytes[1]); // high byte Msg len
-    StkSendByte(Len.bytes[0]); // low byte Msg len
+    StkSendByte(msgLen >> 8);   // high byte Msg len
+    StkSendByte(msgLen & 0xff); // low byte Msg len
     StkSendByte(TOKEN);
     StkSendByte(StkCmd);
-    StkSendByte(LenHi);
-    StkSendByte(LenLo);
+    StkSendByte(len >> 8);
+    StkSendByte(len & 0xff);
     StkSendByte(0); // mode
     StkSendByte(0); // delay
     StkSendByte(0); // cmd1
@@ -333,92 +316,86 @@ static uint8_t _CMD_PROGRAM_MEM_ISP(ioMem_t *pMem)
     StkSendByte(0); // cmd3
     StkSendByte(0); // poll1
     StkSendByte(0); // poll2
-    do {
-        StkSendByte(*pMem->D_PTR_I);
-        pMem->D_PTR_I++;
-        LenLo--;
-    } while (LenLo);
+    for(int i = 0; i < len; i++)
+        StkSendByte(pMem->D_PTR_I[i]);
     StkSendPacketFooter();
-    return StkRcvPacket((void *)StkInBuf);
+    return StkRcvPacket((uint8_t *)stkInBuf);
 }
 
 uint8_t Stk_SignOn(void)
 {
-    StkCmd=CMD_SIGN_ON;
+    StkCmd = CMD_SIGN_ON;
     StkSendPacketHeader();
     StkSendByte(0); // hi byte Msg len
     StkSendByte(1); // lo byte Msg len
     StkSendByte(TOKEN);
     StkSendByte(CMD_SIGN_ON);
     StkSendPacketFooter();
-    return (StkRcvPacket((void *) StkInBuf));
+    return (StkRcvPacket(stkInBuf));
 }
 
-uint8_t Stk_ConnectEx(uint8_32_u *pDeviceInfo)
+uint8_t Stk_ConnectEx(deviceInfo_t *pDeviceInfo)
 {
-    if (Stk_SignOn()) {
-        if (_CMD_SPI_MULTI_EX(&pDeviceInfo->bytes[1], signature_r,0,1)) {
-            if (_CMD_SPI_MULTI_EX(&pDeviceInfo->bytes[0], signature_r,0,2)) {
-                return 1;
-            }
-        }
-    }
-    return 0;
+    if (!Stk_SignOn())
+        return 0;
+    uint8_t signHi, signLo;
+    if (!_CMD_SPI_MULTI_EX(&signHi, SIGNATURE_R, 1))
+        return 0;
+    if (_CMD_SPI_MULTI_EX(&signLo, SIGNATURE_R, 2))
+        return 0;
+    pDeviceInfo->signature = (signHi << 8) | signLo;
+    return 1;
 }
 
 uint8_t Stk_Chip_Erase(void)
 {
-	StkCmd = CMD_CHIP_ERASE_ISP;
-	StkSendPacketHeader();
-	StkSendByte(0); // high byte Msg len
-	StkSendByte(7); // low byte Msg len
-	StkSendByte(TOKEN);
-	StkSendByte(CMD_CHIP_ERASE_ISP);
-	StkSendByte(20); // ChipErase_eraseDelay atmega8
-	StkSendByte(0); // ChipErase_pollMethod atmega8
-	StkSendByte(0xAC);
-	StkSendByte(0x88);
-	StkSendByte(0x13);
-	StkSendByte(0x76);
-	StkSendPacketFooter();
-	return (StkRcvPacket(StkInBuf));
+    StkCmd = CMD_CHIP_ERASE_ISP;
+    StkSendPacketHeader();
+    StkSendByte(0);  // high byte Msg len
+    StkSendByte(7);  // low byte Msg len
+    StkSendByte(TOKEN);
+    StkSendByte(StkCmd);
+    StkSendByte(20); // ChipErase_eraseDelay atmega8
+    StkSendByte(0);  // ChipErase_pollMethod atmega8
+    StkSendByte(0xAC);
+    StkSendByte(0x88);
+    StkSendByte(0x13);
+    StkSendByte(0x76);
+    StkSendPacketFooter();
+    return StkRcvPacket(stkInBuf);
 }
 
 uint8_t Stk_ReadFlash(ioMem_t *pMem)
 {
-	if (_CMD_LOAD_ADDRESS(pMem)) {
-		StkCmd = CMD_READ_FLASH_ISP;
-		return (_CMD_READ_MEM_ISP(pMem));
-	}
-	return 0;
+    if (!_CMD_LOAD_ADDRESS(pMem))
+        return 0;
+    StkCmd = CMD_READ_FLASH_ISP;
+    return _CMD_READ_MEM_ISP(pMem);
 }
 
 
 uint8_t Stk_ReadEEprom(ioMem_t *pMem)
 {
-	if (_CMD_LOAD_ADDRESS(pMem)) {
-		StkCmd = CMD_READ_EEPROM_ISP;
-		return (_CMD_READ_MEM_ISP(pMem));
-	}
-	return 0;
+    if (!_CMD_LOAD_ADDRESS(pMem))
+        return 0;
+    StkCmd = CMD_READ_EEPROM_ISP;
+    return _CMD_READ_MEM_ISP(pMem);
 }
 
 uint8_t Stk_WriteFlash(ioMem_t *pMem)
 {
-	if (_CMD_LOAD_ADDRESS(pMem)) {
-		StkCmd = CMD_PROGRAM_FLASH_ISP;
-		return (_CMD_PROGRAM_MEM_ISP(pMem));
-	}
-	return 0;
+    if (!_CMD_LOAD_ADDRESS(pMem))
+        return 0;
+    StkCmd = CMD_PROGRAM_FLASH_ISP;
+    return _CMD_PROGRAM_MEM_ISP(pMem);
 }
 
 uint8_t Stk_WriteEEprom(ioMem_t *pMem)
 {
-	if (_CMD_LOAD_ADDRESS(pMem)) {
-		StkCmd = CMD_PROGRAM_EEPROM_ISP;
-		return (_CMD_PROGRAM_MEM_ISP(pMem));
-	}
-	return 0;
+    if (!_CMD_LOAD_ADDRESS(pMem))
+        return 0;
+    StkCmd = CMD_PROGRAM_EEPROM_ISP;
+    return _CMD_PROGRAM_MEM_ISP(pMem);
 }
-#endif
+
 #endif

--- a/src/main/io/serial_4way_stk500v2.c
+++ b/src/main/io/serial_4way_stk500v2.c
@@ -209,7 +209,7 @@ timeout:
     return 0;
 }
 
-static uint8_t StkRcvPacket(uint8_t *pstring)
+static uint8_t StkRcvPacket(uint8_t *pstring, int maxLen)
 {
     int byte;
     int len;
@@ -221,7 +221,7 @@ static uint8_t StkRcvPacket(uint8_t *pstring)
     if ((byte = ReadByte()) < 0 || (byte != SeqNumber)) goto Err;
     len = ReadByte() << 8;
     len |= ReadByte();
-    if(len < 1 || len > 0x1ff)  // will catch timeout too (TODO - original code did not allow 0x100 (low byte has to be non-zero)
+    if(len < 1 || len >= maxLen + 2)  // will catch timeout too; limit length to buffer size
         goto Err;
     if ((byte = ReadByte()) < 0 || (byte != TOKEN)) goto Err;
     if ((byte = ReadByte()) < 0 || (byte != StkCmd)) goto Err;
@@ -252,7 +252,7 @@ static uint8_t _CMD_SPI_MULTI_EX(uint8_t * resByte, uint8_t subcmd, uint16_t add
     StkSendByte(addr & 0xff);	// {TxData} AdrLow
     StkSendByte(0);             // {TxData} 0
     StkSendPacketFooter();
-    if (StkRcvPacket(stkInBuf)) { // NumRX + 3
+    if (StkRcvPacket(stkInBuf, sizeof(stkInBuf))) { // NumRX + 3
         if ((stkInBuf[0] == 0x00)
             && ((stkInBuf[1] == subcmd) || (stkInBuf[1] == 0x00 /* ignore  zero returns */))
             && (stkInBuf[2] == 0x00)) {
@@ -277,7 +277,7 @@ static uint8_t _CMD_LOAD_ADDRESS(ioMem_t *pMem)
     StkSendByte(pMem->addr >> 8);
     StkSendByte(pMem->addr & 0xff);
     StkSendPacketFooter();
-    return StkRcvPacket(stkInBuf);
+    return StkRcvPacket(stkInBuf, sizeof(stkInBuf));
 }
 
 static uint8_t _CMD_READ_MEM_ISP(ioMem_t *pMem)
@@ -288,7 +288,7 @@ static uint8_t _CMD_READ_MEM_ISP(ioMem_t *pMem)
     StkSendByte(pMem->len & 0xff);
     StkSendByte(CmdFlashEepromRead);
     StkSendPacketFooter();
-    return StkRcvPacket(pMem->data);
+    return StkRcvPacket(pMem->data, pMem->len);
 }
 
 static uint8_t _CMD_PROGRAM_MEM_ISP(ioMem_t *pMem)
@@ -307,7 +307,7 @@ static uint8_t _CMD_PROGRAM_MEM_ISP(ioMem_t *pMem)
     for(int i = 0; i < pMem->len; i++)
         StkSendByte(pMem->data[i]);
     StkSendPacketFooter();
-    return StkRcvPacket((uint8_t *)stkInBuf);
+    return StkRcvPacket(stkInBuf, sizeof(stkInBuf));
 }
 
 uint8_t Stk_SignOn(void)
@@ -316,7 +316,7 @@ uint8_t Stk_SignOn(void)
     StkSendPacketHeader(1);
     StkSendByte(CMD_SIGN_ON);
     StkSendPacketFooter();
-    return (StkRcvPacket(stkInBuf));
+    return StkRcvPacket(stkInBuf, sizeof(stkInBuf));
 }
 
 uint8_t Stk_ConnectEx(deviceInfo_t *pDeviceInfo)
@@ -346,7 +346,7 @@ uint8_t Stk_Chip_Erase(void)
     StkSendByte(0x13);
     StkSendByte(0x76);
     StkSendPacketFooter();
-    return StkRcvPacket(stkInBuf);
+    return StkRcvPacket(stkInBuf, sizeof(stkInBuf));
 }
 
 uint8_t Stk_ReadFlash(ioMem_t *pMem)

--- a/src/main/io/serial_4way_stk500v2.c
+++ b/src/main/io/serial_4way_stk500v2.c
@@ -80,7 +80,7 @@ static uint8_t ckSumOut;
 #define CmdFlashEepromRead      0xA0
 #define EnterIspCmd1            0xAC
 #define EnterIspCmd2            0x53
-#define SIGNATURE_R             0x30
+#define SPI_SIGNATURE_READ      0x30
 
 #define delay_us(x) delayMicroseconds(x)
 #define IRQ_OFF // dummy
@@ -111,7 +111,7 @@ static void StkSendByte(uint8_t dat)
     }
 }
 
-static void StkSendPacketHeader(void)
+static void StkSendPacketHeader(uint16_t len)
 {
     IRQ_OFF;
     ESC_OUTPUT;
@@ -121,6 +121,9 @@ static void StkSendPacketHeader(void)
     ckSumOut = 0;
     StkSendByte(MESSAGE_START);
     StkSendByte(++SeqNumber);
+    StkSendByte(len >> 8);
+    StkSendByte(len & 0xff);
+    StkSendByte(TOKEN);
 }
 
 static void StkSendPacketFooter(void)
@@ -236,27 +239,24 @@ Err:
     return 0;
 }
 
-static uint8_t _CMD_SPI_MULTI_EX(uint8_t * ResByte, uint8_t Cmd, uint16_t addr)
+static uint8_t _CMD_SPI_MULTI_EX(uint8_t * resByte, uint8_t subcmd, uint16_t addr)
 {
     StkCmd = CMD_SPI_MULTI;
-    StkSendPacketHeader();
-    StkSendByte(0);             // hi byte Msg len
-    StkSendByte(8);             // lo byte Msg len
-    StkSendByte(TOKEN);
+    StkSendPacketHeader(8);
     StkSendByte(CMD_SPI_MULTI);
     StkSendByte(4);             // NumTX
     StkSendByte(4);             // NumRX
     StkSendByte(0);             // RxStartAdr
-    StkSendByte(Cmd);    	// {TxData} Cmd
+    StkSendByte(subcmd);    	// {TxData} Cmd
     StkSendByte(addr >> 8);     // {TxData} AdrHi
-    StkSendByte(addr & 0xff);	// {TxData} AdrLoch
+    StkSendByte(addr & 0xff);	// {TxData} AdrLow
     StkSendByte(0);             // {TxData} 0
     StkSendPacketFooter();
     if (StkRcvPacket(stkInBuf)) { // NumRX + 3
         if ((stkInBuf[0] == 0x00)
-            && ((stkInBuf[1] == Cmd) || (stkInBuf[1] == 0x00 /* ignore  zero returns */))
+            && ((stkInBuf[1] == subcmd) || (stkInBuf[1] == 0x00 /* ignore  zero returns */))
             && (stkInBuf[2] == 0x00)) {
-            *ResByte = stkInBuf[3];
+            *resByte = stkInBuf[3];
         }
         return 1;
     }
@@ -266,49 +266,37 @@ static uint8_t _CMD_SPI_MULTI_EX(uint8_t * ResByte, uint8_t Cmd, uint16_t addr)
 static uint8_t _CMD_LOAD_ADDRESS(ioMem_t *pMem)
 {
     // ignore 0xFFFF
-    // assume address is set before and we read or write the immediately following package
-    if((pMem->D_FLASH_ADDR_H == 0xFF) && (pMem->D_FLASH_ADDR_L == 0xFF))
+    // assume address is set before and we read or write the immediately following memory
+    if((pMem->addr == 0xffff))
         return 1;
     StkCmd = CMD_LOAD_ADDRESS;
-    StkSendPacketHeader();
-    StkSendByte(0); // hi byte Msg len
-    StkSendByte(5); // lo byte Msg len
-    StkSendByte(TOKEN);
+    StkSendPacketHeader(5);
     StkSendByte(CMD_LOAD_ADDRESS);
     StkSendByte(0);
     StkSendByte(0);
-    StkSendByte(pMem->D_FLASH_ADDR_H);
-    StkSendByte(pMem->D_FLASH_ADDR_L);
+    StkSendByte(pMem->addr >> 8);
+    StkSendByte(pMem->addr & 0xff);
     StkSendPacketFooter();
     return StkRcvPacket(stkInBuf);
 }
 
 static uint8_t _CMD_READ_MEM_ISP(ioMem_t *pMem)
 {
-    int len =  (pMem->D_NUM_BYTES == 0) ? 0x100 : pMem->D_NUM_BYTES;
-    StkSendPacketHeader();
-    StkSendByte(0); // hi byte Msg len
-    StkSendByte(4); // lo byte Msg len
-    StkSendByte(TOKEN);
+    StkSendPacketHeader(4);
     StkSendByte(StkCmd);
-    StkSendByte(len >> 8);
-    StkSendByte(len & 0xff);
+    StkSendByte(pMem->len >> 8);
+    StkSendByte(pMem->len & 0xff);
     StkSendByte(CmdFlashEepromRead);
     StkSendPacketFooter();
-    return StkRcvPacket(pMem->D_PTR_I);
+    return StkRcvPacket(pMem->data);
 }
 
 static uint8_t _CMD_PROGRAM_MEM_ISP(ioMem_t *pMem)
 {
-    int len =  (pMem->D_NUM_BYTES == 0) ? 0x100 : pMem->D_NUM_BYTES;
-    int msgLen = len + 10;
-    StkSendPacketHeader();
-    StkSendByte(msgLen >> 8);   // high byte Msg len
-    StkSendByte(msgLen & 0xff); // low byte Msg len
-    StkSendByte(TOKEN);
+    StkSendPacketHeader(pMem->len + 10);
     StkSendByte(StkCmd);
-    StkSendByte(len >> 8);
-    StkSendByte(len & 0xff);
+    StkSendByte(pMem->len >> 8);
+    StkSendByte(pMem->len & 0xff);
     StkSendByte(0); // mode
     StkSendByte(0); // delay
     StkSendByte(0); // cmd1
@@ -316,8 +304,8 @@ static uint8_t _CMD_PROGRAM_MEM_ISP(ioMem_t *pMem)
     StkSendByte(0); // cmd3
     StkSendByte(0); // poll1
     StkSendByte(0); // poll2
-    for(int i = 0; i < len; i++)
-        StkSendByte(pMem->D_PTR_I[i]);
+    for(int i = 0; i < pMem->len; i++)
+        StkSendByte(pMem->data[i]);
     StkSendPacketFooter();
     return StkRcvPacket((uint8_t *)stkInBuf);
 }
@@ -325,10 +313,7 @@ static uint8_t _CMD_PROGRAM_MEM_ISP(ioMem_t *pMem)
 uint8_t Stk_SignOn(void)
 {
     StkCmd = CMD_SIGN_ON;
-    StkSendPacketHeader();
-    StkSendByte(0); // hi byte Msg len
-    StkSendByte(1); // lo byte Msg len
-    StkSendByte(TOKEN);
+    StkSendPacketHeader(1);
     StkSendByte(CMD_SIGN_ON);
     StkSendPacketFooter();
     return (StkRcvPacket(stkInBuf));
@@ -338,22 +323,21 @@ uint8_t Stk_ConnectEx(deviceInfo_t *pDeviceInfo)
 {
     if (!Stk_SignOn())
         return 0;
-    uint8_t signHi, signLo;
-    if (!_CMD_SPI_MULTI_EX(&signHi, SIGNATURE_R, 1))
-        return 0;
-    if (_CMD_SPI_MULTI_EX(&signLo, SIGNATURE_R, 2))
-        return 0;
-    pDeviceInfo->signature = (signHi << 8) | signLo;
+    uint8_t signature[3];    // device signature, MSB first
+    for(unsigned i = 0; i < sizeof(signature); i++) {
+        if (!_CMD_SPI_MULTI_EX(&signature[i], SPI_SIGNATURE_READ, i))
+            return 0;
+    }
+    // convert signature to little endian
+    pDeviceInfo->signature = (signature[1] << 8) | signature[2];
+    pDeviceInfo->signature2 = signature[0];
     return 1;
 }
 
 uint8_t Stk_Chip_Erase(void)
 {
     StkCmd = CMD_CHIP_ERASE_ISP;
-    StkSendPacketHeader();
-    StkSendByte(0);  // high byte Msg len
-    StkSendByte(7);  // low byte Msg len
-    StkSendByte(TOKEN);
+    StkSendPacketHeader(7);
     StkSendByte(StkCmd);
     StkSendByte(20); // ChipErase_eraseDelay atmega8
     StkSendByte(0);  // ChipErase_pollMethod atmega8

--- a/src/main/io/serial_4way_stk500v2.h
+++ b/src/main/io/serial_4way_stk500v2.h
@@ -18,7 +18,7 @@
 #pragma once
 
 uint8_t Stk_SignOn(void);
-uint8_t Stk_ConnectEx(uint8_32_u *pDeviceInfo);
+uint8_t Stk_ConnectEx(deviceInfo_t *pDeviceInfo);
 uint8_t Stk_ReadEEprom(ioMem_t *pMem);
 uint8_t Stk_WriteEEprom(ioMem_t *pMem);
 uint8_t Stk_ReadFlash(ioMem_t *pMem);

--- a/src/main/io/serial_msp.c
+++ b/src/main/io/serial_msp.c
@@ -1704,7 +1704,7 @@ static bool processInCommand(void)
         // rem: App: Wait at least appx. 500 ms for BLHeli to jump into
         // bootloader mode before try to connect any ESC
         // Start to activate here
-        Process4WayInterface(currentPort, writer);
+        Process4WayInterface(currentPort->port);
         // former used MSP uart is still active
         // proceed as usual with MSP commands
         break;


### PR DESCRIPTION
Here is my attempt to cleanup 4WAY-IF.. It is untested yet (but it should not change anything important), I'll do some test soon.
All comments are welcome

Cleaning 4-way interface sources.
Source formatting changed to CleanFlight style
Removed AVR idioms where possible
Remove some unnecessary optimization
Use serialPort_t instead of mspPort_t