### PR TITLE
Merge PID filter changes from betaflight.

### DIFF
--- a/src/main/common/filter.h
+++ b/src/main/common/filter.h
@@ -15,11 +15,11 @@
  * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-typedef struct filterStatePt1_s {
-	float state;
-	float RC;
-	float constdT;
-} filterStatePt1_t;
+typedef struct pt1Filter_s {
+    float state;
+    float RC;
+    float dT;
+} pt1Filter_t;
 
 /* this holds the data required to update samples thru a filter */
 typedef struct biquad_s {
@@ -27,8 +27,12 @@ typedef struct biquad_s {
     float x1, x2, y1, y2;
 } biquad_t;
 
-float filterApplyPt1(float input, filterStatePt1_t *filter, uint8_t f_cut, float dt);
 float applyBiQuadFilter(float sample, biquad_t *state);
 void BiQuadNewLpf(float filterCutFreq, biquad_t *newState, uint32_t refreshRate);
+
+void pt1FilterInit(pt1Filter_t *filter, uint8_t f_cut, float dT);
+float pt1FilterApply(pt1Filter_t *filter, float input);
+float pt1FilterApply4(pt1Filter_t *filter, float input, uint8_t f_cut, float dT);
+
 int32_t filterApplyAverage(int32_t input, uint8_t count, int32_t averageState[]);
 float filterApplyAveragef(float input, uint8_t count, float averageState[]);

--- a/src/main/config/config_unittest.h
+++ b/src/main/config/config_unittest.h
@@ -47,7 +47,6 @@ bool unittest_outsideRealtimeGuardInterval;
 #ifdef UNIT_TEST
 
 float unittest_pidLuxFloatCore_lastRateForDelta[3];
-float unittest_pidLuxFloatCore_deltaState[3][DTERM_AVERAGE_COUNT];
 float unittest_pidLuxFloatCore_PTerm[3];
 float unittest_pidLuxFloatCore_ITerm[3];
 float unittest_pidLuxFloatCore_DTerm[3];
@@ -55,17 +54,11 @@ float unittest_pidLuxFloatCore_DTerm[3];
 #define SET_PID_LUX_FLOAT_CORE_LOCALS(axis) \
     { \
         lastRateForDelta[axis] = unittest_pidLuxFloatCore_lastRateForDelta[axis]; \
-        for (int ii = 0; ii < DTERM_AVERAGE_COUNT; ++ii) { \
-            deltaState[axis][ii] = unittest_pidLuxFloatCore_deltaState[axis][ii]; \
-        } \
     }
 
 #define GET_PID_LUX_FLOAT_CORE_LOCALS(axis) \
     { \
         unittest_pidLuxFloatCore_lastRateForDelta[axis] = lastRateForDelta[axis]; \
-        for (int ii = 0; ii < DTERM_AVERAGE_COUNT; ++ii) { \
-            unittest_pidLuxFloatCore_deltaState[axis][ii] = deltaState[axis][ii]; \
-        } \
         unittest_pidLuxFloatCore_PTerm[axis] = PTerm; \
         unittest_pidLuxFloatCore_ITerm[axis] = ITerm; \
         unittest_pidLuxFloatCore_DTerm[axis] = DTerm; \
@@ -84,7 +77,6 @@ float unittest_pidLuxFloatCore_DTerm[3];
 #ifdef UNIT_TEST
 
 int32_t unittest_pidMultiWiiRewriteCore_lastRateForDelta[3];
-int32_t unittest_pidMultiWiiRewriteCore_deltaState[3][DTERM_AVERAGE_COUNT];
 int32_t unittest_pidMultiWiiRewriteCore_PTerm[3];
 int32_t unittest_pidMultiWiiRewriteCore_ITerm[3];
 int32_t unittest_pidMultiWiiRewriteCore_DTerm[3];
@@ -92,17 +84,11 @@ int32_t unittest_pidMultiWiiRewriteCore_DTerm[3];
 #define SET_PID_MULTI_WII_REWRITE_CORE_LOCALS(axis) \
     { \
         lastRateForDelta[axis] = unittest_pidMultiWiiRewriteCore_lastRateForDelta[axis]; \
-        for (int ii = 0; ii < DTERM_AVERAGE_COUNT; ++ii) { \
-            deltaState[axis][ii] = unittest_pidMultiWiiRewriteCore_deltaState[axis][ii]; \
-        } \
     }
 
 #define GET_PID_MULTI_WII_REWRITE_CORE_LOCALS(axis) \
     { \
         unittest_pidMultiWiiRewriteCore_lastRateForDelta[axis] = lastRateForDelta[axis]; \
-        for (int ii = 0; ii < DTERM_AVERAGE_COUNT; ++ii) { \
-            unittest_pidMultiWiiRewriteCore_deltaState[axis][ii] = deltaState[axis][ii]; \
-        } \
         unittest_pidMultiWiiRewriteCore_PTerm[axis] = PTerm; \
         unittest_pidMultiWiiRewriteCore_ITerm[axis] = ITerm; \
         unittest_pidMultiWiiRewriteCore_DTerm[axis] = DTerm; \

--- a/src/main/fc/cleanflight_fc.c
+++ b/src/main/fc/cleanflight_fc.c
@@ -121,7 +121,7 @@ extern uint8_t PIDweight[3];
 extern uint8_t dynP8[3], dynI8[3], dynD8[3];
 
 static bool isRXDataNew;
-static filterStatePt1_t filteredCycleTimeState;
+static pt1Filter_t filteredCycleTimeState;
 uint16_t filteredCycleTime;
 
 extern pidControllerFuncPtr pid_controller;
@@ -662,7 +662,7 @@ void taskMainPidLoop(void)
     dT = (float)cycleTime * 0.000001f;
 
     // Calculate average cycle time and average jitter
-    filteredCycleTime = filterApplyPt1(cycleTime, &filteredCycleTimeState, 1, dT);
+    filteredCycleTime = pt1FilterApply4(&filteredCycleTimeState, cycleTime, 1, dT);
 
 #ifdef DEBUG_CYCLE_TIME
     debug[0] = cycleTime;

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -407,7 +407,7 @@ static bool isMagnetometerHealthy(void)
 
 static void imuCalculateEstimatedAttitude(void)
 {
-    static filterStatePt1_t accLPFState[3];
+    static pt1Filter_t accLPFState[3];
     static uint32_t previousIMUUpdateTime;
     float rawYawError = 0;
     int32_t axis;
@@ -422,7 +422,7 @@ static void imuCalculateEstimatedAttitude(void)
     // Smooth and use only valid accelerometer readings
     for (axis = 0; axis < 3; axis++) {
         if (imuRuntimeConfig->acc_cut_hz > 0) {
-            accSmooth[axis] = filterApplyPt1(accADC[axis], &accLPFState[axis], imuRuntimeConfig->acc_cut_hz, deltaT * 1e-6f);
+            accSmooth[axis] = pt1FilterApply4(&accLPFState[axis], accADC[axis], imuRuntimeConfig->acc_cut_hz, deltaT * 1e-6f);
         } else {
             accSmooth[axis] = accADC[axis];
         }

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -59,6 +59,10 @@ uint8_t PIDweight[3];
 int32_t lastITerm[3], ITermLimit[3];
 float lastITermf[3], ITermLimitf[3];
 
+pt1Filter_t deltaFilter[3];
+pt1Filter_t yawFilter;
+
+
 void pidLuxFloat(const pidProfile_t *pidProfile, const controlRateConfig_t *controlRateConfig,
         uint16_t max_angle_inclination, const rollAndPitchTrims_t *angleTrim, const rxConfig_t *rxConfig);
 void pidMultiWiiRewrite(const pidProfile_t *pidProfile, const controlRateConfig_t *controlRateConfig,
@@ -102,7 +106,8 @@ PG_RESET_TEMPLATE(pidProfile_t, pidProfile,
     .D8[PIDVEL] = 1,
 
     .yaw_p_limit = YAW_P_LIMIT_MAX,
-    .dterm_cut_hz = 0,
+    .dterm_lpf = 100,   // DTERM filtering ON by default
+    .yaw_lpf = 80,
 );
 
 void pidResetITerm(void)
@@ -110,19 +115,6 @@ void pidResetITerm(void)
     for (int axis = 0; axis < 3; axis++) {
         lastITerm[axis] = 0;
         lastITermf[axis] = 0.0f;
-    }
-}
-
-biquad_t deltaFilterState[3];
-
-void pidFilterIsSetCheck(const pidProfile_t *pidProfile)
-{
-    static bool deltaStateIsSet = false;
-    if (!deltaStateIsSet && pidProfile->dterm_cut_hz) {
-        for (int axis = 0; axis < 3; axis++) {
-            BiQuadNewLpf(pidProfile->dterm_cut_hz, &deltaFilterState[axis], targetLooptime);
-        }
-        deltaStateIsSet = true;
     }
 }
 

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -25,8 +25,6 @@
 #define YAW_P_LIMIT_MIN 100                 // Maximum value for yaw P limiter
 #define YAW_P_LIMIT_MAX 500                 // Maximum value for yaw P limiter
 
-#define DTERM_AVERAGE_COUNT 4
-
 typedef enum {
     PIDROLL,
     PIDPITCH,
@@ -56,7 +54,8 @@ typedef struct pidProfile_s {
     uint8_t D8[PID_ITEM_COUNT];
     uint8_t pidController;
     uint16_t yaw_p_limit;                   // set P term limit (fixed value was 300)
-    uint16_t dterm_cut_hz;                  // dterm filtering
+    uint16_t dterm_lpf;                     // dterm filtering
+    uint16_t yaw_lpf;                       // additional yaw filter when yaw axis too noisy
 } pidProfile_t;
 
 PG_DECLARE_PROFILE(pidProfile_t, pidProfile);

--- a/src/main/flight/pid_luxfloat.c
+++ b/src/main/flight/pid_luxfloat.c
@@ -59,7 +59,8 @@ extern float dT;
 extern uint8_t PIDweight[3];
 extern float lastITermf[3], ITermLimitf[3];
 
-extern biquad_t deltaFilterState[3];
+extern pt1Filter_t deltaFilter[3];
+extern pt1Filter_t yawFilter;
 
 extern uint8_t motorCount;
 
@@ -76,7 +77,6 @@ static const float luxGyroScale = 16.4f / 4; // the 16.4 is needed because mwrew
 STATIC_UNIT_TESTED int16_t pidLuxFloatCore(int axis, const pidProfile_t *pidProfile, float gyroRate, float angleRate)
 {
     static float lastRateForDelta[3];
-    static float deltaState[3][DTERM_AVERAGE_COUNT];
 
     SET_PID_LUX_FLOAT_CORE_LOCALS(axis);
 
@@ -85,8 +85,13 @@ STATIC_UNIT_TESTED int16_t pidLuxFloatCore(int axis, const pidProfile_t *pidProf
     // -----calculate P component
     float PTerm = luxPTermScale * rateError * pidProfile->P8[axis] * PIDweight[axis] / 100;
     // Constrain YAW by yaw_p_limit value if not servo driven, in that case servolimits apply
-    if (axis == YAW && pidProfile->yaw_p_limit && motorCount >= 4) {
-        PTerm = constrainf(PTerm, -pidProfile->yaw_p_limit, pidProfile->yaw_p_limit);
+    if (axis == YAW) {
+        if (pidProfile->yaw_lpf) {
+            PTerm = pt1FilterApply4(&yawFilter, PTerm, pidProfile->yaw_lpf, dT);
+        }
+        if (pidProfile->yaw_p_limit && motorCount >= 4) {
+            PTerm = constrainf(PTerm, -pidProfile->yaw_p_limit, pidProfile->yaw_p_limit);
+        }
     }
 
     // -----calculate I component
@@ -115,12 +120,9 @@ STATIC_UNIT_TESTED int16_t pidLuxFloatCore(int axis, const pidProfile_t *pidProf
         lastRateForDelta[axis] = gyroRate;
         // Divide delta by dT to get differential (ie dr/dt)
         delta *= (1.0f / dT);
-        if (pidProfile->dterm_cut_hz) {
+        if (pidProfile->dterm_lpf) {
             // DTerm delta low pass filter
-            delta = applyBiQuadFilter(delta, &deltaFilterState[axis]);
-        } else {
-            // When DTerm low pass filter disabled apply moving average to reduce noise
-            delta = filterApplyAveragef(delta, DTERM_AVERAGE_COUNT, deltaState[axis]);
+            delta = pt1FilterApply4(&deltaFilter[axis], delta, pidProfile->dterm_lpf, dT);
         }
         DTerm = luxDTermScale * delta * pidProfile->D8[axis] * PIDweight[axis] / 100;
         DTerm = constrainf(DTerm, -PID_MAX_D, PID_MAX_D);
@@ -139,9 +141,7 @@ STATIC_UNIT_TESTED int16_t pidLuxFloatCore(int axis, const pidProfile_t *pidProf
 void pidLuxFloat(const pidProfile_t *pidProfile, const controlRateConfig_t *controlRateConfig,
         uint16_t max_angle_inclination, const rollAndPitchTrims_t *angleTrim, const rxConfig_t *rxConfig)
 {
-    pidFilterIsSetCheck(pidProfile);
-
-    float horizonLevelStrength = 0;
+    float horizonLevelStrength = 0.0f;
     if (FLIGHT_MODE(HORIZON_MODE)) {
         // Figure out the most deflected stick position
         const int32_t stickPosAil = ABS(getRcStickDeflection(ROLL, rxConfig->midrc));

--- a/src/main/flight/pid_mw23.c
+++ b/src/main/flight/pid_mw23.c
@@ -57,6 +57,7 @@ static int32_t ITermAngle[2];
 
 uint8_t dynP8[3], dynI8[3], dynD8[3];
 
+extern float dT;
 extern uint8_t motorCount;
 
 #ifdef BLACKBOX
@@ -64,7 +65,7 @@ extern int32_t axisPID_P[3], axisPID_I[3], axisPID_D[3];
 #endif
 extern int32_t lastITerm[3], ITermLimit[3];
 
-extern biquad_t deltaFilterState[3];
+extern pt1Filter_t deltaFilter[3];
 
 
 void pidResetITermAngle(void)
@@ -83,8 +84,6 @@ void pidMultiWii23(const pidProfile_t *pidProfile, const controlRateConfig_t *co
     int32_t PTerm, ITerm, PTermACC, ITermACC, DTerm;
     static int16_t lastErrorForDelta[2];
     static int32_t delta1[2], delta2[2];
-
-    pidFilterIsSetCheck(pidProfile);
 
     if (FLIGHT_MODE(HORIZON_MODE)) {
         prop = MIN(MAX(ABS(rcCommand[PITCH]), ABS(rcCommand[ROLL])), 512);
@@ -146,10 +145,10 @@ void pidMultiWii23(const pidProfile_t *pidProfile, const controlRateConfig_t *co
         // Delta from measurement
         delta = -(gyroError - lastErrorForDelta[axis]);
         lastErrorForDelta[axis] = gyroError;
-        if (pidProfile->dterm_cut_hz) {
+        if (pidProfile->dterm_lpf) {
             // Dterm delta low pass
             DTerm = delta;
-            DTerm = lrintf(applyBiQuadFilter((float) DTerm, &deltaFilterState[axis])) * 3;  // Keep same scaling as unfiltered DTerm
+            DTerm = lrintf(pt1FilterApply4(&deltaFilter[axis], (float)DTerm, pidProfile->dterm_lpf, dT)) * 3;  // Keep same scaling as unfiltered DTerm
         } else {
             // When dterm filter disabled apply moving average to reduce noise
             DTerm  = delta1[axis] + delta2[axis] + delta;

--- a/src/main/flight/pid_mwrewrite.c
+++ b/src/main/flight/pid_mwrewrite.c
@@ -54,10 +54,12 @@
 #include "flight/mixer.h"
 
 
+extern float dT;
 extern uint8_t PIDweight[3];
 extern int32_t lastITerm[3], ITermLimit[3];
 
-extern biquad_t deltaFilterState[3];
+extern pt1Filter_t deltaFilter[3];
+extern pt1Filter_t yawFilter;
 
 extern uint8_t motorCount;
 
@@ -69,7 +71,6 @@ extern int32_t axisPID_P[3], axisPID_I[3], axisPID_D[3];
 STATIC_UNIT_TESTED int16_t pidMultiWiiRewriteCore(int axis, const pidProfile_t *pidProfile, int32_t gyroRate, int32_t angleRate)
 {
     static int32_t lastRateForDelta[3];
-    static int32_t deltaState[3][DTERM_AVERAGE_COUNT];
 
     SET_PID_MULTI_WII_REWRITE_CORE_LOCALS(axis);
 
@@ -78,8 +79,13 @@ STATIC_UNIT_TESTED int16_t pidMultiWiiRewriteCore(int axis, const pidProfile_t *
     // -----calculate P component
     int32_t PTerm = (rateError * pidProfile->P8[axis] * PIDweight[axis] / 100) >> 7;
     // Constrain YAW by yaw_p_limit value if not servo driven, in that case servolimits apply
-    if (axis == YAW && pidProfile->yaw_p_limit && motorCount >= 4) {
-        PTerm = constrain(PTerm, -pidProfile->yaw_p_limit, pidProfile->yaw_p_limit);
+    if (axis == YAW) {
+        if (pidProfile->yaw_lpf) {
+            PTerm = pt1FilterApply4(&yawFilter, PTerm, pidProfile->yaw_lpf, dT);
+        }
+        if (pidProfile->yaw_p_limit && motorCount >= 4) {
+            PTerm = constrain(PTerm, -pidProfile->yaw_p_limit, pidProfile->yaw_p_limit);
+        }
     }
 
     // -----calculate I component
@@ -113,12 +119,9 @@ STATIC_UNIT_TESTED int16_t pidMultiWiiRewriteCore(int axis, const pidProfile_t *
         lastRateForDelta[axis] = gyroRate;
         // Divide delta by targetLooptime to get differential (ie dr/dt)
         delta = (delta * ((uint16_t)0xFFFF / ((uint16_t)targetLooptime >> 4))) >> 5;
-        if (pidProfile->dterm_cut_hz) {
+        if (pidProfile->dterm_lpf) {
             // DTerm delta low pass filter
-            delta = lrintf(applyBiQuadFilter((float)delta, &deltaFilterState[axis]));
-        } else {
-            // When DTerm low pass filter disabled apply moving average to reduce noise
-            delta = filterApplyAverage(delta, DTERM_AVERAGE_COUNT, deltaState[axis]);
+            delta = lrintf(pt1FilterApply4(&deltaFilter[axis], (float)delta, pidProfile->dterm_lpf, dT));
         }
         DTerm = (delta * pidProfile->D8[axis] * PIDweight[axis] / 100) >> 8;
         DTerm = constrain(DTerm, -PID_MAX_D, PID_MAX_D);
@@ -137,8 +140,6 @@ STATIC_UNIT_TESTED int16_t pidMultiWiiRewriteCore(int axis, const pidProfile_t *
 void pidMultiWiiRewrite(const pidProfile_t *pidProfile, const controlRateConfig_t *controlRateConfig,
         uint16_t max_angle_inclination, const rollAndPitchTrims_t *angleTrim, const rxConfig_t *rxConfig)
 {
-    pidFilterIsSetCheck(pidProfile);
-
     int8_t horizonLevelStrength = 0;
     if (FLIGHT_MODE(HORIZON_MODE)) {
         // Figure out the most deflected stick position

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -696,7 +696,8 @@ const clivalue_t valueTable[] = {
     { "d_vel",                      VAR_UINT8  | PROFILE_VALUE, .config.minmax = { PID_MIN,  PID_MAX } , PG_PID_PROFILE, offsetof(pidProfile_t, D8[PIDVEL])},
 
     { "yaw_p_limit",                VAR_UINT16 | PROFILE_VALUE, .config.minmax = { YAW_P_LIMIT_MIN, YAW_P_LIMIT_MAX } , PG_PID_PROFILE, offsetof(pidProfile_t, yaw_p_limit)},
-    { "dterm_cut_hz",               VAR_UINT16 | PROFILE_VALUE, .config.minmax = {0, 500 } , PG_PID_PROFILE, offsetof(pidProfile_t, dterm_cut_hz)},
+    { "yaw_lpf",                    VAR_UINT16 | PROFILE_VALUE, .config.minmax = {0, 500 } , PG_PID_PROFILE, offsetof(pidProfile_t, yaw_lpf)},
+    { "dterm_cut_hz",               VAR_UINT16 | PROFILE_VALUE, .config.minmax = {0, 500 } , PG_PID_PROFILE, offsetof(pidProfile_t, dterm_lpf)},
 
 #ifdef GTUNE
     { "gtune_loP_rll",              VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 10,  200 } , PG_GTUNE_CONFIG, offsetof(gtuneConfig_t, gtune_lolimP[FD_ROLL])},

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -58,9 +58,14 @@ static bool gyroFilterStateIsSet;
 
 PG_REGISTER_WITH_RESET_TEMPLATE(gyroConfig_t, gyroConfig, PG_GYRO_CONFIG, 0);
 
+#define GYRO_LPF_256HZ 0
+#define GYRO_LPF_188HZ 1
+#define GYRO_LPF_98HZ  2
+#define GYRO_LPF_42HZ  3
+
 PG_RESET_TEMPLATE(gyroConfig_t, gyroConfig,
-    .gyro_lpf = 1,                 // supported by all gyro drivers now. In case of ST gyro, will default to 32Hz instead
-    .soft_gyro_lpf_hz = 60,        // Software based lpf filter for gyro
+    .gyro_lpf = GYRO_LPF_188HZ, // supported by all gyro drivers now. In case of ST gyro, will default to 32Hz instead
+    .soft_gyro_lpf_hz = 100,    // software based lpf filter for gyro
 
     .gyroMovementCalibrationThreshold = 32,
 );

--- a/src/test/unit/flight_pid_unittest.cc
+++ b/src/test/unit/flight_pid_unittest.cc
@@ -63,12 +63,10 @@ extern "C" {
     float dT; // dT for pidLuxFloat
     int32_t targetLooptime; // targetLooptime for pidMultiWiiRewrite
     float unittest_pidLuxFloatCore_lastRateForDelta[3];
-    int32_t unittest_pidLuxFloatCore_deltaState[3][DTERM_AVERAGE_COUNT];
     float unittest_pidLuxFloatCore_PTerm[3];
     float unittest_pidLuxFloatCore_ITerm[3];
     float unittest_pidLuxFloatCore_DTerm[3];
     int32_t unittest_pidMultiWiiRewriteCore_lastRateForDelta[3];
-    int32_t unittest_pidMultiWiiRewriteCore_deltaState[3][DTERM_AVERAGE_COUNT];
     int32_t unittest_pidMultiWiiRewriteCore_PTerm[3];
     int32_t unittest_pidMultiWiiRewriteCore_ITerm[3];
     int32_t unittest_pidMultiWiiRewriteCore_DTerm[3];
@@ -82,7 +80,7 @@ static const int mwrGyroScaleNum = 4;
 static const int mwrGyroScaleDenom = 1;
 #define TARGET_LOOPTIME 2048
 
-static const int DTermAverageCount = 4;
+static const int DTermAverageCount = 1;
 
 void resetPidProfile(pidProfile_t *pidProfile)
 {
@@ -118,7 +116,8 @@ void resetPidProfile(pidProfile_t *pidProfile)
     pidProfile->D8[PIDVEL] = 1;
 
     pidProfile->yaw_p_limit = YAW_P_LIMIT_MAX;
-    pidProfile->dterm_cut_hz = 0;
+    pidProfile->dterm_lpf = 0;
+    pidProfile->yaw_lpf = 0;
 }
 
 void resetRcCommands(void)
@@ -154,9 +153,6 @@ void pidControllerInitLuxFloatCore(void)
     // reset the pidLuxFloat static values
     for (int axis = FD_ROLL; axis <= FD_YAW; ++axis) {
         unittest_pidLuxFloatCore_lastRateForDelta[axis] = 0.0f;
-        for (int ii = 0; ii < DTERM_AVERAGE_COUNT; ++ii) { \
-            unittest_pidLuxFloatCore_deltaState[axis][ii] = 0.0f; \
-        } \
     }
 }
 
@@ -544,9 +540,6 @@ void pidControllerInitMultiWiiRewriteCore(void)
     // reset the pidMultiWiiRewrite static values
     for (int axis = FD_ROLL; axis <= FD_YAW; ++axis) {
         unittest_pidMultiWiiRewriteCore_lastRateForDelta[axis] = 0;
-        for (int ii = 0; ii < DTERM_AVERAGE_COUNT; ++ii) { \
-            unittest_pidMultiWiiRewriteCore_deltaState[axis][ii] = 0; \
-        } \
     }
 }
 


### PR DESCRIPTION
This addresses issue  "Use PT1 filters rather than biQuad filters for PIDs. Improve filter defaults" from issue https://github.com/cleanflight/cleanflight/issues/2213.