### PR TITLE
Graft of 'serial RX and telemetry on same port' feature from Betaflight.

### DIFF
--- a/docs/Serial.md
+++ b/docs/Serial.md
@@ -46,8 +46,9 @@ e.g. after configuring a port for GPS enable the GPS feature.
 * If SoftSerial is used, then all SoftSerial ports must use the same baudrate.
 * Softserial is limited to 19200 baud.
 * All telemetry systems except MSP will ignore any attempts to override the baudrate.
-* MSP/CLI can be shared with EITHER Blackbox OR telemetry.  In shared mode blackbox or telemetry will be output only when armed.
+* MSP/CLI can be shared with EITHER Blackbox OR telemetry. In shared mode blackbox or telemetry will be output only when armed.
 * Smartport telemetry cannot be shared with MSP.
+* FrSky and LTM telemetry can be shared with serial RX. In this case, the serial port's RX pin on the flight controller will be used for serial RX, the TX pin for telemetry output. When used this way, the baudrate used for telemetry will be set to the baudrate that is used by serial RX, make sure to check your RX supports this (currently only confirmed working with openLRSng modules).
 * No other serial port sharing combinations are valid.
 * You can use as many different telemetry systems as you like at the same time.
 * You can only use each telemetry system once.  e.g.  FrSky telemetry cannot be used on two port, but MSP Telemetry + FrSky on different ports is fine.

--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -203,7 +203,11 @@ serialPort_t *findNextSharedSerialPort(uint16_t functionMask, serialPortFunction
     return NULL;
 }
 
+#ifdef TELEMETRY
+#define ALL_TELEMETRY_FUNCTIONS_MASK (TELEMETRY_SHAREABLE_PORT_FUNCTIONS_MASK | FUNCTION_TELEMETRY_HOTT | FUNCTION_TELEMETRY_SMARTPORT)
+#else
 #define ALL_TELEMETRY_FUNCTIONS_MASK (FUNCTION_TELEMETRY_FRSKY | FUNCTION_TELEMETRY_HOTT | FUNCTION_TELEMETRY_SMARTPORT | FUNCTION_TELEMETRY_LTM | FUNCTION_TELEMETRY_MAVLINK)
+#endif
 #define ALL_FUNCTIONS_SHARABLE_WITH_MSP_SERVER (FUNCTION_BLACKBOX | ALL_TELEMETRY_FUNCTIONS_MASK)
 
 bool isSerialConfigValid(serialConfig_t *serialConfigToCheck)
@@ -212,7 +216,8 @@ bool isSerialConfigValid(serialConfig_t *serialConfigToCheck)
     /*
      * rules:
      * - 1 MSP port minimum, max MSP ports is defined and must be adhered to.
-     * - Only MSP SERVER is allowed to be shared with EITHER any telemetry OR blackbox.
+     * - MSP SERVER is allowed to be shared with EITHER any telemetry OR blackbox.
+     * - serial RX and FrSky / LTM telemetry can be shared
      * - No other sharing combinations are valid.
      */
     uint8_t mspPortCount = 0;
@@ -232,12 +237,14 @@ bool isSerialConfigValid(serialConfig_t *serialConfigToCheck)
                 return false;
             }
 
-            if (!(portConfig->functionMask & FUNCTION_MSP_SERVER)) {
-                return false;
-            }
-
-            if (!(portConfig->functionMask & ALL_FUNCTIONS_SHARABLE_WITH_MSP_SERVER)) {
-                // some other bit must have been set.
+            if ((portConfig->functionMask & FUNCTION_MSP_SERVER) && (portConfig->functionMask & ALL_FUNCTIONS_SHARABLE_WITH_MSP_SERVER)) {
+                // MSP & telemetry
+#ifdef TELEMETRY
+            } else if (telemetryIsPortSharedWithRx(portConfig)) {
+                // serial RX & telemetry
+#endif
+            } else {
+                // some other combination
                 return false;
             }
         }

--- a/src/main/rx/ibus.c
+++ b/src/main/rx/ibus.c
@@ -38,6 +38,10 @@
 #include "drivers/serial_uart.h"
 #include "io/serial.h"
 
+#ifdef TELEMETRY
+#include "telemetry/telemetry.h"
+#endif
+
 #include "rx/rx.h"
 #include "rx/ibus.h"
 
@@ -65,7 +69,19 @@ bool ibusInit(rxRuntimeConfig_t *rxRuntimeConfig, rcReadRawDataPtr *callback)
         return false;
     }
 
-    serialPort_t *ibusPort = openSerialPort(portConfig->identifier, FUNCTION_RX_SERIAL, ibusDataReceive, IBUS_BAUDRATE, MODE_RX, SERIAL_NOT_INVERTED);
+#ifdef TELEMETRY
+    bool portShared = telemetryIsPortSharedWithRx(portConfig);
+#else
+    bool portShared = false;
+#endif
+
+    serialPort_t *ibusPort = openSerialPort(portConfig->identifier, FUNCTION_RX_SERIAL, ibusDataReceive, IBUS_BAUDRATE, portShared ? MODE_RXTX : MODE_RX, SERIAL_NOT_INVERTED);
+
+#ifdef TELEMETRY
+    if (portShared) {
+        telemetrySharedPort = ibusPort;
+    }
+#endif
 
     return ibusPort != NULL;
 }

--- a/src/main/rx/sbus.c
+++ b/src/main/rx/sbus.c
@@ -35,6 +35,9 @@
 #include "drivers/serial_uart.h"
 #include "io/serial.h"
 
+#ifdef TELEMETRY
+#include "telemetry/telemetry.h"
+#endif
 #include "rx/rx.h"
 #include "rx/sbus.h"
 
@@ -94,8 +97,21 @@ bool sbusInit(rxRuntimeConfig_t *rxRuntimeConfig, rcReadRawDataPtr *callback)
     if (!portConfig) {
         return false;
     }
+
+#ifdef TELEMETRY
+    bool portShared = telemetryIsPortSharedWithRx(portConfig);
+#else
+    bool portShared = false;
+#endif
+
     portOptions_t options = (rxConfig()->sbus_inversion) ? (SBUS_PORT_OPTIONS | SERIAL_INVERTED) : SBUS_PORT_OPTIONS;
-    serialPort_t *sBusPort = openSerialPort(portConfig->identifier, FUNCTION_RX_SERIAL, sbusDataReceive, SBUS_BAUDRATE, MODE_RX, options);
+    serialPort_t *sBusPort = openSerialPort(portConfig->identifier, FUNCTION_RX_SERIAL, sbusDataReceive, SBUS_BAUDRATE, portShared ? MODE_RXTX : MODE_RX, options);
+
+#ifdef TELEMETRY
+    if (portShared) {
+        telemetrySharedPort = sBusPort;
+    }
+#endif
 
     return sBusPort != NULL;
 }

--- a/src/main/rx/spektrum.c
+++ b/src/main/rx/spektrum.c
@@ -36,6 +36,10 @@
 
 #include "fc/config.h"
 
+#ifdef TELEMETRY
+#include "telemetry/telemetry.h"
+#endif
+
 #include "rx/rx.h"
 #include "rx/spektrum.h"
 
@@ -91,7 +95,19 @@ bool spektrumInit(rxRuntimeConfig_t *rxRuntimeConfig, rcReadRawDataPtr *callback
         return false;
     }
 
-    serialPort_t *spektrumPort = openSerialPort(portConfig->identifier, FUNCTION_RX_SERIAL, spektrumDataReceive, SPEKTRUM_BAUDRATE, MODE_RX, SERIAL_NOT_INVERTED);
+#ifdef TELEMETRY
+    bool portShared = telemetryIsPortSharedWithRx(portConfig);
+#else
+    bool portShared = false;
+#endif
+
+    serialPort_t *spektrumPort = openSerialPort(portConfig->identifier, FUNCTION_RX_SERIAL, spektrumDataReceive, SPEKTRUM_BAUDRATE, portShared ? MODE_RXTX : MODE_RX, SERIAL_NOT_INVERTED);
+
+#ifdef TELEMETRY
+    if (portShared) {
+        telemetrySharedPort = spektrumPort;
+    }
+#endif
 
     return spektrumPort != NULL;
 }

--- a/src/main/rx/sumd.c
+++ b/src/main/rx/sumd.c
@@ -32,6 +32,10 @@
 #include "drivers/serial_uart.h"
 #include "io/serial.h"
 
+#ifdef TELEMETRY
+#include "telemetry/telemetry.h"
+#endif
+
 #include "rx/rx.h"
 #include "rx/sumd.h"
 
@@ -64,7 +68,19 @@ bool sumdInit(rxRuntimeConfig_t *rxRuntimeConfig, rcReadRawDataPtr *callback)
         return false;
     }
 
-    serialPort_t *sumdPort = openSerialPort(portConfig->identifier, FUNCTION_RX_SERIAL, sumdDataReceive, SUMD_BAUDRATE, MODE_RX, SERIAL_NOT_INVERTED);
+#ifdef TELEMETRY
+    bool portShared = telemetryIsPortSharedWithRx(portConfig);
+#else
+    bool portShared = false;
+#endif
+
+    serialPort_t *sumdPort = openSerialPort(portConfig->identifier, FUNCTION_RX_SERIAL, sumdDataReceive, SUMD_BAUDRATE, portShared ? MODE_RXTX : MODE_RX, SERIAL_NOT_INVERTED);
+
+#ifdef TELEMETRY
+    if (portShared) {
+        telemetrySharedPort = sumdPort;
+    }
+#endif
 
     return sumdPort != NULL;
 }

--- a/src/main/rx/sumh.c
+++ b/src/main/rx/sumh.c
@@ -38,6 +38,10 @@
 #include "drivers/serial_uart.h"
 #include "io/serial.h"
 
+#ifdef TELEMETRY
+#include "telemetry/telemetry.h"
+#endif
+
 #include "rx/rx.h"
 #include "rx/sumh.h"
 
@@ -78,7 +82,19 @@ bool sumhInit(rxRuntimeConfig_t *rxRuntimeConfig, rcReadRawDataPtr *callback)
         return false;
     }
 
-    sumhPort = openSerialPort(portConfig->identifier, FUNCTION_RX_SERIAL, sumhDataReceive, SUMH_BAUDRATE, MODE_RX, SERIAL_NOT_INVERTED);
+#ifdef TELEMETRY
+    bool portShared = telemetryIsPortSharedWithRx(portConfig);
+#else
+    bool portShared = false;
+#endif
+
+    sumhPort = openSerialPort(portConfig->identifier, FUNCTION_RX_SERIAL, sumhDataReceive, SUMH_BAUDRATE, portShared ? MODE_RXTX : MODE_RX, SERIAL_NOT_INVERTED);
+
+#ifdef TELEMETRY
+    if (portShared) {
+        telemetrySharedPort = sumhPort;
+    }
+#endif
 
     return sumhPort != NULL;
 }

--- a/src/main/target/CC3D/target.h
+++ b/src/main/target/CC3D/target.h
@@ -128,7 +128,7 @@
 
 #define USE_SERIAL_4WAY_BLHELI_INTERFACE
 
-#define SONAR
+//#define SONAR
 #define SONAR_TRIGGER_PIN           Pin_5   // (PB5)
 #define SONAR_TRIGGER_GPIO          GPIOB
 #define SONAR_ECHO_PIN              Pin_0   // (PB0) - only 3.3v ( add a 1K Ohms resistor )

--- a/src/main/target/NAZE/target.h
+++ b/src/main/target/NAZE/target.h
@@ -122,7 +122,7 @@
 #define INVERTER
 #define DISPLAY
 
-#define SONAR
+//#define SONAR
 #define SONAR_PWM_TRIGGER_PIN       Pin_8   // PWM5 (PB8) - 5v tolerant
 #define SONAR_PWM_TRIGGER_GPIO      GPIOB
 #define SONAR_PWM_ECHO_PIN          Pin_9   // PWM6 (PB9) - 5v tolerant

--- a/src/main/telemetry/frsky.c
+++ b/src/main/telemetry/frsky.c
@@ -476,16 +476,23 @@ bool hasEnoughTimeLapsedSinceLastTelemetryTransmission(uint32_t currentMillis)
 
 bool checkFrSkyTelemetryState(void)
 {
-    bool newTelemetryEnabledValue = telemetryDetermineEnabledState(frskyPortSharing);
+    if (portConfig && telemetryIsPortSharedWithRx(portConfig)) {
+        if (!frskyTelemetryEnabled && telemetrySharedPort != NULL) {
+            frskyPort = telemetrySharedPort;
+            frskyTelemetryEnabled = true;
+        }
+    } else {
+        bool newTelemetryEnabledValue = telemetryDetermineEnabledState(frskyPortSharing);
 
-    if (newTelemetryEnabledValue == frskyTelemetryEnabled) {
-        return false;
+        if (newTelemetryEnabledValue == frskyTelemetryEnabled) {
+            return false;
+        }
+
+        if (newTelemetryEnabledValue)
+            configureFrSkyTelemetryPort();
+        else
+            freeFrSkyTelemetryPort();
     }
-
-    if (newTelemetryEnabledValue)
-        configureFrSkyTelemetryPort();
-    else
-        freeFrSkyTelemetryPort();
 
     return true;
 }

--- a/src/main/telemetry/ltm.c
+++ b/src/main/telemetry/ltm.c
@@ -284,16 +284,20 @@ void configureLtmTelemetryPort(void)
 
 bool checkLtmTelemetryState(void)
 {
-    bool newTelemetryEnabledValue = telemetryDetermineEnabledState(ltmPortSharing);
-
-    if (newTelemetryEnabledValue == ltmEnabled) {
-        return false;
+    if (portConfig && telemetryIsPortSharedWithRx(portConfig)) {
+        if (!ltmEnabled && telemetrySharedPort != NULL) {
+            ltmPort = telemetrySharedPort;
+            ltmEnabled = true;
+        }
+    } else {
+        bool newTelemetryEnabledValue = telemetryDetermineEnabledState(ltmPortSharing);
+        if (newTelemetryEnabledValue == ltmEnabled)
+            return false;
+        if (newTelemetryEnabledValue)
+            configureLtmTelemetryPort();
+        else
+            freeLtmTelemetryPort();
     }
-
-    if (newTelemetryEnabledValue)
-        configureLtmTelemetryPort();
-    else
-        freeLtmTelemetryPort();
 
     return true;
 }

--- a/src/main/telemetry/telemetry.c
+++ b/src/main/telemetry/telemetry.c
@@ -86,6 +86,13 @@ bool telemetryDetermineEnabledState(portSharing_e portSharing)
     return enabled;
 }
 
+bool telemetryIsPortSharedWithRx(serialPortConfig_t *portConfig)
+{
+    return portConfig->functionMask & FUNCTION_RX_SERIAL && portConfig->functionMask & TELEMETRY_SHAREABLE_PORT_FUNCTIONS_MASK;
+}
+
+serialPort_t *telemetrySharedPort = NULL;
+
 // 0 =  no states changed, > 0, some state changed.
 uint8_t telemetryCheckState(void)
 {

--- a/src/main/telemetry/telemetry.h
+++ b/src/main/telemetry/telemetry.h
@@ -43,6 +43,9 @@ PG_DECLARE(telemetryConfig_t, telemetryConfig);
 
 void telemetryInit(void);
 
+bool telemetryIsPortSharedWithRx(serialPortConfig_t *portConfig);
+extern serialPort_t *telemetrySharedPort;
+
 uint8_t telemetryCheckState(void);
 void telemetryProcess(uint16_t deadband3d_throttle);
 
@@ -50,3 +53,4 @@ bool telemetryDetermineEnabledState(portSharing_e portSharing);
 
 void telemetryUseConfig(telemetryConfig_t *telemetryConfig);
 
+#define TELEMETRY_SHAREABLE_PORT_FUNCTIONS_MASK (FUNCTION_TELEMETRY_FRSKY | FUNCTION_TELEMETRY_LTM)

--- a/src/test/unit/io_serial_unittest.cc
+++ b/src/test/unit/io_serial_unittest.cc
@@ -101,4 +101,10 @@ serialPort_t *usbVcpOpen(void) { return NULL; }
 serialPort_t *uartOpen(USART_TypeDef *, serialReceiveCallbackPtr, uint32_t, portMode_t, portOptions_t) { return NULL; }
 serialPort_t *openSoftSerial(softSerialPortIndex_e, serialReceiveCallbackPtr, uint32_t, portOptions_t) { return NULL; }
 void serialSetMode(serialPort_t *, portMode_t) {}
+bool telemetryIsPortSharedWithRx(serialPortConfig_t *portConfig)
+{
+	UNUSED(portConfig);
+
+	return false;
+}
 }

--- a/src/test/unit/msp_fc_unittest.cc
+++ b/src/test/unit/msp_fc_unittest.cc
@@ -594,5 +594,11 @@ bool isSerialTransmitBufferEmpty(serialPort_t *) { return true; }
 amperageMeter_t *getAmperageMeter(amperageMeter_e index) { UNUSED(index); return &amperageMeter; }
 batteryState_e getBatteryState(void) { return BATTERY_NOT_PRESENT; }
 voltageMeterState_t *getVoltageMeter(uint8_t ) { return &voltageMeter; }
-}
 
+bool telemetryIsPortSharedWithRx(serialPortConfig_t *portConfig)
+{
+    UNUSED(portConfig);
+
+    return false;
+}
+}

--- a/src/test/unit/msp_serial_unittest.cc
+++ b/src/test/unit/msp_serial_unittest.cc
@@ -270,5 +270,11 @@ serialPort_t *uartOpen(USART_TypeDef *, serialReceiveCallbackPtr, uint32_t, port
 serialPort_t *openSoftSerial(softSerialPortIndex_e, serialReceiveCallbackPtr, uint32_t, portOptions_t) { return NULL; }
 void serialSetMode(serialPort_t *, portMode_t) {}
 bool isRebootScheduled = false;
+bool telemetryIsPortSharedWithRx(serialPortConfig_t *portConfig)
+{
+    UNUSED(portConfig);
+
+    return false;
+}
 }
 


### PR DESCRIPTION
This PR enables sharing of one serial port between serial RX and telemetry. If a port is shared, the speed and inversion settings of the port are dictated by the serial RX protocol used, and any settings for the telemetry protocol are ignored. As a consequence, this will only work if the RX can receive telemetry data at the same speed as the serial RX data it is set to output.

This has only been tested (and found to work fine) with a Naze32 rev 6 as the FC, and an OrangeRx openLRS RX. The combination of SUMD RX and FrSky telemetry over the same serial port works fine with this hardware.

Any feedback on other combinations working / not working is appreciated, and will be integrated.
