### PR TITLE
Implement LEDStripModeColor messages in MSP

### DIFF
--- a/src/main/io/msp_protocol.h
+++ b/src/main/io/msp_protocol.h
@@ -59,7 +59,7 @@
 #define MSP_PROTOCOL_VERSION                0
 
 #define API_VERSION_MAJOR                   1 // increment when major changes are made
-#define API_VERSION_MINOR                   18 // increment when any change is made, reset to zero when major changes are released after changing API_VERSION_MAJOR
+#define API_VERSION_MINOR                   19 // increment when any change is made, reset to zero when major changes are released after changing API_VERSION_MAJOR
 
 #define API_VERSION_LENGTH                  2
 
@@ -164,6 +164,9 @@
 
 #define MSP_TRANSPONDER_CONFIG          82 //out message         Get transponder settings
 #define MSP_SET_TRANSPONDER_CONFIG      83 //in  message         Set transponder settings
+
+#define MSP_LED_STRIP_MODECOLOR         86 //out message         Get LED strip mode_color settings
+#define MSP_SET_LED_STRIP_MODECOLOR     87 //in  message         Set LED strip mode_color settings
 
 //
 // Baseflight MSP commands (if enabled they exist in Cleanflight)

--- a/src/test/unit/msp_unittest.cc
+++ b/src/test/unit/msp_unittest.cc
@@ -105,6 +105,8 @@ extern "C" {
     PG_REGISTER(motor3DConfig_t, motor3DConfig, PG_MOTOR_3D_CONFIG, 0);
     PG_REGISTER_ARR(ledConfig_t, LED_MAX_STRIP_LENGTH, ledConfigs, PG_LED_STRIP_CONFIG, 0);
     PG_REGISTER_ARR(hsvColor_t, LED_CONFIGURABLE_COLOR_COUNT, colors, PG_COLOR_CONFIG, 0);
+    PG_REGISTER_ARR(modeColorIndexes_t, LED_MODE_COUNT, modeColors, PG_MODE_COLOR_CONFIG, 0);
+    PG_REGISTER_ARR(specialColorIndexes_t, 1, specialColors, PG_SPECIAL_COLOR_CONFIG, 0);
     PG_REGISTER(gpsConfig_t, gpsConfig, PG_GPS_CONFIG, 0);
     PG_REGISTER(telemetryConfig_t, telemetryConfig, PG_TELEMETRY_CONFIG, 0);
     PG_REGISTER(frskyTelemetryConfig_t, frskyTelemetryConfig, PG_FRSKY_TELEMETRY_CONFIG, 0);
@@ -425,6 +427,8 @@ TEST_F(MspTest, TestMspCommands)
         MSP_SDCARD_SUMMARY,             // 79 //out message         Get the state of the SD card
         MSP_BLACKBOX_CONFIG,            // 80 //out message         Get blackbox settings
         MSP_TRANSPONDER_CONFIG,         // 82 //out message         Get transponder settings
+        MSP_LED_STRIP_MODECOLOR,        // 85 //out message         Get LED strip mode_color settings
+        MSP_SET_LED_STRIP_MODECOLOR,    // 86 //out message         Set LED strip mode_color settings
         // Baseflight MSP commands (if enabled they exist in Cleanflight)
         MSP_RX_MAP,                     // 64 //out message get channel map (also returns number of channels total)
         // DEPRECATED - DO NOT USE "MSP_BF_CONFIG" and MSP_SET_BF_CONFIG.  In Cleanflight, isolated commands already exist and should be used instead.
@@ -531,6 +535,7 @@ attitudeEulerAngles_t attitude = { { 0, 0, 0 } };     // absolute angle inclinat
 int16_t accSmooth[XYZ_AXIS_COUNT];
 // from ledstrip.c
 void reevalulateLedConfig(void) {}
+bool setModeColor(ledModeIndex_e , int , int ) { return true; }
 // from mixer.c
 int16_t motor[MAX_SUPPORTED_MOTORS];
 int16_t motor_disarmed[MAX_SUPPORTED_MOTORS];


### PR DESCRIPTION
Implement new MSP messages :
- MSP_LED_STRIP_MODECOLOR
- MSP_SET_LED_STRIP_MODECOLOR

Additionally, in MSP_SET_LED_COLORS, check color HSV validity before appplying it.

Based on @ledvinap's Ledstrip Cleanup.
