### PR TITLE
Fix win32 unitests

### DIFF
--- a/src/main/common/utils.h
+++ b/src/main/common/utils.h
@@ -52,6 +52,12 @@ static inline int32_t cmp32(uint32_t a, uint32_t b) { return a-b; }
 
 // using memcpy_fn will force memcpy function call, instead of inlining it. In most cases function call takes fewer instructions
 //  than inlined version (inlining is cheaper for very small moves < 8 bytes / 2 store instructions)
+#ifdef UNIT_TEST
+// Call memcpy when building unittest - this is easier that asm symbol name mangling (symbols start with _underscore on win32)
+#include <string.h>
+static inline void  memcpy_fn ( void * destination, const void * source, size_t num ) { memcpy(destination, source, num); };
+#else
 void * memcpy_fn ( void * destination, const void * source, size_t num ) asm("memcpy");
+#endif
 
 #endif


### PR DESCRIPTION
memcpy was not mangled on win32 targets