### PR TITLE
Make I2C STOPF detection work (F3)

### DIFF
--- a/src/main/drivers/bus_i2c_stm32f30x.c
+++ b/src/main/drivers/bus_i2c_stm32f30x.c
@@ -242,6 +242,9 @@ bool i2cWrite(uint8_t addr_, uint8_t reg, uint8_t data)
         }
     }
 
+    /* Pre-clear STOPF flag */
+    I2C_ClearFlag(I2Cx, I2C_ICR_STOPCF);
+
     /* Configure slave address, nbytes, reload, end mode and start or stop generation */
     I2C_TransferHandling(I2Cx, addr_, 1, I2C_AutoEnd_Mode, I2C_No_StartStop);
 
@@ -303,6 +306,9 @@ bool i2cRead(uint8_t addr_, uint8_t reg, uint8_t len, uint8_t* buf)
             return i2cTimeoutUserCallback(I2Cx);
         }
     }
+
+    /* Pre-clear STOPF flag */
+    I2C_ClearFlag(I2Cx, I2C_ICR_STOPCF);
 
     /* Configure slave address, nbytes, reload, end mode and start or stop generation */
     I2C_TransferHandling(I2Cx, addr_, len, I2C_AutoEnd_Mode, I2C_Generate_Start_Read);


### PR DESCRIPTION
`i2cWrite()` and `i2cRead()` returns prematurely without waiting for a stop condition if `STOPF` is already set before a transaction for some reason.

There are slave devices that can not handle back-to-back transactions, in which case some delay must explicitly be programmed. Returning prematurely from previous transaction makes it extremely difficult to determine the correct amount of delay, often ending up with large delay count that works for all cases.

This PR will pre-clear the `STOPF` prior to a transaction so the STOPF detection at the end of function correctly detect the stop condition for the transaction.