### PR TITLE
 The 2nd memset() argument '1500' doesn't fit into an 'unsigned char'.

### DIFF
--- a/src/test/unit/rx_rx_unittest.cc
+++ b/src/test/unit/rx_rx_unittest.cc
@@ -19,6 +19,7 @@
 #include <stdbool.h>
 
 #include <limits.h>
+#include <algorithm>
 
 extern "C" {
     #include <platform.h>
@@ -109,7 +110,7 @@ TEST(RxTest, TestInvalidFlightChannels)
 
     // and
     uint16_t channelPulses[MAX_SUPPORTED_RC_CHANNEL_COUNT];
-    memset(&channelPulses, 1500, sizeof(channelPulses));
+    std::fill( channelPulses, channelPulses + sizeof(channelPulses), 1500 );
 
     // and
     rxInit(modeActivationConditions);


### PR DESCRIPTION
The 2nd parameter is passed as an 'int', but the function fills the block of memory using the 'unsigned char' conversion of this value.

"void* memset( void* dest, int ch, std::size_t count );
Converts the value ch to unsigned char and copies it into each of the first count characters of the object pointed to by dest."