### PR TITLE
Fix warnings

### DIFF
--- a/src/main/drivers/compass_ak8963.c
+++ b/src/main/drivers/compass_ak8963.c
@@ -263,7 +263,7 @@ void ak8963Init()
 
 bool ak8963Read(int16_t *magData)
 {
-    bool ack;
+    bool ack = false;
     uint8_t buf[7];
 
 #if defined(USE_SPI) && defined(MPU9250_SPI_INSTANCE)

--- a/src/main/flight/pid_luxfloat.c
+++ b/src/main/flight/pid_luxfloat.c
@@ -141,7 +141,7 @@ void pidLuxFloat(const pidProfile_t *pidProfile, const controlRateConfig_t *cont
 {
     pidFilterIsSetCheck(pidProfile);
 
-    float horizonLevelStrength;
+    float horizonLevelStrength = 0;
     if (FLIGHT_MODE(HORIZON_MODE)) {
         // Figure out the most deflected stick position
         const int32_t stickPosAil = ABS(getRcStickDeflection(ROLL, rxConfig->midrc));

--- a/src/main/flight/pid_mwrewrite.c
+++ b/src/main/flight/pid_mwrewrite.c
@@ -139,7 +139,7 @@ void pidMultiWiiRewrite(const pidProfile_t *pidProfile, const controlRateConfig_
 {
     pidFilterIsSetCheck(pidProfile);
 
-    int8_t horizonLevelStrength;
+    int8_t horizonLevelStrength = 0;
     if (FLIGHT_MODE(HORIZON_MODE)) {
         // Figure out the most deflected stick position
         const int32_t stickPosAil = ABS(getRcStickDeflection(ROLL, rxConfig->midrc));

--- a/src/main/io/ledstrip.c
+++ b/src/main/io/ledstrip.c
@@ -78,7 +78,9 @@ static uint32_t nextAnimationUpdateAt = 0;
 static uint32_t nextIndicatorFlashAt = 0;
 static uint32_t nextBlinkFlashAt = 0;
 static uint32_t nextWarningFlashAt = 0;
+#ifdef GPS
 static uint32_t nextGpsFlashAt = 0;
+#endif
 static uint32_t nextRotationUpdateAt = 0;
 
 #define LED_STRIP_20HZ ((1000 * 1000) / 20)

--- a/src/main/mavlink/mavlink_types.h
+++ b/src/main/mavlink/mavlink_types.h
@@ -8,6 +8,11 @@
 
 #include <stdint.h>
 
+#ifdef __GNUC__
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
 // Macro to define packed structures
 #ifdef __GNUC__
   #define MAVPACKED( __Declaration__ ) __Declaration__ __attribute__((packed))
@@ -217,5 +222,9 @@ typedef struct __mavlink_status {
 
 #define MAVLINK_BIG_ENDIAN 0
 #define MAVLINK_LITTLE_ENDIAN 1
+
+#ifdef __GNUC__
+# pragma GCC diagnostic pop
+#endif
 
 #endif /* MAVLINK_TYPES_H_ */


### PR DESCRIPTION
Trivial fix for warnings in current code.

mavlink fix should be probably reverted when some conclusion about -Wpedantic is reached.

@hydra : Please merge this ASAP - it is so annoying to skip existing warnings when testing new code ..  