### PR TITLE
The 2nd memset() argument '1500' doesn't fit into an 'unsigned char'.

### DIFF
--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -25,7 +25,6 @@
 #include "common/maths.h"
 
 #define M_LN2_FLOAT	0.69314718055994530942f
-#define M_PI_FLOAT	3.14159265358979323846f
 
 #define BIQUAD_BANDWIDTH 1.9f     /* bandwidth in octaves */
 
@@ -54,7 +53,7 @@ void BiQuadNewLpf(float filterCutFreq, biquad_t *newState, uint32_t refreshRate)
     float a0, a1, a2, b0, b1, b2;
 
     /* setup variables */
-    omega = 2 * M_PI_FLOAT * filterCutFreq / sampleRate;
+    omega = 2 * M_PIf * filterCutFreq / sampleRate;
     sn = sinf(omega);
     cs = cosf(omega);
     alpha = sn * sinf(M_LN2_FLOAT /2 * BIQUAD_BANDWIDTH * omega /sn);

--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -33,10 +33,10 @@
 float filterApplyPt1(float input, filterStatePt1_t *filter, uint8_t f_cut, float dT)
 {
 
-	// Pre calculate and store RC
-	if (!filter->RC) {
-		filter->RC = 1.0f / ( 2.0f * (float)M_PI * f_cut );
-	}
+    // Pre calculate and store RC
+    if (!filter->RC) {
+        filter->RC = 1.0f / ( 2.0f * (float)M_PI * f_cut );
+    }
 
     filter->state = filter->state + dT / (filter->RC + dT) * (input - filter->state);
 

--- a/src/test/unit/rx_rx_unittest.cc
+++ b/src/test/unit/rx_rx_unittest.cc
@@ -19,6 +19,7 @@
 #include <stdbool.h>
 
 #include <limits.h>
+#include <algorithm>
 
 extern "C" {
     #include <platform.h>
@@ -29,6 +30,7 @@ extern "C" {
     #include "rx/rx.h"
     #include "io/rc_controls.h"
     #include "common/maths.h"
+    #include "common/utils.h"
 
     uint32_t rcModeActivationMask;
 
@@ -109,7 +111,7 @@ TEST(RxTest, TestInvalidFlightChannels)
 
     // and
     uint16_t channelPulses[MAX_SUPPORTED_RC_CHANNEL_COUNT];
-    memset(&channelPulses, 1500, sizeof(channelPulses));
+    std::fill( channelPulses, ARRAYEND(channelPulses), 1500 );
 
     // and
     rxInit(modeActivationConditions);


### PR DESCRIPTION
The 2nd parameter is passed as an 'int', but the function fills the block
of memory using the 'unsigned char' conversion of this value.

"void* memset( void* dest, int ch, std::size_t count );
Converts the value ch to unsigned char and copies it into each of the first
count characters of the object pointed to by dest."