### PR TITLE
I2C: Allow 0xFF as sub-address

### DIFF
--- a/src/main/drivers/bus_i2c.h
+++ b/src/main/drivers/bus_i2c.h
@@ -28,8 +28,8 @@ typedef enum I2CDevice {
 } I2CDevice;
 
 void i2cInit(I2CDevice index);
-bool i2cWriteBuffer(uint8_t addr_, uint8_t reg_, uint8_t len_, uint8_t *data);
-bool i2cWrite(uint8_t addr_, uint8_t reg, uint8_t data);
-bool i2cRead(uint8_t addr_, uint8_t reg, uint8_t len, uint8_t* buf);
+bool i2cWriteBuffer(uint8_t addr_, int reg_, uint8_t len_, uint8_t *data);
+bool i2cWrite(uint8_t addr_, int reg, uint8_t data);
+bool i2cRead(uint8_t addr_, int reg, uint8_t len, uint8_t* buf);
 uint16_t i2cGetErrorCounter(void);
 void i2cSetOverclock(uint8_t OverClock);

--- a/src/main/drivers/bus_i2c_stm32f10x.c
+++ b/src/main/drivers/bus_i2c_stm32f10x.c
@@ -94,7 +94,7 @@ static volatile bool error = false;
 static volatile bool busy;
 
 static volatile uint8_t addr;
-static volatile uint8_t reg;
+static volatile int reg;
 static volatile uint8_t bytes;
 static volatile uint8_t writing;
 static volatile uint8_t reading;
@@ -109,7 +109,7 @@ static bool i2cHandleHardwareFailure(void)
     return false;
 }
 
-bool i2cWriteBuffer(uint8_t addr_, uint8_t reg_, uint8_t len_, uint8_t *data)
+bool i2cWriteBuffer(uint8_t addr_, int reg_, uint8_t len_, uint8_t *data)
 {
     uint32_t timeout = I2C_DEFAULT_TIMEOUT;
 
@@ -146,12 +146,12 @@ bool i2cWriteBuffer(uint8_t addr_, uint8_t reg_, uint8_t len_, uint8_t *data)
     return !error;
 }
 
-bool i2cWrite(uint8_t addr_, uint8_t reg_, uint8_t data)
+bool i2cWrite(uint8_t addr_, int reg_, uint8_t data)
 {
     return i2cWriteBuffer(addr_, reg_, 1, &data);
 }
 
-bool i2cRead(uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t* buf)
+bool i2cRead(uint8_t addr_, int reg_, uint8_t len, uint8_t* buf)
 {
     uint32_t timeout = I2C_DEFAULT_TIMEOUT;
 
@@ -226,14 +226,14 @@ void i2c_ev_handler(void)
         I2Cx->CR1 &= ~0x0800;                                           // reset the POS bit so ACK/NACK applied to the current byte
         I2C_AcknowledgeConfig(I2Cx, ENABLE);                            // make sure ACK is on
         index = 0;                                                      // reset the index
-        if (reading && (subaddress_sent || 0xFF == reg)) {              // we have sent the subaddr
+        if (reading && (subaddress_sent || -1 == reg)) {                // we have sent the subaddr
             subaddress_sent = 1;                                        // make sure this is set in case of no subaddress, so following code runs correctly
             if (bytes == 2)
                 I2Cx->CR1 |= 0x0800;                                    // set the POS bit so NACK applied to the final byte in the two byte read
             I2C_Send7bitAddress(I2Cx, addr, I2C_Direction_Receiver);    // send the address and set hardware mode
         } else {                                                        // direction is Tx, or we havent sent the sub and rep start
             I2C_Send7bitAddress(I2Cx, addr, I2C_Direction_Transmitter); // send the address and set hardware mode
-            if (reg != 0xFF)                                            // 0xFF as subaddress means it will be ignored, in Tx or Rx mode
+            if (reg != -1)                                              // -1 as subaddress means it will be ignored, in Tx or Rx mode
                 index = -1;                                             // send a subaddress
         }
     } else if (SReg_1 & 0x0002) {                                       // we just sent the address - EV6 in ref manual

--- a/src/main/drivers/bus_i2c_stm32f10x.c
+++ b/src/main/drivers/bus_i2c_stm32f10x.c
@@ -226,7 +226,7 @@ void i2c_ev_handler(void)
         I2Cx->CR1 &= ~0x0800;                                           // reset the POS bit so ACK/NACK applied to the current byte
         I2C_AcknowledgeConfig(I2Cx, ENABLE);                            // make sure ACK is on
         index = 0;                                                      // reset the index
-        if (reading && (subaddress_sent || -1 == reg)) {                // we have sent the subaddr
+        if (reading && (subaddress_sent || reg == -1)) {                // we have sent the subaddr
             subaddress_sent = 1;                                        // make sure this is set in case of no subaddress, so following code runs correctly
             if (bytes == 2)
                 I2Cx->CR1 |= 0x0800;                                    // set the POS bit so NACK applied to the final byte in the two byte read

--- a/src/main/drivers/bus_i2c_stm32f30x.c
+++ b/src/main/drivers/bus_i2c_stm32f30x.c
@@ -208,7 +208,7 @@ uint16_t i2cGetErrorCounter(void)
 
 }
 
-bool i2cWrite(uint8_t addr_, uint8_t reg, uint8_t data)
+bool i2cWrite(uint8_t addr_, int reg, uint8_t data)
 {
     addr_ <<= 1;
 
@@ -231,15 +231,17 @@ bool i2cWrite(uint8_t addr_, uint8_t reg, uint8_t data)
         }
     }
 
-    /* Send Register address */
-    I2C_SendData(I2Cx, (uint8_t) reg);
+    if (reg != -1) {
+        /* Send Register address */
+        I2C_SendData(I2Cx, (uint8_t) reg);
 
-    /* Wait until TCR flag is set */
-    i2cTimeout = I2C_DEFAULT_TIMEOUT;
-    while (I2C_GetFlagStatus(I2Cx, I2C_ISR_TCR) == RESET)
-    {
-        if ((i2cTimeout--) == 0) {
-            return i2cTimeoutUserCallback(I2Cx);
+        /* Wait until TCR flag is set */
+        i2cTimeout = I2C_DEFAULT_TIMEOUT;
+        while (I2C_GetFlagStatus(I2Cx, I2C_ISR_TCR) == RESET)
+        {
+            if ((i2cTimeout--) == 0) {
+                return i2cTimeoutUserCallback(I2Cx);
+            }
         }
     }
 
@@ -271,7 +273,7 @@ bool i2cWrite(uint8_t addr_, uint8_t reg, uint8_t data)
     return true;
 }
 
-bool i2cRead(uint8_t addr_, uint8_t reg, uint8_t len, uint8_t* buf)
+bool i2cRead(uint8_t addr_, int reg, uint8_t len, uint8_t* buf)
 {
     addr_ <<= 1;
 
@@ -283,25 +285,27 @@ bool i2cRead(uint8_t addr_, uint8_t reg, uint8_t len, uint8_t* buf)
         }
     }
 
-    /* Configure slave address, nbytes, reload, end mode and start or stop generation */
-    I2C_TransferHandling(I2Cx, addr_, 1, I2C_SoftEnd_Mode, I2C_Generate_Start_Write);
+    if (reg != -1) {
+        /* Configure slave address, nbytes, reload, end mode and start or stop generation */
+        I2C_TransferHandling(I2Cx, addr_, 1, I2C_SoftEnd_Mode, I2C_Generate_Start_Write);
 
-    /* Wait until TXIS flag is set */
-    i2cTimeout = I2C_DEFAULT_TIMEOUT;
-    while (I2C_GetFlagStatus(I2Cx, I2C_ISR_TXIS) == RESET) {
-        if ((i2cTimeout--) == 0) {
-            return i2cTimeoutUserCallback(I2Cx);
+        /* Wait until TXIS flag is set */
+        i2cTimeout = I2C_DEFAULT_TIMEOUT;
+        while (I2C_GetFlagStatus(I2Cx, I2C_ISR_TXIS) == RESET) {
+            if ((i2cTimeout--) == 0) {
+                return i2cTimeoutUserCallback(I2Cx);
+            }
         }
-    }
 
-    /* Send Register address */
-    I2C_SendData(I2Cx, (uint8_t) reg);
+        /* Send Register address */
+        I2C_SendData(I2Cx, (uint8_t) reg);
 
-    /* Wait until TC flag is set */
-    i2cTimeout = I2C_DEFAULT_TIMEOUT;
-    while (I2C_GetFlagStatus(I2Cx, I2C_ISR_TC) == RESET) {
-        if ((i2cTimeout--) == 0) {
-            return i2cTimeoutUserCallback(I2Cx);
+        /* Wait until TC flag is set */
+        i2cTimeout = I2C_DEFAULT_TIMEOUT;
+        while (I2C_GetFlagStatus(I2Cx, I2C_ISR_TC) == RESET) {
+            if ((i2cTimeout--) == 0) {
+                return i2cTimeoutUserCallback(I2Cx);
+            }
         }
     }
 


### PR DESCRIPTION
`i2cRead()`, `i2cWrite()` and `i2cWriteBuffer()`(F1 only) uses `0xFF` in `reg` to signal the non-subaddressed access. It doesn’t work for the case in which we have actually have to access a register at `0xFF`. u-blox DDC (I2C) is an example of the device with register at `0xFF`.

Fix this by `reg` argument to `i2cRead()`, `i2cWrite()` and `i2cWriteBuffer()` be an `int`, and use `-1` rather than `0xFF` to signal the non-subaddressed access.

This is another isolated PR on I2C code. As I understand this repo prefers this kind of fix as a part of a feature PR, my intention is to share my findings with other developers to avoid potential, unnecessary debug efforts.
