### PR TITLE
Added support for older (and newer) versions of JR XBus DMSS sats

### DIFF
--- a/src/main/rx/xbus.c
+++ b/src/main/rx/xbus.c
@@ -202,7 +202,6 @@ static void xBusUnpackModeBFrame(uint8_t offsetBytes)
             xBusChannelData[i] = XBUS_CONVERT_TO_USEC(value);
         }
 
-        xBusFrameReceived = true;
     }
 
 }
@@ -291,16 +290,7 @@ static void xBusDataReceive(uint16_t c)
 
     // Done?
     if (xBusFramePosition == xBusFrameLength) {
-        switch (xBusProvider) {
-            case SERIALRX_XBUS_MODE_B:
-                xBusUnpackModeBFrame(0);
-                break;
-            case SERIALRX_XBUS_MODE_B_RJ01:
-                xBusUnpackRJ01Frame();
-                break;
-        }
-        xBusDataIncoming = false;
-        xBusFramePosition = 0;
+        xBusFrameReceived = true;
     }
 }
 
@@ -310,6 +300,17 @@ uint8_t xBusFrameStatus(void)
     if (!xBusFrameReceived) {
         return SERIAL_RX_FRAME_PENDING;
     }
+
+    switch (xBusProvider) {
+        case SERIALRX_XBUS_MODE_B:
+            xBusUnpackModeBFrame(0);
+            break;
+        case SERIALRX_XBUS_MODE_B_RJ01:
+            xBusUnpackRJ01Frame();
+            break;
+    }
+    xBusDataIncoming = false;
+    xBusFramePosition = 0;
 
     xBusFrameReceived = false;
 


### PR DESCRIPTION
Some of the different sats for JR XBus with old firmware were not working. This pull request has re-worked the code for the XBus protocol to support all these sats. The code has been tested by various people including JR. Hopefully this can be accepted and added to the main code.

Edit: This update actually enables all DMSS sats from JR. It even supports the new range of diversity sats.