### PR TITLE
Add horizon_incl_fact parameter

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -47,6 +47,7 @@
 #include "io/rate_profile.h"
 
 #include "flight/pid.h"
+#include "flight/imu.h"
 
 int16_t axisPID[3];
 
@@ -96,7 +97,7 @@ PG_RESET_TEMPLATE(pidProfile_t, pidProfile,
     .D8[PIDNAVR] = 83,  // NAV_D * 1000
     .P8[PIDLEVEL] = 20,
     .I8[PIDLEVEL] = 10,
-    .D8[PIDLEVEL] = 100,
+    .D8[PIDLEVEL] = 75,
     .P8[PIDMAG] = 40,
     .P8[PIDVEL] = 120,
     .I8[PIDVEL] = 45,
@@ -104,6 +105,7 @@ PG_RESET_TEMPLATE(pidProfile_t, pidProfile,
 
     .yaw_p_limit = YAW_P_LIMIT_MAX,
     .dterm_cut_hz = 0,
+    .horizon_incl_fact = 75,
 );
 
 void pidResetITerm(void)
@@ -145,4 +147,89 @@ void pidSetController(pidControllerType_e type)
             break;
 #endif
     }
+}
+
+// calculates strength of horizon leveling; 0 = none, 100 = most leveling
+int calcHorizonLevelStrength(uint16_t rxConfigMidrc, int horizonInclFact,
+                                                          int horizonSensit)
+{
+    int horizonLevelStrength, inclinationLevelRatio, factorRatio;
+    int currentInclination, cutoffDeciDegrees, sensitFact;
+
+    // get raw stick positions (-500 to 500):
+    const int32_t stickPosAil = getRcStickDeflection(FD_ROLL, rxConfigMidrc);
+    const int32_t stickPosEle = getRcStickDeflection(FD_PITCH, rxConfigMidrc);
+
+    // 0 at center stick, 500 at max stick deflection:
+    const int32_t mostDeflectedPos = MAX(ABS(stickPosAil), ABS(stickPosEle));
+
+    // start with 100 at center stick, 0 at max stick deflection:
+    horizonLevelStrength = (500 - mostDeflectedPos) / 5;
+
+    // 0 at level, 900 at vertical, 1800 at inverted (degrees * 10)
+    currentInclination = MAX(ABS(attitude.values.roll),
+                                                ABS(attitude.values.pitch));
+
+    // 'horizon_incl_fact' configuration setting:
+    // 0-99 = range 1 (leveling always active when sticks centered)
+    // 100-250 = range 2 (leveling can be totally off when inverted)
+    if (horizonInclFact >= 100) {
+        // range 2 (leveling can be totally off when inverted)
+        if (horizonInclFact < 250) {
+            // horizon_incl_fact 100 to 200 => 2700 to 900
+            //  (represents where leveling goes to zero):
+            cutoffDeciDegrees = (250-horizonInclFact) * 18;
+            // inclinationLevelRatio (0 to 100) is smaller (less leveling)
+            //  for larger inclinations; 0 at cutoffDeciDegrees value:
+            inclinationLevelRatio = constrain(
+                              (((cutoffDeciDegrees-currentInclination)*10) /
+                                           (cutoffDeciDegrees/10)), 0, 100);
+            // apply configured horizon sensitivity:
+            if (horizonSensit <= 0) {       // zero means no leveling
+                horizonLevelStrength = 0;
+            } else {
+                // when stick is near center (horizonLevelStrength ~= 100)
+                //  H_sensitivity value has little effect,
+                // when stick is deflected (horizonLevelStrength near 0)
+                //  H_sensitivity value has more effect:
+                horizonLevelStrength = constrain(
+                                        (((horizonLevelStrength-100) * 100 /
+                                             horizonSensit) + 100), 0, 100);
+            }
+            // apply inclination ratio, which may lower leveling
+            //  to zero regardless of stick position:
+            horizonLevelStrength =
+                         horizonLevelStrength * inclinationLevelRatio / 100;
+        }
+        else
+          horizonLevelStrength = 0;
+    } else {       // horizon_incl_fact < 100
+        // range 1 (leveling always active when sticks centered)
+        if (horizonInclFact > 0) {
+            // ratio of 100 to 0 (larger means more leveling):
+            factorRatio = 100 - horizonInclFact;
+            // inclinationLevelRatio (0 to 100) is smaller (less leveling)
+            //  for larger inclinations, goes to 100 at inclination level:
+            inclinationLevelRatio =
+                  ((1800-currentInclination)/18 * (100-factorRatio)) / 100 +
+                                                                factorRatio;
+            // apply ratio to configured horizon sensitivity:
+            sensitFact = horizonSensit * inclinationLevelRatio / 100;
+        }
+        else   // horizon_incl_fact=0 for "old" functionality
+            sensitFact = horizonSensit;
+
+        if (sensitFact <= 0) {           // zero means no leveling
+            horizonLevelStrength = 0;
+        } else {
+            // when stick is near center (horizonLevelStrength ~= 100)
+            //  sensitFact value has little effect,
+            // when stick is deflected (horizonLevelStrength near 0)
+            //  sensitFact value has more effect:
+            horizonLevelStrength = constrain(
+                    ((horizonLevelStrength - 100) * 100 / sensitFact + 100),
+                                                                    0, 100);
+        }
+    }
+    return horizonLevelStrength;
 }

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -57,6 +57,7 @@ typedef struct pidProfile_s {
     uint8_t pidController;
     uint16_t yaw_p_limit;                   // set P term limit (fixed value was 300)
     uint16_t dterm_cut_hz;                  // dterm filtering
+    uint8_t horizon_incl_fact;              // inclination factor for Horizon mode
 } pidProfile_t;
 
 PG_DECLARE_PROFILE(pidProfile_t, pidProfile);
@@ -77,3 +78,5 @@ void pidSetController(pidControllerType_e type);
 void pidResetITermAngle(void);
 void pidResetITerm(void);
 
+int calcHorizonLevelStrength(uint16_t rxConfigMidrc, int horizonInclFact,
+                                                         int horizonSensit);

--- a/src/main/flight/pid_luxfloat.c
+++ b/src/main/flight/pid_luxfloat.c
@@ -143,18 +143,9 @@ void pidLuxFloat(const pidProfile_t *pidProfile, const controlRateConfig_t *cont
 
     float horizonLevelStrength = 0;
     if (FLIGHT_MODE(HORIZON_MODE)) {
-        // Figure out the most deflected stick position
-        const int32_t stickPosAil = ABS(getRcStickDeflection(ROLL, rxConfig->midrc));
-        const int32_t stickPosEle = ABS(getRcStickDeflection(PITCH, rxConfig->midrc));
-        const int32_t mostDeflectedPos =  MAX(stickPosAil, stickPosEle);
-
-        // Progressively turn off the horizon self level strength as the stick is banged over
-        horizonLevelStrength = (float)(500 - mostDeflectedPos) / 500;  // 1 at centre stick, 0 = max stick deflection
-        if(pidProfile->D8[PIDLEVEL] == 0){
-            horizonLevelStrength = 0;
-        } else {
-            horizonLevelStrength = constrainf(((horizonLevelStrength - 1) * (100 / pidProfile->D8[PIDLEVEL])) + 1, 0, 1);
-        }
+        // (convert 0-100 range to 0.0-1.0 range)
+        horizonLevelStrength = (float)calcHorizonLevelStrength(rxConfig->midrc,
+            pidProfile->horizon_incl_fact, pidProfile->D8[PIDLEVEL]) / 100.0f;
     }
 
     // ----------PID controller----------

--- a/src/main/flight/pid_mwrewrite.c
+++ b/src/main/flight/pid_mwrewrite.c
@@ -139,20 +139,13 @@ void pidMultiWiiRewrite(const pidProfile_t *pidProfile, const controlRateConfig_
 {
     pidFilterIsSetCheck(pidProfile);
 
-    int8_t horizonLevelStrength = 0;
+    int horizonLevelStrength = 0;
     if (FLIGHT_MODE(HORIZON_MODE)) {
-        // Figure out the most deflected stick position
-        const int32_t stickPosAil = ABS(getRcStickDeflection(ROLL, rxConfig->midrc));
-        const int32_t stickPosEle = ABS(getRcStickDeflection(PITCH, rxConfig->midrc));
-        const int32_t mostDeflectedPos =  MAX(stickPosAil, stickPosEle);
-
-        // Progressively turn off the horizon self level strength as the stick is banged over
-        horizonLevelStrength = (500 - mostDeflectedPos) / 5;  // 100 at centre stick, 0 = max stick deflection
-
-        // Using D8[PIDLEVEL] as a Sensitivity for Horizon.
-        // 0 more level to 255 more rate. Default value of 100 seems to work fine.
-        // For more rate mode increase D and slower flips and rolls will be possible
-        horizonLevelStrength = constrain((10 * (horizonLevelStrength - 100) * (10 * pidProfile->D8[PIDLEVEL] / 80) / 100) + 100, 0, 100);
+        // Using Level D as a Sensitivity for Horizon. 0 more rate to 255 more level.
+        // For more rate mode decrease D and slower flips and rolls will be possible
+        horizonLevelStrength = calcHorizonLevelStrength(
+                             rxConfig->midrc, pidProfile->horizon_incl_fact,
+                                                  pidProfile->D8[PIDLEVEL]);
     }
 
     // ----------PID controller----------

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -693,6 +693,7 @@ const clivalue_t valueTable[] = {
 
     { "yaw_p_limit",                VAR_UINT16 | PROFILE_VALUE, .config.minmax = { YAW_P_LIMIT_MIN, YAW_P_LIMIT_MAX } , PG_PID_PROFILE, offsetof(pidProfile_t, yaw_p_limit)},
     { "dterm_cut_hz",               VAR_UINT16 | PROFILE_VALUE, .config.minmax = {0, 500 } , PG_PID_PROFILE, offsetof(pidProfile_t, dterm_cut_hz)},
+    { "horizon_incl_fact",          VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 0, 250 } , PG_PID_PROFILE, offsetof(pidProfile_t, horizon_incl_fact)},
 
 #ifdef GTUNE
     { "gtune_loP_rll",              VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 10,  200 } , PG_GTUNE_CONFIG, offsetof(gtuneConfig_t, gtune_lolimP[FD_ROLL])},


### PR DESCRIPTION
Note:  This PR has been superseded by #2364

This modification adds a new CLI parameter, 'horizon_incl_fact' ("inclination factor"), which controls the effect the current inclination has on self-leveling in the Horizon flight mode.  With the existing horizon mode, the strength of the self-leveling is solely dependent on the stick position.  This is problematic when trying to do maneuvers like large loops and fast-forward flight.  Adding a factor that takes into account the current inclination of the craft provides a big improvement for these maneuvers and improves the "feel" of horizon mode.  (The current inclination is the number of degrees of pitch or roll that the vehicle is away from level, whichever is greater).

The 'horizon_incl_fact' parameter affects Horizon mode for the LUX and REWRITE controllers.  The math is all integer based, so no (slower) floating-point operations are involved when using the REWRITE controller.

This mod also addresses an issue with the "Transition (Horizon)" ('d_level') parameter -- as of Cleanflight v1.13.0 the 'sensitivity_horizon' (LUX) and 'd_level' (REWRITE) CLI parameters were merged so that both use the 'd_level' parameter.  The problem is that the ranges behave differently -- in LUX, increasing the value results in more self leveling and zero results in no self leveling; in REWRITE, increasing the value results in less self leveling.  With this mod, increasing the value results in more self leveling and zero results in no self leveling.  The default has been changed to 75, which should give relatively unchanged default behavior for this parameter on both PID controllers.

The original idea for this mod came from ctzsnooze (see CleanFlight [issue #695](http://github.com/cleanflight/cleanflight/issues/695)); I've expanded on it and turned it into a configurable option.  One characteristic of horizon mode I made a point of retaining is that, when the vehicle is flat and the sticks are near center, the self-leveling effect is not diminished by larger 'horizon_incl_fact' settings.  Like in the existing horizon mode, the strength of the self-leveling can be effectively managed using the "Strength (Horizon)" ('i_level') parameter.  Also, the "Transition (Horizon)" ('d_level') parameter operates the same as before.

Setting 'horizon_incl_fact' to 0 will run the current horizon-mode behavior.  For other values, there are two ranges for the 'horizon_incl_fact' parameter:

1 to 99 => Range 1 - leveling always active when sticks centered:
This is the "safer" range because the self-leveling is always active when the sticks are centered.  So, when the vehicle is upside down (180 degrees) and the sticks are then centered, the vehicle will immediately be self-leveled to upright and flat.  This is similar to the current horizon-mode behavior.  (Note that after this kind of very-fast 180-degree self-leveling, the heading of the vehicle can be unpredictable.)  Larger values result in less self-leveling in response to large inclinations.  The 'horizon_incl_fact' value is combined with the 'level_horizon' parameter to control the self-leveling effect.  The default value of 75 should provide significant improvements in horizon-mode flight characteristics.

100 to 250 => Range 2 - leveling can be totally off when inverted:
In this range, the inclination of the vehicle can fully "override" the self-leveling.  When the parameter set to around 150, and the vehicle is upside down (180 degrees) and the sticks are then centered, the vehicle is not self-leveled.  This can be desirable for performing more-acrobatic maneuvers and potentially for 3D-mode flying.

The 'horizon_incl_fact' parameter value is separate for each profile, and is implemented for both the LUX and REWRITE PID controllers.

I've posted a version of this modification applied to the v1.13.0 (release) version of Cleanflight, [here](http://www.etheli.com/CF/addHorizonInclFactCmd).  My test flights with this version were successful.  (A PR of this mod for Betaflight is [here](https://github.com/borisbstyle/betaflight/pull/382)).

I've been flying this mod in my [MiniFTC](http://www.etheli.com/MiniFTC) and other copters for quite a while now; I think it makes Horizon mode much better.

--ET