### PR TITLE
Channel forwarding docs

### DIFF
--- a/docs/Mixer.md
+++ b/docs/Mixer.md
@@ -47,6 +47,14 @@ You can also use the Command Line Interface (CLI) to set the mixer type:
 The cli `servo` command defines the settings for the servo outputs. 
 The cli mixer `smix` command controllers how the mixer maps internal FC data (RC input, PID stabilisation output, channel forwarding, etc) to servo outputs.
 
+
+### Channel Forwarding
+
+Channel Forwarding allows you to forward your AUX channels directly to servos over PWM pins 5-8. You can enable it under features in the GUI or using the cli 
+with ``feature CHANNEL_FORWARDING``. This requires you to run PPM or another serial RC protocol, and is currently supported on NAZE and SPRACINGF3 targets.
+Note that if you have the led feature enabled on the NAZE target,  AUX1-2 is mapped to PWM13-14 instead. So for instance if you enable this feature on a Naze
+AUX1 from your receiver will automatically be forwarded to PWM5 as a servo signal.
+
 ## Servo filtering
 
 A low-pass filter can be enabled for the servos.  It may be useful for avoiding structural modes in the airframe, for example.  


### PR DESCRIPTION
Add a little info to the mixer documentation about channel forwarding. Note that behavior has been described to the best of my understanding of the code in pwm_mapping.c

As far as I can tell, channel forwarding only works on naze and spracing? Not sure if this should be said more clearly? I'm also curious if the led strip condition also should check for soft serial, as this seems to overlap with the 5-8 pwm pins as well. 