### PR TITLE
Spektrum serial receiver changes

### DIFF
--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -267,7 +267,7 @@ uint8_t serialRxFrameStatus(void)
     switch (rxConfig()->serialrx_provider) {
         case SERIALRX_SPEKTRUM1024:
         case SERIALRX_SPEKTRUM2048:
-            return spektrumFrameStatus();
+            return spektrumFrameStatus(rxConfig, &rxRuntimeConfig);
         case SERIALRX_SBUS:
             return sbusFrameStatus();
         case SERIALRX_SUMD:
@@ -583,12 +583,12 @@ void updateRSSIPWM(void)
     int16_t pwmRssi = 0;
     // Read value of AUX channel as rssi
     pwmRssi = rcData[rxConfig()->rssi_channel - 1];
-	
-	// RSSI_Invert option	
+
+	// RSSI_Invert option
 	if (rxConfig()->rssi_ppm_invert) {
 	    pwmRssi = ((2000 - pwmRssi) + 1000);
 	}
-	
+
     // Range of rawPwmRssi is [1000;2000]. rssi should be in [0;1023];
     rssi = (uint16_t)((constrain(pwmRssi - 1000, 0, 1000) / 1000.0f) * 1023.0f);
 }

--- a/src/main/rx/spektrum.c
+++ b/src/main/rx/spektrum.c
@@ -201,13 +201,17 @@ static uint16_t spektrumReadRawRC(rxRuntimeConfig_t *rxRuntimeConfig, uint8_t ch
         return 0;
     }
 
+#ifdef SPEKTRUM_PROPER_SCALING //To match intended spektrum pulse range. This will allow consistent travel between ppm and serial rx's
+    if (spekHiRes)
+        data = 903 + (spekChannelData[chan]*.583);    // 2048 mode
+    else
+        data = 903 + (spekChannelData[chan]*1.166);   // 1024 mode
+#else
     if (spekHiRes)
         data = 988 + (spekChannelData[chan] >> 1);      // 2048 mode
-        //data = 903 + (spekChannelData[chan]*.583);    // 2048 mode
     else
         data = 988 + spekChannelData[chan];             // 1024 mode
-        //data = 903 + (spekChannelData[chan]*1.166);   // 1024 mode
-
+#endif
     return data;
 }
 

--- a/src/main/rx/spektrum.c
+++ b/src/main/rx/spektrum.c
@@ -48,6 +48,8 @@
 
 #define SPEKTRUM_BAUDRATE 115200
 
+static uint8_t initialPacket = 0;
+static uint8_t frameLoss = 0;
 static uint8_t spek_chan_shift;
 static uint8_t spek_chan_mask;
 static bool rcFrameComplete = false;
@@ -121,7 +123,7 @@ static void spektrumDataReceive(uint16_t c)
 
 static uint32_t spekChannelData[SPEKTRUM_MAX_SUPPORTED_CHANNEL_COUNT];
 
-uint8_t spektrumFrameStatus(void)
+uint8_t spektrumFrameStatus(rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig)
 {
     uint8_t b;
 
@@ -130,6 +132,51 @@ uint8_t spektrumFrameStatus(void)
     }
 
     rcFrameComplete = false;
+
+	//Check for bind type in the first packet after startup. This is provided in the second byte in a data packet from the internal remote.
+    //This packet wont contain any data if the remote was bound using a separate receiver (bound as external remote)
+    if(!initialPacket){
+
+        switch (spekFrame[1]){
+            case 0xb2:       //11MS 2048 DSMX
+                rxConfig->serialrx_provider = SERIALRX_SPEKTRUM2048;
+                saveConfigAndNotify();
+                break;
+            case 0xa2:  //22MS 2048 DSMX
+                rxConfig->serialrx_provider = SERIALRX_SPEKTRUM2048;
+                saveConfigAndNotify();
+                break;
+            case 0x12:  //11MS 2048 DSM2
+                rxConfig->serialrx_provider = SERIALRX_SPEKTRUM2048;
+                saveConfigAndNotify();
+                break;
+            case 0x01:  //22MS 1024 DSM2
+                rxConfig->serialrx_provider = SERIALRX_SPEKTRUM1024;
+                saveConfigAndNotify();
+                break;
+        }
+        //Immediately set the resolution settings so that a reboot isn't required after binding.
+        switch (rxConfig->serialrx_provider) {
+            case SERIALRX_SPEKTRUM2048:
+                // 11 bit frames
+                spek_chan_shift = 3;
+                spek_chan_mask = 0x07;
+                spekHiRes = true;
+                rxRuntimeConfig->channelCount = SPEKTRUM_2048_CHANNEL_COUNT;
+                break;
+            case SERIALRX_SPEKTRUM1024:
+                // 10 bit frames
+                spek_chan_shift = 2;
+                spek_chan_mask = 0x03;
+                spekHiRes = false;
+                rxRuntimeConfig->channelCount = SPEKTRUM_1024_CHANNEL_COUNT;
+                break;
+        }
+
+        initialPacket=1;    //prevent this byte from being read every packet. It's only necessary to determine bind type at startup.
+    }
+
+    frameLoss = spekFrame[0];   //fades (or frame loss if single sat rx) is provided in the first byte of a sat rx packet
 
     for (b = 3; b < SPEK_FRAME_SIZE; b += 2) {
         uint8_t spekChannel = 0x0F & (spekFrame[b - 1] >> spek_chan_shift);
@@ -150,9 +197,9 @@ static uint16_t spektrumReadRawRC(rxRuntimeConfig_t *rxRuntimeConfig, uint8_t ch
     }
 
     if (spekHiRes)
-        data = 988 + (spekChannelData[chan] >> 1);   // 2048 mode
+        data = 903 + (spekChannelData[chan]*.583);      // 2048 mode
     else
-        data = 988 + spekChannelData[chan];          // 1024 mode
+        data = 903 + (spekChannelData[chan]*1.166);     // 1024 mode
 
     return data;
 }

--- a/src/main/rx/spektrum.c
+++ b/src/main/rx/spektrum.c
@@ -137,24 +137,29 @@ uint8_t spektrumFrameStatus(rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeCo
     //This packet wont contain any data if the remote was bound using a separate receiver (bound as external remote)
     if(!initialPacket){
 
+        //save current resolution to variable in case remote rx is bound as external.
+        //This will prevent the if statement (after the switch case) from setting the resolution to an incorrect value if no resolution data is received.
+        uint8_t spmResolution = rxConfig->serialrx_provider;
+
         switch (spekFrame[1]){
             case 0xb2:       //11MS 2048 DSMX
-                rxConfig->serialrx_provider = SERIALRX_SPEKTRUM2048;
-                saveConfigAndNotify();
+                spmResolution = SERIALRX_SPEKTRUM2048;
                 break;
             case 0xa2:  //22MS 2048 DSMX
-                rxConfig->serialrx_provider = SERIALRX_SPEKTRUM2048;
-                saveConfigAndNotify();
+                spmResolution = SERIALRX_SPEKTRUM2048;
                 break;
             case 0x12:  //11MS 2048 DSM2
-                rxConfig->serialrx_provider = SERIALRX_SPEKTRUM2048;
-                saveConfigAndNotify();
+                spmResolution = SERIALRX_SPEKTRUM2048;
                 break;
             case 0x01:  //22MS 1024 DSM2
-                rxConfig->serialrx_provider = SERIALRX_SPEKTRUM1024;
-                saveConfigAndNotify();
+                spmResolution = SERIALRX_SPEKTRUM1024;
                 break;
         }
+
+    if(rxConfig->serialrx_provider != spmResolution){
+        rxConfig->serialrx_provider = spmResolution;
+        saveConfigAndNotify();
+    }
         //Immediately set the resolution settings so that a reboot isn't required after binding.
         switch (rxConfig->serialrx_provider) {
             case SERIALRX_SPEKTRUM2048:
@@ -197,9 +202,11 @@ static uint16_t spektrumReadRawRC(rxRuntimeConfig_t *rxRuntimeConfig, uint8_t ch
     }
 
     if (spekHiRes)
-        data = 903 + (spekChannelData[chan]*.583);      // 2048 mode
+        data = 988 + (spekChannelData[chan] >> 1);      // 2048 mode
+        //data = 903 + (spekChannelData[chan]*.583);    // 2048 mode
     else
-        data = 903 + (spekChannelData[chan]*1.166);     // 1024 mode
+        data = 988 + spekChannelData[chan];             // 1024 mode
+        //data = 903 + (spekChannelData[chan]*1.166);   // 1024 mode
 
     return data;
 }

--- a/src/main/rx/spektrum.h
+++ b/src/main/rx/spektrum.h
@@ -20,7 +20,7 @@
 #define SPEKTRUM_SAT_BIND_DISABLED 0
 #define SPEKTRUM_SAT_BIND_MAX 10
 
-uint8_t spektrumFrameStatus(void);
+uint8_t spektrumFrameStatus(rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig);
 bool spektrumInit(rxRuntimeConfig_t *rxRuntimeConfig, rcReadRawDataPtr *callback);
 
 void spektrumBind(rxConfig_t *rxConfig);


### PR DESCRIPTION
Follow up on pull request #1985 

Some additions and changes done to current Spektrum rx serial implementation.
In short.
-scaling change to have serial and ppm input travel matching if SPEKTRUM_PROPER_SCALING is defined. Otherwise, scaling remains as before
-If bound as internal receiver, system data (resolution) is automatically read from the rx and set if not already correct
-though currently not implemented elsewhere, frame losses are now read from rx and stored in "frameLoss" variable.
