### PR TITLE
cleanup led_config declaration.

### DIFF
--- a/src/main/drivers/light_led.h
+++ b/src/main/drivers/light_led.h
@@ -17,10 +17,12 @@
 
 #pragma once
 
-struct {
+struct led_config_t{
     GPIO_TypeDef *gpio;
     uint16_t pin;
-} led_config[3];
+};
+
+extern struct led_config_t led_config[3];
 
 // Helpful macros
 #ifdef LED0

--- a/src/main/drivers/light_led.h
+++ b/src/main/drivers/light_led.h
@@ -17,12 +17,12 @@
 
 #pragma once
 
-struct led_config_t{
+typedef struct led_config_s {
     GPIO_TypeDef *gpio;
     uint16_t pin;
-};
+} led_config_t;
 
-extern struct led_config_t led_config[3];
+extern led_config_t led_config[3];
 
 // Helpful macros
 #ifdef LED0

--- a/src/main/drivers/light_led_stm32f10x.c
+++ b/src/main/drivers/light_led_stm32f10x.c
@@ -28,6 +28,8 @@
 
 #include "light_led.h"
 
+led_config_t led_config[3];
+
 void ledInit(bool alternative_led)
 {
     UNUSED(alternative_led);

--- a/src/main/drivers/light_led_stm32f10x.c
+++ b/src/main/drivers/light_led_stm32f10x.c
@@ -28,7 +28,7 @@
 
 #include "light_led.h"
 
-led_config_t led_config[3];
+struct led_config_t led_config[3];
 
 void ledInit(bool alternative_led)
 {

--- a/src/main/drivers/light_led_stm32f10x.c
+++ b/src/main/drivers/light_led_stm32f10x.c
@@ -28,7 +28,7 @@
 
 #include "light_led.h"
 
-struct led_config_t led_config[3];
+led_config_t led_config[3];
 
 void ledInit(bool alternative_led)
 {

--- a/src/main/drivers/light_led_stm32f30x.c
+++ b/src/main/drivers/light_led_stm32f30x.c
@@ -27,6 +27,8 @@
 
 #include "light_led.h"
 
+led_config_t led_config[3];
+
 void ledInit(bool alternative_led)
 {
 #if defined(LED0) || defined(LED1) || defined(LED2)

--- a/src/main/drivers/light_led_stm32f30x.c
+++ b/src/main/drivers/light_led_stm32f30x.c
@@ -27,7 +27,7 @@
 
 #include "light_led.h"
 
-led_config_t led_config[3];
+struct led_config_t led_config[3];
 
 void ledInit(bool alternative_led)
 {

--- a/src/main/drivers/light_led_stm32f30x.c
+++ b/src/main/drivers/light_led_stm32f30x.c
@@ -27,7 +27,7 @@
 
 #include "light_led.h"
 
-struct led_config_t led_config[3];
+led_config_t led_config[3];
 
 void ledInit(bool alternative_led)
 {


### PR DESCRIPTION
Is this unintentional mistype or there is some logic behind it?

I think it's more appropriate to declare it as "extern" in header.