### PR TITLE
Status led pattern: disabled arm reason

### DIFF
--- a/docs/Controls.md
+++ b/docs/Controls.md
@@ -9,12 +9,16 @@ that is not recommended).
 By default, arming and disarming is done using stick positions.  (NOTE: this feature is disabled when using a
 switch to arm.)
 
-Arming is disabled if:
-- CLI is active in the configurator
-- The aircraft has landed in failsafe mode
-- Maximum arming angle is exceeded
-- Calibration is active
-- The system is overloaded
+Some conditions will disable arming. In this case the Warning LED on the board will flash a certain number of times, indicating what the condition is:
+
+| Reason for disabled Arming               | LED Flashes |
+|------------------------------------------|-------------|
+| CLI is active in the configurator        | 2           |
+| Failsafe mode is active                  | 3           |
+| The aircraft has landed in failsafe mode | 3           |
+| Maximum arming angle is exceeded         | 4           |
+| Calibration is active                    | 5           |
+| The system is overloaded                 | 6           |
 
 ## Stick Positions
 

--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -92,6 +92,7 @@ If one of these tests fail, do not attempt to fly, but go back to the configurat
 ## Using it (AKA: Flying)
 
 Go to the field, turn Tx on, place aircraft on the ground, connect flight battery and wait. Arm and fly. Good luck!
+If the aircraft won't arm, count the red Warning LED flashes and find out the reason in [Controls](Controls.md).
 
 ## Advanced Matters
 

--- a/src/main/io/beeper.c
+++ b/src/main/io/beeper.c
@@ -28,14 +28,13 @@
 #include "config/feature.h"
 
 #include "io/rc_controls.h"
+#include "io/statusindicator.h"
 
 #include "drivers/gpio.h"
 #include "drivers/sound_beeper.h"
 #include "drivers/system.h"
 #include "sensors/battery.h"
 #include "sensors/sensors.h"
-
-#include "io/statusindicator.h"
 
 #ifdef GPS
 #include "io/gps.h"
@@ -218,12 +217,9 @@ void beeper(beeperMode_e mode)
 
 void beeperSilence(void)
 {
-    BEEP_OFF;
-    warningLedDisable();
-    warningLedRefresh();
-
-
     beeperIsOn = 0;
+    BEEP_OFF;
+    warningLedBeeper(false);
 
     beeperNextToggleTime = 0;
     beeperPos = 0;
@@ -305,8 +301,7 @@ void beeperUpdate(void)
         beeperIsOn = 1;
         if (currentBeeperEntry->sequence[beeperPos] != 0) {
             BEEP_ON;
-            warningLedEnable();
-            warningLedRefresh();
+            warningLedBeeper(true);
             // if this was arming beep then mark time (for blackbox)
             if (
                 beeperPos == 0
@@ -319,8 +314,7 @@ void beeperUpdate(void)
         beeperIsOn = 0;
         if (currentBeeperEntry->sequence[beeperPos] != 0) {
             BEEP_OFF;
-            warningLedDisable();
-            warningLedRefresh();
+            warningLedBeeper(false);
         }
     }
 

--- a/src/main/io/statusindicator.h
+++ b/src/main/io/statusindicator.h
@@ -17,8 +17,7 @@
 
 #pragma once
 
-void warningLedEnable(void);
-void warningLedDisable(void);
-void warningLedRefresh(void);
+#define WARNING_LED_BLINK_DELAY  200000
+
+void warningLedBeeper(bool on);
 void warningLedUpdate(void);
-void warningLedFlash(void);

--- a/src/main/mw.c
+++ b/src/main/mw.c
@@ -261,14 +261,7 @@ static void updateLEDs(void)
         }
 
         if (isCalibrating() || isSystemOverloaded()) {
-            warningLedFlash();
             DISABLE_ARMING_FLAG(OK_TO_ARM);
-        } else {
-            if (ARMING_FLAG(OK_TO_ARM)) {
-                warningLedDisable();
-            } else {
-                warningLedFlash();
-            }
         }
 
         warningLedUpdate();


### PR DESCRIPTION
 Use Warning LED flash count to inform arming prevention reason.

| Reason for disabled Arming               | LED Flashes |
|------------------------------------------|-------------|
| CLI is active in the configurator        | 2           |
| Failsafe mode is active                  | 3           |
| The aircraft has landed in failsafe mode | 3           |
| Maximum arming angle is exceeded         | 4           |
| Calibration is active                    | 5           |
| The system is overloaded                 | 6           |

See PR  #2182
Implements @ledvinap's travis fix.

Looking forward to read your comments.