### PR TITLE
USB-VCP gcc 5.3  fix

### DIFF
--- a/lib/main/STM32_USB-FS-Device_Driver/inc/usb_regs.h
+++ b/lib/main/STM32_USB-FS-Device_Driver/inc/usb_regs.h
@@ -228,8 +228,8 @@ enum EP_BUF_NUM
 /* GetDADDR */
 #define _GetDADDR()  ((__IO uint16_t) *DADDR)
 
-/* GetBTABLE */
-#define _GetBTABLE() ((__IO uint16_t) *BTABLE)
+/* GetBTABLE ; clear low-order bits explicitly to avoid problems in gcc 5.x */
+#define _GetBTABLE() (((__IO uint16_t) *BTABLE) & ~0x07)
 
 /* SetENDPOINT */
 #define _SetENDPOINT(bEpNum,wRegValue)  (*(EP0REG + bEpNum)= \


### PR DESCRIPTION
looks like gcc bug - gcc generates half-word access in _SetEPTxAddr / _SetEPRxAddr macro. Using `addr & ~ 3` fixes this and VCP works fine

Code works when optimization level is decreased for `Virtual_Com_Port_Reset`

here is invalid code for reference:
```
	.loc 4 493 0
	ldr	r3, [r7]	@ D.5186, MEM[(volatile unsigned int *)1073765456B(BTABLE)] SetEPRxAddr
	uxtah	r3, r2, r3	@ D.5188, tmp245, D.5186
	lsls	r3, r3, #1	@ D.5189, D.5188,
	mov	r9, #64	@ tmp249,
	ldrh	r2, [r3]	@, *_219
	strh	r9, [r3]	@ movhi	@ tmp249, *_219
	ldrh	r2, [r3, #2]	@, *_219
	strh	r4, [r3, #2]	@ movhi	@ tmp217, *_219
.LVL58:
.LBE93:
.LBE98:
.LBB99:
.LBB100:
	.loc 4 481 0
	ldr	r3, [r7]	@ D.5186, MEM[(volatile unsigned int *)1073765456B(BTABLE)] SetEPTxAddr
	uxth	r3, r3	@ D.5187, D.5186
	add	r3, r3, #536870912	@ D.5188, D.5187,
	add	r3, r3, #12288	@ D.5188, D.5188,
	lsls	r3, r3, #1	@ D.5189, D.5188,
.LBE100:
.LBE99:
	.loc 1 139 0
	mov	r0, r4	@, tmp217
.LBB102:
.LBB101:
	.loc 4 481 0
	ldrh	r2, [r3]	@, *_207
	movs	r2, #128	@ tmp261,
	strh	r2, [r3]	@ movhi	@ tmp261, *_207
	ldrh	r2, [r3, #2]	@, *_207
	strh	r4, [r3, #2]	@ movhi	@ tmp217, *_207
```