### PR TITLE
SPRACINGF3MINI - Add 5 channel parallel PWM receiver support

### DIFF
--- a/docs/Board - SPRacingF3Mini.md
+++ b/docs/Board - SPRacingF3Mini.md
@@ -23,6 +23,7 @@ http://seriouslypro.com/spracingf3mini
 * 8 PWM output lines for ESCs and Servos. Arranged for easy wiring on standard pin headers.
 * Supports direct connection of SBus, SumH, SumD, Spektrum1024/2048, XBus receivers. No external inverters required (built-in).
 * Supports direct connection of 3.3v Spektrum Satellite receivers via 3 pin through-hole JST-ZH connector.
+* Supports direct connection of 1-5 channel Parallel PWM receivers *1. 
 * Dedicated PPM receiver input.
 * 3 Serial Ports - NOT shared with the USB socket.
 * Telemetry port (via pin header or USART2 JST-SH socket).
@@ -42,6 +43,9 @@ http://seriouslypro.com/spracingf3mini
 * LEDs for 3v, 5v and Status for easy diagnostics.
 * Copper-etched Cleanflight and #RB logos.
 
+
+*1 - PWM receiver must use 3.3v outputs.  Works only in multirotor mode.  Uses motor outputs 5-8 and PPM pin as RC 1-5 inputs.
+
 ## Pinouts
 
 Full pinout details are available in the manual, here:
@@ -54,12 +58,12 @@ The main section is the square part of the board with the 30.5mm mounting holes.
 
 ### Left Side IO (Front to Back)
 
-| Pin | Function               | Notes                                        |
-| --- | ---------------------- | -------------------------------------------- |
-| 1   | RX3                    | Square Pad                                   |
-| 2   | TX3                    | Round Pad                                    |
-| 3   | PWM8 / SoftSerial 1 RX | Square Pad                                   |
-| 4   | PWM7 / SoftSerial 1 TX | Square Pad                                   |
+| Pin | Function                     | Notes                                        |
+| --- | ---------------------------- | -------------------------------------------- |
+| 1   | RX3                          | Square Pad                                   |
+| 2   | TX3                          | Round Pad                                    |
+| 3   | PWM8 / SoftSerial 1 RX / RC4 | Square Pad                                   |
+| 4   | PWM7 / SoftSerial 1 TX / RC3 | Square Pad                                   |
 
 To the left of both PWM7 and PWM8 there are 2 more pins - left to right: GND, VIN, PWM7/8.
 To the right of RX3 there are two more though holes.  Use RX3 and the 2 holes to attach a JST-ZH connector for a Spektrum Satellite 3v receiver.
@@ -70,8 +74,8 @@ To the right of RX3 there are two more though holes.  Use RX3 and the 2 holes to
 | --- | -------------- | -------------------------------------------- |
 | 1   | RSSI           | Round Pad / PWM                              |
 | 2   | CURRENT        | Round Pad                                    |
-| 3   | PWM6           | Square Pad                                   |
-| 4   | PWM5           | Square Pad                                   |
+| 3   | PWM6 / RC2     | Square Pad                                   |
+| 4   | PWM5 / RC1     | Square Pad                                   |
 | 5   | T1             | Round Pad                                    |
 | 6   | R1             | Round Pad                                    |
 | 7   | 5v             | Round Pad                                    |

--- a/src/main/drivers/pwm_mapping.c
+++ b/src/main/drivers/pwm_mapping.c
@@ -593,6 +593,7 @@ static const uint16_t multiPWM[] = {
     PWM7  | (MAP_TO_MOTOR_OUTPUT << 8),
     PWM8  | (MAP_TO_MOTOR_OUTPUT << 8),
     PWM9  | (MAP_TO_MOTOR_OUTPUT << 8),
+    PWM1  | (MAP_TO_PWM_INPUT    << 8), // Use PWM input for AUX1, PWM6-9 get remapped by conditional code.
     PWM10 | (MAP_TO_MOTOR_OUTPUT << 8),
     PWM11 | (MAP_TO_MOTOR_OUTPUT << 8),
     0xFFFF
@@ -622,6 +623,7 @@ static const uint16_t airPWM[] = {
     PWM7  | (MAP_TO_SERVO_OUTPUT  << 8),
     PWM8  | (MAP_TO_SERVO_OUTPUT  << 8),
     PWM9  | (MAP_TO_SERVO_OUTPUT  << 8),
+    PWM1  | (MAP_TO_PWM_INPUT    << 8), // Use PWM input for AUX1, PWM6-9 get remapped by conditional code.
     PWM10 | (MAP_TO_SERVO_OUTPUT  << 8),
     PWM11 | (MAP_TO_SERVO_OUTPUT  << 8), // servo #8
     0xFFFF
@@ -755,6 +757,14 @@ pwmIOConfiguration_t *pwmInit(drv_pwm_config_t *init)
 #endif
 
         // hacks to allow current functionality
+
+#if defined(SPRACINGF3MINI)
+            // remap PWM1, 6-9 as PWM input when parallel PWM is used (for AUX1 and RC1-4, respectively)
+            if (init->useParallelPWM && (timerIndex == PWM6 || timerIndex == PWM7 || timerIndex == PWM8 || timerIndex == PWM9 || timerIndex == PWM1)) {
+                type = MAP_TO_PWM_INPUT;
+            }
+#endif
+
         if (type == MAP_TO_PWM_INPUT && !init->useParallelPWM)
             continue;
 


### PR DESCRIPTION
Via MOTOR 6-8 for RC CH 1-4 and PPM for AUX1.

PA0-3 are the input which are __NOT 5V TOLERANT__.

This works perfectly with receivers that give 3v outputs, such as the nice little FrSky VD5M (Tested).