### PR TITLE
BaroAlt initialisation fix

### DIFF
--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -161,10 +161,13 @@ int32_t baroCalculateAltitude(void)
 
     // calculates height from ground via baro readings
     // see: https://github.com/diydrones/ardupilot/blob/master/libraries/AP_Baro/AP_Baro.cpp#L140
-    BaroAlt_tmp = lrintf((1.0f - powf((float)(baroPressureSum / PRESSURE_SAMPLE_COUNT) / 101325.0f, 0.190295f)) * 4433000.0f); // in cm
-    BaroAlt_tmp -= baroGroundAltitude;
-    BaroAlt = lrintf((float)BaroAlt * barometerConfig()->baro_noise_lpf + (float)BaroAlt_tmp * (1.0f - barometerConfig()->baro_noise_lpf)); // additional LPF to reduce baro noise
-
+    if(isBaroCalibrationComplete()) {
+        BaroAlt_tmp = lrintf((1.0f - powf((float)(baroPressureSum / PRESSURE_SAMPLE_COUNT) / 101325.0f, 0.190295f)) * 4433000.0f); // in cm
+        BaroAlt_tmp -= baroGroundAltitude;
+        BaroAlt = lrintf((float)BaroAlt * barometerConfig()->baro_noise_lpf + (float)BaroAlt_tmp * (1.0f - barometerConfig()->baro_noise_lpf)); // additional LPF to reduce baro noise
+    }
+    else
+        BaroAlt = 0;
     return BaroAlt;
 }
 

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -161,7 +161,7 @@ int32_t baroCalculateAltitude(void)
 
     // calculates height from ground via baro readings
     // see: https://github.com/diydrones/ardupilot/blob/master/libraries/AP_Baro/AP_Baro.cpp#L140
-    if(isBaroCalibrationComplete()) {
+    if (isBaroCalibrationComplete()) {
         BaroAlt_tmp = lrintf((1.0f - powf((float)(baroPressureSum / PRESSURE_SAMPLE_COUNT) / 101325.0f, 0.190295f)) * 4433000.0f); // in cm
         BaroAlt_tmp -= baroGroundAltitude;
         BaroAlt = lrintf((float)BaroAlt * barometerConfig()->baro_noise_lpf + (float)BaroAlt_tmp * (1.0f - barometerConfig()->baro_noise_lpf)); // additional LPF to reduce baro noise

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -166,8 +166,9 @@ int32_t baroCalculateAltitude(void)
         BaroAlt_tmp -= baroGroundAltitude;
         BaroAlt = lrintf((float)BaroAlt * barometerConfig()->baro_noise_lpf + (float)BaroAlt_tmp * (1.0f - barometerConfig()->baro_noise_lpf)); // additional LPF to reduce baro noise
     }
-    else
+    else {
         BaroAlt = 0;
+    }
     return BaroAlt;
 }
 


### PR DESCRIPTION
BaroAlt is being updated prior to Baro calibration being complete.
This was causing my taranis radio telemetry to sometimes report the wrong altitude as it learns the starting Smartport altitude value to in order to offset it to altitude above ground. (It was learning some of the initial incorrect values)
Below is a capture of the Smartport telemetry causing the intermittent issue. 

Example Smartport messages after reset......
100 (Altitude): 0
100 (Altitude): 0
100 (Altitude): -6861
100 (Altitude): 13004
100 (Altitude): -29604
100 (Altitude): -6729
100 (Altitude): -1759
100 (Altitude): -401
100 (Altitude): -105
100 (Altitude): -26
100 (Altitude): -8
100 (Altitude): 0
100 (Altitude): 0
100 (Altitude): -1
100 (Altitude): 0
100 (Altitude): 0
100 (Altitude): 0
100 (Altitude): -7