### PR TITLE
Add horizon_tilt_effect command

### DIFF
--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -53,6 +53,11 @@ typedef enum {
     PID_DELTA_FROM_ERROR
 } pidDeltaMethod_e;
 
+typedef enum {
+    HORIZON_TILT_MODE_SAFE = 0,
+    HORIZON_TILT_MODE_EXPERT
+} horizonTiltMode_e;
+
 typedef struct pidProfile_s {
     uint8_t  P8[PID_ITEM_COUNT];
     uint8_t  I8[PID_ITEM_COUNT];
@@ -62,6 +67,8 @@ typedef struct pidProfile_s {
     uint16_t dterm_lpf;                     // dterm filtering
     uint16_t yaw_lpf;                       // additional yaw filter when yaw axis too noisy
     uint8_t  deltaMethod;
+    uint8_t horizon_tilt_effect;            // inclination factor for Horizon mode
+    uint8_t horizon_tilt_mode;              // SAFE or EXPERT
 } pidProfile_t;
 
 PG_DECLARE_PROFILE(pidProfile_t, pidProfile);
@@ -82,3 +89,5 @@ void pidSetController(pidControllerType_e type);
 void pidResetITermAngle(void);
 void pidResetITerm(void);
 
+int calcHorizonLevelStrength(uint16_t rxConfigMidrc, int horizonTiltEffect,
+        uint8_t horizonTiltMode, int horizonSensitivity);

--- a/src/main/flight/pid_luxfloat.c
+++ b/src/main/flight/pid_luxfloat.c
@@ -148,18 +148,9 @@ void pidLuxFloat(const pidProfile_t *pidProfile, const controlRateConfig_t *cont
 {
     float horizonLevelStrength = 0.0f;
     if (FLIGHT_MODE(HORIZON_MODE)) {
-        // Figure out the most deflected stick position
-        const int32_t stickPosAil = ABS(getRcStickDeflection(ROLL, rxConfig->midrc));
-        const int32_t stickPosEle = ABS(getRcStickDeflection(PITCH, rxConfig->midrc));
-        const int32_t mostDeflectedPos =  MAX(stickPosAil, stickPosEle);
-
-        // Progressively turn off the horizon self level strength as the stick is banged over
-        horizonLevelStrength = (float)(500 - mostDeflectedPos) / 500;  // 1 at centre stick, 0 = max stick deflection
-        if(pidProfile->D8[PIDLEVEL] == 0){
-            horizonLevelStrength = 0;
-        } else {
-            horizonLevelStrength = constrainf(((horizonLevelStrength - 1) * (100 / pidProfile->D8[PIDLEVEL])) + 1, 0, 1);
-        }
+        // (convert 0-100 range to 0.0-1.0 range)
+        horizonLevelStrength = (float)calcHorizonLevelStrength(rxConfig->midrc, pidProfile->horizon_tilt_effect,
+                pidProfile->horizon_tilt_mode, pidProfile->D8[PIDLEVEL]) / 100.0f;
     }
 
     // ----------PID controller----------

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -401,6 +401,10 @@ static const char * const lookupTablePidDeltaMethod[] = {
     "MEASUREMENT", "ERROR"
 };
 
+static const char * const lookupTableHorizonTiltMode[] = {
+    "SAFE", "EXPERT"
+};
+
 typedef struct lookupTableEntry_s {
     const char * const *values;
     const uint8_t valueCount;
@@ -424,6 +428,7 @@ typedef enum {
     TABLE_GYRO_FILTER,
     TABLE_GYRO_LPF,
     TABLE_PID_DELTA_METHOD,
+    TABLE_HORIZON_TILT_MODE,
 } lookupTableIndex_e;
 
 static const lookupTableEntry_t lookupTables[] = {
@@ -444,6 +449,7 @@ static const lookupTableEntry_t lookupTables[] = {
     { lookupTableGyroFilter, sizeof(lookupTableGyroFilter) / sizeof(char *) },
     { lookupTableGyroLpf, sizeof(lookupTableGyroLpf) / sizeof(char *) },
     { lookupTablePidDeltaMethod, sizeof(lookupTablePidDeltaMethod) / sizeof(char *) },
+    { lookupTableHorizonTiltMode, sizeof(lookupTableHorizonTiltMode) / sizeof(char *) },
 };
 
 #define VALUE_TYPE_OFFSET 0
@@ -705,6 +711,8 @@ const clivalue_t valueTable[] = {
     { "yaw_p_limit",                VAR_UINT16 | PROFILE_VALUE, .config.minmax = { YAW_P_LIMIT_MIN, YAW_P_LIMIT_MAX } , PG_PID_PROFILE, offsetof(pidProfile_t, yaw_p_limit)},
     { "yaw_lpf",                    VAR_UINT16 | PROFILE_VALUE, .config.minmax = {0, 500 } , PG_PID_PROFILE, offsetof(pidProfile_t, yaw_lpf)},
     { "dterm_cut_hz",               VAR_UINT16 | PROFILE_VALUE, .config.minmax = {0, 500 } , PG_PID_PROFILE, offsetof(pidProfile_t, dterm_lpf)},
+    { "horizon_tilt_effect",        VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 0, 250 } , PG_PID_PROFILE, offsetof(pidProfile_t, horizon_tilt_effect)},
+    { "horizon_tilt_mode",          VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_HORIZON_TILT_MODE }, PG_PID_PROFILE, offsetof(pidProfile_t, horizon_tilt_mode)},
 
 #ifdef GTUNE
     { "gtune_loP_rll",              VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 10,  200 } , PG_GTUNE_CONFIG, offsetof(gtuneConfig_t, gtune_lolimP[FD_ROLL])},


### PR DESCRIPTION
This is an updated version of PR #2268 "Add horizon_incl_fact parameter"

This modification adds two new CLI commands, 'horizon_tilt_effect' and 'horizon_tilt_mode', which control the effect the current inclination has on self-leveling in the Horizon flight mode.  With the existing horizon mode, the strength of the self-leveling is solely dependent on the stick position.  This is problematic when trying to do maneuvers like large loops and fast-forward flight.  Adding a factor that takes into account the current inclination of the craft provides a big improvement for these maneuvers and improves the "feel" of horizon mode.  (The current inclination is the number of degrees of pitch or roll that the vehicle is away from level, whichever is greater).

These commands affect Horizon mode for the LUX and REWRITE controllers.  The math is all integer based, so no (slower) floating-point operations are involved when using the REWRITE controller.

This mod also addresses an issue with the "Transition (Horizon)" ('d_level') parameter -- as of Cleanflight v1.13.0 the 'sensitivity_horizon' (LUX) and 'd_level' (REWRITE) CLI parameters were merged so that both use the 'd_level' parameter.  The problem is that the ranges behave differently -- in LUX, increasing the value results in more self leveling and zero results in no self leveling; in REWRITE, increasing the value results in less self leveling.  With this mod, increasing the value results in more self leveling and zero results in no self leveling.  The default has been changed to 75, which should give relatively unchanged default behavior for this parameter on both PID controllers.

The original idea for this mod came from ctzsnooze (see CleanFlight [issue #695](http://github.com/cleanflight/cleanflight/issues/695)); I've expanded on it and turned it into a configurable option.  One characteristic of horizon mode I made a point of retaining is that, when the vehicle is flat and the sticks are near center, the self-leveling effect is not diminished by larger 'horizon_incl_fact' settings.  Like in the existing horizon mode, the strength of the self-leveling can be effectively managed using the "Strength (Horizon)" ('i_level') parameter.  Also, the "Transition (Horizon)" ('d_level') parameter operates the same as before.

Setting 'horizon_tilt_effect' to 0 will run the old horizon-mode behavior.  For other values, see below:

horizon_tilt_effect 0|175|75: Controls the effect the current inclination (tilt) has on self-leveling in the Horizon flight mode. Larger values result in less self-leveling (more "acro") as the tilt of the vehicle increases. The default value of 75 provides good performance when doing large loops and fast-forward flight. With a value of 0 the strength of the self-leveling would be solely dependent on the stick position.

horizon_tilt_mode SAFE|EXPERT: Sets the preformance mode for 'horizon_tilt_effect'

SAFE = leveling always active when sticks centered:
This is the "safer" range because the self-leveling is always active when the sticks are centered. So, when the vehicle is upside down (180 degrees) and the sticks are then centered, the vehicle will immediately be self-leveled to upright and flat. (Note that after this kind of very-fast 180-degree self-leveling, the heading of the vehicle can be unpredictable.)

EXPERT = leveling can be totally off when inverted:
In this range, the inclination (tilt) of the vehicle can fully "override" the self-leveling. In this mode, when the 'horizon_tilt_effect' parameter is set to around 75, and the vehicle is upside down (180 degrees) and the sticks are then centered, the vehicle is not self-leveled. This can be desirable for performing more-acrobatic maneuvers and potentially for 3D-mode flying.

The 'horizon_tilt_effect' and 'horizon_tilt_mode' values are separate for each profile, and are implemented for both the LUX and REWRITE PID controllers.

I've posted a version of this modification applied to the v1.13.0 (release) version of Cleanflight, [here](http://www.etheli.com/CF/addHorizonTiltEffect).  A PR of this mod for Betaflight is [here](https://github.com/betaflight/betaflight/pull/1064).

I've been flying this mod in my [MiniFTC](http://www.etheli.com/MiniFTC) and other copters for quite a while now; I think it makes Horizon mode much better.

--ET