### PR TITLE
Fixed ambiguous mode bit masking.

### DIFF
--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -400,10 +400,10 @@ void handleSmartPortTelemetry(void)
                     tmpi += 10;
                 if (FLIGHT_MODE(HORIZON_MODE))
                     tmpi += 20;
-                if (FLIGHT_MODE(UNUSED_MODE))
-                    tmpi += 40;
                 if (FLIGHT_MODE(PASSTHRU_MODE))
                     tmpi += 40;
+                if (FLIGHT_MODE(UNUSED_MODE))
+                    tmpi += 80;
 
                 if (FLIGHT_MODE(MAG_MODE))
                     tmpi += 100;


### PR DESCRIPTION
Even if the UNUSED_MODE is not used it is still in the code. A future implementation might integrate the old bug that AUTOTUNE_MODE or however you will call it in the future (at the moment UNUSED_MODE) gets the same bit as PASSTHRU_MODE (40).

Since the PASSTHRU_MODE is used and currently at bitmask 40 I moved the Unused mode to 80. Otherwise the resulting mask is broken when adding 40 twice. Is that correct? If not, please tell me why! :)