### PR TITLE
Cleanup of gyro_sync.c

### DIFF
--- a/src/main/drivers/gyro_sync.c
+++ b/src/main/drivers/gyro_sync.c
@@ -34,31 +34,31 @@
 extern gyro_t gyro;
 
 uint32_t targetLooptime;
-uint8_t mpuDividerDrops;
+static uint8_t mpuDividerDrops;
 
-bool gyroSyncCheckUpdate(void) {
+bool gyroSyncCheckUpdate(void)
+{
     return gyro.isDataReady && gyro.isDataReady();
 }
 
-void gyroUpdateSampleRate(uint32_t looptime, uint8_t lpf, uint8_t gyroSync, uint8_t gyroSyncDenominator) {
-    int gyroSamplePeriod;
-
+void gyroSetSampleRate(uint32_t looptime, uint8_t lpf, uint8_t gyroSync, uint8_t gyroSyncDenominator)
+{
     if (gyroSync) {
-        if (!lpf) {
+        int gyroSamplePeriod;
+        if (lpf == 0) {
             gyroSamplePeriod = 125;
-
         } else {
             gyroSamplePeriod = 1000;
         }
-
         mpuDividerDrops = gyroSyncDenominator - 1;
-        targetLooptime = (mpuDividerDrops + 1) * gyroSamplePeriod;
+        targetLooptime = gyroSyncDenominator * gyroSamplePeriod;
     } else {
-    	mpuDividerDrops = 0;
-    	targetLooptime = looptime;
+        mpuDividerDrops = 0;
+        targetLooptime = looptime;
     }
 }
 
-uint8_t gyroMPU6xxxCalculateDivider(void) {
+uint8_t gyroMPU6xxxCalculateDivider(void)
+{
     return mpuDividerDrops;
 }

--- a/src/main/drivers/gyro_sync.h
+++ b/src/main/drivers/gyro_sync.h
@@ -21,4 +21,4 @@ extern uint32_t targetLooptime;
 
 bool gyroSyncCheckUpdate(void);
 uint8_t gyroMPU6xxxCalculateDivider(void);
-void gyroUpdateSampleRate(uint32_t looptime, uint8_t lpf, uint8_t gyroSync, uint8_t gyroSyncDenominator);
+void gyroSetSampleRate(uint32_t looptime, uint8_t lpf, uint8_t gyroSync, uint8_t gyroSyncDenominator);

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -589,7 +589,7 @@ const clivalue_t valueTable[] = {
     { "max_angle_inclination",      VAR_UINT16 | MASTER_VALUE, .config.minmax = { 100,  900 } , PG_IMU_CONFIG, offsetof(imuConfig_t, max_angle_inclination) },
 
     { "gyro_lpf",                   VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_GYRO_LPF } , PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_lpf)},
-    { "gyro_soft_lpf",              VAR_FLOAT  | MASTER_VALUE, .config.minmax = { 0,  500 } , PG_GYRO_CONFIG, offsetof(gyroConfig_t, soft_gyro_lpf_hz)},
+    { "gyro_soft_lpf",              VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0,  500 } , PG_GYRO_CONFIG, offsetof(gyroConfig_t, soft_gyro_lpf_hz)},
     { "moron_threshold",            VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0,  128 } , PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyroMovementCalibrationThreshold)},
     { "imu_dcm_kp",                 VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0,  20000 } , PG_IMU_CONFIG, offsetof(imuConfig_t, dcm_kp)},
     { "imu_dcm_ki",                 VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0,  20000 } , PG_IMU_CONFIG, offsetof(imuConfig_t, dcm_ki)},

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -480,7 +480,7 @@ void init(void)
     }
 #endif
 
-    gyroUpdateSampleRate(imuConfig()->looptime, gyroConfig()->gyro_lpf, imuConfig()->gyroSync, imuConfig()->gyroSyncDenominator);   // Set gyro sampling rate divider before initialization
+    gyroSetSampleRate(imuConfig()->looptime, gyroConfig()->gyro_lpf, imuConfig()->gyroSync, imuConfig()->gyroSyncDenominator);   // Set gyro sampling rate divider before initialization
 
     if (!sensorsAutodetect()) {
         // if gyro was not detected due to whatever reason, we give up now.

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -33,12 +33,11 @@ extern gyro_t gyro;
 extern sensor_align_e gyroAlign;
 
 extern int32_t gyroADC[XYZ_AXIS_COUNT];
-extern int32_t gyroZero[FD_INDEX_COUNT];
 
 typedef struct gyroConfig_s {
-    uint8_t gyroMovementCalibrationThreshold; // people keep forgetting that moving model while init results in wrong gyro offsets. and then they never reset gyro. so this is now on by default.
-    uint8_t gyro_lpf;                       // gyro LPF setting - values are driver specific, in case of invalid number, a reasonable default ~30-40HZ is chosen.
-    float soft_gyro_lpf_hz;                 // Software based gyro filter in hz
+    uint8_t gyroMovementCalibrationThreshold;   // people keep forgetting that moving model while init results in wrong gyro offsets. and then they never reset gyro. so this is now on by default.
+    uint8_t gyro_lpf;                           // gyro LPF setting - values are driver specific, in case of invalid number, a reasonable default ~30-40HZ is chosen.
+    uint16_t soft_gyro_lpf_hz;                  // Software based gyro filter in hz
 } gyroConfig_t;
 
 PG_DECLARE(gyroConfig_t, gyroConfig);


### PR DESCRIPTION
Make variables and functions static where appropriate. Removed duplicated condition. Made `gyro_soft_lpf` `uint16_t` rather than `float`.

Saves 160 bytes of ROM.

