### PR TITLE
Docs: Ubuntu - Updating the Repo Url Because the old Url is dead.

### DIFF
--- a/docs/development/Building in Ubuntu.md
+++ b/docs/development/Building in Ubuntu.md
@@ -18,7 +18,7 @@ For your release, you should first remove any older pacakges (from Debian or Ubu
 Terry's PPA, and update:
 ```
 sudo apt-get remove binutils-arm-none-eabi gcc-arm-none-eabi
-sudo add-apt-repository ppa:terry.guo/gcc-arm-embedded
+sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa
 sudo apt-get update
 ```
 


### PR DESCRIPTION
There are a few other pull requests out to fix the version numbers of the packages, but none addressed the issue that the repository url listed in the docs is now redacted. 