### PR TITLE
Cleanup of acc device drivers extern usage

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1141,7 +1141,7 @@ static bool blackboxWriteSysinfo()
             blackboxPrintfHeaderLine("gyro.scale:0x%x", castFloatBytesToInt(gyro.scale));
         break;
         case 9:
-            blackboxPrintfHeaderLine("acc_1G:%u", acc_1G);
+            blackboxPrintfHeaderLine("acc_1G:%u", acc.acc_1G);
         break;
         case 10:
             if (testBlackboxCondition(FLIGHT_LOG_FIELD_CONDITION_VBAT)) {

--- a/src/main/drivers/accgyro.h
+++ b/src/main/drivers/accgyro.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-
 typedef struct gyro_s {
     sensorGyroInitFuncPtr init;                             // initialize function
     sensorReadFuncPtr read;                                 // read 3 axis data function

--- a/src/main/drivers/accgyro.h
+++ b/src/main/drivers/accgyro.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-extern uint16_t acc_1G; // FIXME move into acc_t
 
 typedef struct gyro_s {
     sensorGyroInitFuncPtr init;                             // initialize function
@@ -28,7 +27,9 @@ typedef struct gyro_s {
 } gyro_t;
 
 typedef struct acc_s {
-    sensorInitFuncPtr init;                                 // initialize function
+    sensorAccInitFuncPtr init;                              // initialize function
     sensorReadFuncPtr read;                                 // read 3 axis data function
+    uint16_t acc_1G;
     char revisionCode;                                      // a revision code for the sensor, if known
 } acc_t;
+

--- a/src/main/drivers/accgyro_adxl345.c
+++ b/src/main/drivers/accgyro_adxl345.c
@@ -91,7 +91,7 @@ static void adxl345Init(acc_t *acc)
         i2cWrite(ADXL345_ADDRESS, ADXL345_DATA_FORMAT, ADXL345_FULL_RANGE | ADXL345_RANGE_8G);
         i2cWrite(ADXL345_ADDRESS, ADXL345_BW_RATE, ADXL345_RATE_100);
     }
-    acc->acc_1G = 265; // 3.3V operation // FIXME verify this is supposed to be 265, not 256. Typo?
+    acc->acc_1G = 256;
 }
 
 uint8_t acc_samples = 0;

--- a/src/main/drivers/accgyro_adxl345.c
+++ b/src/main/drivers/accgyro_adxl345.c
@@ -56,7 +56,7 @@
 #define ADXL345_RANGE_16G   0x03
 #define ADXL345_FIFO_STREAM 0x80
 
-static void adxl345Init(void);
+static void adxl345Init(acc_t *acc);
 static bool adxl345Read(int16_t *accelData);
 
 static bool useFifo = false;
@@ -78,7 +78,7 @@ bool adxl345Detect(drv_adxl345_config_t *init, acc_t *acc)
     return true;
 }
 
-static void adxl345Init(void)
+static void adxl345Init(acc_t *acc)
 {
     if (useFifo) {
         uint8_t fifoDepth = 16;
@@ -91,7 +91,7 @@ static void adxl345Init(void)
         i2cWrite(ADXL345_ADDRESS, ADXL345_DATA_FORMAT, ADXL345_FULL_RANGE | ADXL345_RANGE_8G);
         i2cWrite(ADXL345_ADDRESS, ADXL345_BW_RATE, ADXL345_RATE_100);
     }
-    acc_1G = 265; // 3.3V operation // FIXME verify this is supposed to be 265, not 256. Typo?
+    acc->acc_1G = 265; // 3.3V operation // FIXME verify this is supposed to be 265, not 256. Typo?
 }
 
 uint8_t acc_samples = 0;

--- a/src/main/drivers/accgyro_bma280.c
+++ b/src/main/drivers/accgyro_bma280.c
@@ -32,7 +32,7 @@
 #define BMA280_PMU_BW      0x10
 #define BMA280_PMU_RANGE   0x0F
 
-static void bma280Init(void);
+static void bma280Init(acc_t *acc);
 static bool bma280Read(int16_t *accelData);
 
 bool bma280Detect(acc_t *acc)
@@ -49,12 +49,12 @@ bool bma280Detect(acc_t *acc)
     return true;
 }
 
-static void bma280Init(void)
+static void bma280Init(acc_t *acc)
 {
     i2cWrite(BMA280_ADDRESS, BMA280_PMU_RANGE, 0x08); // +-8g range
     i2cWrite(BMA280_ADDRESS, BMA280_PMU_BW, 0x0E); // 500Hz BW
 
-    acc_1G = 512 * 8;
+    acc->acc_1G = 512 * 8;
 }
 
 static bool bma280Read(int16_t *accelData)

--- a/src/main/drivers/accgyro_lsm303dlhc.c
+++ b/src/main/drivers/accgyro_lsm303dlhc.c
@@ -113,7 +113,7 @@ int32_t accelSummedSamples100Hz[3];
 
 int32_t accelSummedSamples500Hz[3];
 
-void lsm303dlhcAccInit(void)
+void lsm303dlhcAccInit(acc_t *acc)
 {
     i2cWrite(LSM303DLHC_ACCEL_ADDRESS, CTRL_REG5_A, BOOT);
 
@@ -127,7 +127,7 @@ void lsm303dlhcAccInit(void)
 
     delay(100);
 
-    acc_1G = 512 * 8;
+    acc->acc_1G = 512 * 8;
 }
 
 // Read 3 gyro values into user-provided buffer. No overrun checking is done.

--- a/src/main/drivers/accgyro_mma845x.c
+++ b/src/main/drivers/accgyro_mma845x.c
@@ -77,7 +77,7 @@
 
 static uint8_t device_id;
 
-static void mma8452Init(void);
+static void mma8452Init(acc_t *acc);
 static bool mma8452Read(int16_t *accelData);
 
 bool mma8452Detect(acc_t *acc)
@@ -117,7 +117,7 @@ static inline void mma8451ConfigureInterrupt(void)
     i2cWrite(MMA8452_ADDRESS, MMA8452_CTRL_REG5, 0); // DRDY routed to INT2
 }
 
-static void mma8452Init(void)
+static void mma8452Init(acc_t *acc)
 {
 
     i2cWrite(MMA8452_ADDRESS, MMA8452_CTRL_REG1, 0); // Put device in standby to configure stuff
@@ -129,7 +129,7 @@ static void mma8452Init(void)
 
     i2cWrite(MMA8452_ADDRESS, MMA8452_CTRL_REG1, MMA8452_CTRL_REG1_LNOISE | MMA8452_CTRL_REG1_ACTIVE); // Turn on measurements, low noise at max scale mode, Data Rate 800Hz. LNoise mode makes range +-4G.
 
-    acc_1G = 256;
+    acc->acc_1G = 256;
 }
 
 static bool mma8452Read(int16_t *accelData)

--- a/src/main/drivers/accgyro_mpu6050.c
+++ b/src/main/drivers/accgyro_mpu6050.c
@@ -51,7 +51,7 @@ extern uint8_t mpuLowPassFilter;
 
 #define MPU6050_SMPLRT_DIV      0       // 8000Hz
 
-static void mpu6050AccInit(void);
+static void mpu6050AccInit(acc_t *acc);
 static void mpu6050GyroInit(uint8_t lpf);
 
 bool mpu6050AccDetect(acc_t *acc)
@@ -82,16 +82,16 @@ bool mpu6050GyroDetect(gyro_t *gyro)
     return true;
 }
 
-static void mpu6050AccInit(void)
+static void mpu6050AccInit(acc_t *acc)
 {
     mpuIntExtiInit();
 
     switch (mpuDetectionResult.resolution) {
         case MPU_HALF_RESOLUTION:
-            acc_1G = 256 * 8;
+            acc->acc_1G = 256 * 8;
             break;
         case MPU_FULL_RESOLUTION:
-            acc_1G = 512 * 8;
+            acc->acc_1G = 512 * 8;
             break;
     }
 }

--- a/src/main/drivers/accgyro_mpu6500.c
+++ b/src/main/drivers/accgyro_mpu6500.c
@@ -35,8 +35,6 @@
 #include "accgyro_mpu.h"
 #include "accgyro_mpu6500.h"
 
-extern uint16_t acc_1G;
-
 bool mpu6500AccDetect(acc_t *acc)
 {
     if (mpuDetectionResult.sensor != MPU_65xx_I2C) {
@@ -65,11 +63,11 @@ bool mpu6500GyroDetect(gyro_t *gyro)
     return true;
 }
 
-void mpu6500AccInit(void)
+void mpu6500AccInit(acc_t *acc)
 {
     mpuIntExtiInit();
 
-    acc_1G = 512 * 8;
+    acc->acc_1G = 512 * 8;
 }
 
 void mpu6500GyroInit(uint8_t lpf)

--- a/src/main/drivers/accgyro_mpu6500.h
+++ b/src/main/drivers/accgyro_mpu6500.h
@@ -24,5 +24,5 @@
 bool mpu6500AccDetect(acc_t *acc);
 bool mpu6500GyroDetect(gyro_t *gyro);
 
-void mpu6500AccInit(void);
+void mpu6500AccInit(acc_t *acc);
 void mpu6500GyroInit(uint8_t lpf);

--- a/src/main/drivers/accgyro_spi_mpu6000.c
+++ b/src/main/drivers/accgyro_spi_mpu6000.c
@@ -141,11 +141,11 @@ void mpu6000SpiGyroInit(uint8_t lpf)
     }
 }
 
-void mpu6000SpiAccInit(void)
+void mpu6000SpiAccInit(acc_t *acc)
 {
     mpuIntExtiInit();
 
-    acc_1G = 512 * 8;
+    acc->acc_1G = 512 * 8;
 }
 
 bool mpu6000SpiDetect(void)

--- a/src/main/drivers/accgyro_spi_mpu6500.c
+++ b/src/main/drivers/accgyro_spi_mpu6500.c
@@ -38,8 +38,6 @@
 #define DISABLE_MPU6500       GPIO_SetBits(MPU6500_CS_GPIO,   MPU6500_CS_PIN)
 #define ENABLE_MPU6500        GPIO_ResetBits(MPU6500_CS_GPIO, MPU6500_CS_PIN)
 
-extern uint16_t acc_1G;
-
 bool mpu6500WriteRegister(uint8_t reg, uint8_t data)
 {
     ENABLE_MPU6500;

--- a/src/main/drivers/sensor.h
+++ b/src/main/drivers/sensor.h
@@ -19,5 +19,9 @@
 
 typedef void (*sensorInitFuncPtr)(void);                    // sensor init prototype
 typedef bool (*sensorReadFuncPtr)(int16_t *data);           // sensor read prototype
+
+struct acc_s;
+typedef void (*sensorAccInitFuncPtr)(struct acc_s *acc);                    // sensor init prototype
 typedef void (*sensorGyroInitFuncPtr)(uint8_t lpf);         // gyro sensor init prototype
 typedef bool (*sensorIsDataReadyFuncPtr)(void);             // sensor data ready prototype
+

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -144,7 +144,7 @@ void imuInit(void)
 {
     smallAngleCosZ = cos_approx(degreesToRadians(imuRuntimeConfig->small_angle));
     gyroScale = gyro.scale * (M_PIf / 180.0f);  // gyro output scaled to rad per second
-    accVelScale = 9.80665f / acc_1G / 10000.0f;
+    accVelScale = 9.80665f / acc.acc_1G / 10000.0f;
 
     imuComputeRotationMatrix();
 }
@@ -209,7 +209,7 @@ void imuCalculateAcceleration(uint32_t deltaT)
         }
         accel_ned.V.Z -= accZoffset / 64;  // compensate for gravitation on z-axis
     } else
-        accel_ned.V.Z -= acc_1G;
+        accel_ned.V.Z -= acc.acc_1G;
 
     accz_smooth = accz_smooth + (dT / (fc_acc + dT)) * (accel_ned.V.Z - accz_smooth); // low pass filter
 
@@ -391,7 +391,7 @@ static bool imuIsAccelerometerHealthy(void)
         accMagnitude += (int32_t)accSmooth[axis] * accSmooth[axis];
     }
 
-    accMagnitude = accMagnitude * 100 / (sq((int32_t)acc_1G));
+    accMagnitude = accMagnitude * 100 / (sq((int32_t)acc.acc_1G));
 
     // Accept accel readings only in range 0.90g - 1.10g
     return (81 < accMagnitude) && (accMagnitude < 121);

--- a/src/main/io/msp.c
+++ b/src/main/io/msp.c
@@ -593,7 +593,7 @@ static int processOutCommand(mspPacket_t *cmd, mspPacket_t *reply)
 
         case MSP_RAW_IMU: {
             // Hack scale due to choice of units for sensor data in multiwii
-            unsigned scale_shift = (acc_1G > 1024) ? 3 : 0;
+            unsigned scale_shift = (acc.acc_1G > 1024) ? 3 : 0;
 
             for (unsigned i = 0; i < 3; i++)
                 sbufWriteU16(dst, accSmooth[i] >> scale_shift);

--- a/src/main/sensors/acceleration.c
+++ b/src/main/sensors/acceleration.c
@@ -69,7 +69,6 @@ int32_t accADC[XYZ_AXIS_COUNT];
 
 acc_t acc;                       // acc access functions
 sensor_align_e accAlign = 0;
-uint16_t acc_1G = 256;          // this is the 1G measured acceleration.
 
 uint16_t calibratingA = 0;      // the calibration is done is the main loop. Calibrating decreases at each cycle down to 0, then we enter in a normal mode.
 
@@ -124,7 +123,7 @@ void performAcclerationCalibration(rollAndPitchTrims_t *rollAndPitchTrims)
         // Calculate average, shift Z down by acc_1G and store values in EEPROM at end of calibration
         accelerationTrims->raw[X] = (a[X] + (CALIBRATING_ACC_CYCLES / 2)) / CALIBRATING_ACC_CYCLES;
         accelerationTrims->raw[Y] = (a[Y] + (CALIBRATING_ACC_CYCLES / 2)) / CALIBRATING_ACC_CYCLES;
-        accelerationTrims->raw[Z] = (a[Z] + (CALIBRATING_ACC_CYCLES / 2)) / CALIBRATING_ACC_CYCLES - acc_1G;
+        accelerationTrims->raw[Z] = (a[Z] + (CALIBRATING_ACC_CYCLES / 2)) / CALIBRATING_ACC_CYCLES - acc.acc_1G;
 
         resetRollAndPitchTrims(rollAndPitchTrims);
 
@@ -179,7 +178,7 @@ void performInflightAccelerationCalibration(rollAndPitchTrims_t *rollAndPitchTri
         AccInflightCalibrationSavetoEEProm = false;
         accelerationTrims->raw[X] = b[X] / 50;
         accelerationTrims->raw[Y] = b[Y] / 50;
-        accelerationTrims->raw[Z] = b[Z] / 50 - acc_1G;    // for nunchuck 200=1G
+        accelerationTrims->raw[Z] = b[Z] / 50 - acc.acc_1G;    // for nunchuck 200=1G
 
         resetRollAndPitchTrims(rollAndPitchTrims);
 

--- a/src/main/sensors/acceleration.h
+++ b/src/main/sensors/acceleration.h
@@ -35,7 +35,6 @@ typedef enum {
 
 extern sensor_align_e accAlign;
 extern acc_t acc;
-extern uint16_t acc_1G;
 
 extern int32_t accADC[XYZ_AXIS_COUNT];
 

--- a/src/main/sensors/initialisation.c
+++ b/src/main/sensors/initialisation.c
@@ -694,8 +694,10 @@ bool sensorsAutodetect(void)
 
 
     // Now time to init things, acc first
-    if (sensors(SENSOR_ACC))
-        acc.init();
+    if (sensors(SENSOR_ACC)) {
+        acc.acc_1G = 256; // set default
+        acc.init(&acc);
+    }
     // this is safe because either mpu6050 or mpu3050 or lg3d20 sets it, and in case of fail, we never get here.
     gyro.init(gyroConfig()->gyro_lpf);
 

--- a/src/main/telemetry/frsky.c
+++ b/src/main/telemetry/frsky.c
@@ -152,8 +152,7 @@ static void serializeFrsky(uint8_t data)
 
 static void serialize16(int16_t a)
 {
-    uint8_t t;
-    t = a;
+    uint8_t t = a;
     serializeFrsky(t);
     t = a >> 8 & 0xff;
     serializeFrsky(t);
@@ -161,11 +160,9 @@ static void serialize16(int16_t a)
 
 static void sendAccel(void)
 {
-    int i;
-
-    for (i = 0; i < 3; i++) {
+    for (int i = 0; i < 3; i++) {
         sendDataHead(ID_ACC_X + i);
-        serialize16(((float)accSmooth[i] / acc.acc_1G) * 1000);
+        serialize16(1000 * (int32_t)accSmooth[i] / acc.acc_1G);
     }
 }
 

--- a/src/main/telemetry/frsky.c
+++ b/src/main/telemetry/frsky.c
@@ -165,7 +165,7 @@ static void sendAccel(void)
 
     for (i = 0; i < 3; i++) {
         sendDataHead(ID_ACC_X + i);
-        serialize16(((float)accSmooth[i] / acc_1G) * 1000);
+        serialize16(((float)accSmooth[i] / acc.acc_1G) * 1000);
     }
 }
 

--- a/src/test/unit/flight_imu_unittest.cc
+++ b/src/test/unit/flight_imu_unittest.cc
@@ -154,7 +154,7 @@ uint32_t rcModeActivationMask;
 int16_t rcCommand[4];
 int16_t rcData[MAX_SUPPORTED_RC_CHANNEL_COUNT];
 
-uint16_t acc_1G;
+acc_t acc;
 int16_t heading;
 gyro_t gyro;
 int32_t magADC[XYZ_AXIS_COUNT];


### PR DESCRIPTION
This fixes the horrible condition whereby the acc device drivers use an `extern` (`acc_1G`) owned by `sensors/acceleration.c`, i.e. the acc device drivers have a dependency on higher level code.

As @ledvinap has suggested, in the long term it is probably best that the scaling of the acc output is done in the device drivers themselves.

Has the not insignificant side benefit of saving 136 bytes of ROM.