### PR TITLE
Redesign PG loading from EEPROM

### DIFF
--- a/src/main/config/config_eeprom.c
+++ b/src/main/config/config_eeprom.c
@@ -148,12 +148,13 @@ const configRecord_t *findEEPROM(const pgRegistry_t *reg, configRecordFlags_e cl
     while (true) {
         const configRecord_t *record = (const configRecord_t *)p;
         if (record->size == 0
-           || p + record->size >= &__config_end
-           || record->size < sizeof(*record))
+            || p + record->size >= &__config_end
+            || record->size < sizeof(*record))
             break;
         if (pgN(reg) == record->pgn
-           && (record->flags & CR_CLASSIFICATION_MASK) == classification)
+            && (record->flags & CR_CLASSIFICATION_MASK) == classification)
             return record;
+        p += record->size;
     }
     // record not found
     return NULL;

--- a/src/main/config/config_eeprom.c
+++ b/src/main/config/config_eeprom.c
@@ -41,7 +41,8 @@ typedef enum {
     CR_CLASSICATION_SYSTEM   = 0,
     CR_CLASSICATION_PROFILE1 = 1,
     CR_CLASSICATION_PROFILE2 = 2,
-    CR_CLASSICATION_PROFILE3 = 3
+    CR_CLASSICATION_PROFILE3 = 3,
+    CR_CLASSICATION_PROFILE_LAST = CR_CLASSICATION_PROFILE3,
 } configRecordFlags_e;
 
 #define CR_CLASSIFICATION_MASK (0x3)
@@ -99,35 +100,8 @@ static uint8_t updateChecksum(uint8_t chk, const void *data, uint32_t length)
     return chk;
 }
 
-uint8_t pgMatcherForConfigRecord(const pgRegistry_t *candidate, const void *criteria)
-{
-    const configRecord_t *record = (const configRecord_t *)criteria;
-
-    return (pgN(candidate) == record->pgn && pgVersion(candidate) == record->version);
-}
-
-// Load a PG into RAM, upgrading and downgrading as needed.
-static bool loadPG(const configRecord_t *record)
-{
-    const pgRegistry_t *reg = pgMatcher(pgMatcherForConfigRecord, record);
-
-    if (reg == NULL) {
-        return false;
-    }
-
-    uint8_t profileIndex = 0;
-
-    if (!pgIsSystem(reg)) {
-        profileIndex = (record->flags & CR_CLASSIFICATION_MASK) - 1;
-    }
-
-    pgLoad(reg, record->pg, record->size, profileIndex);
-    return true;
-}
-
-// Scan the EEPROM config.  Optionally also load into memory.  Returns
-// true if the config is valid.
-bool scanEEPROM(bool andLoad) // FIXME boolean argument.
+// Scan the EEPROM config. Returns true if the config is valid.
+bool scanEEPROM(void)
 {
     uint8_t chk = 0;
     const uint8_t *p = &__config_start;
@@ -154,9 +128,6 @@ bool scanEEPROM(bool andLoad) // FIXME boolean argument.
 
         chk = updateChecksum(chk, p, record->size);
 
-        if (andLoad) {
-            loadPG(record);
-        }
         p += record->size;
     }
 
@@ -167,9 +138,58 @@ bool scanEEPROM(bool andLoad) // FIXME boolean argument.
     return chk == *p;
 }
 
+// find config record for reg + classification (profile info) in EEPROM
+// return NULL when record is not found
+// this function assumes that EEPROM content is valid
+const configRecord_t *findEEPROM(const pgRegistry_t *reg, configRecordFlags_e classification)
+{
+    const uint8_t *p = &__config_start;
+    p += sizeof(configHeader_t);             // skip header
+    while(true) {
+        const configRecord_t *record = (const configRecord_t *)p;
+        if(record->size == 0
+           || p + record->size >= &__config_end
+           || record->size < sizeof(*record))
+            break;
+        if(pgN(reg) == record->pgn
+           && (record->flags & CR_CLASSIFICATION_MASK) == classification)
+            return record;
+    }
+    // record not found
+    return NULL;
+}
+
+// Initialize all PG records from EEPROM.
+// This functions processes all PGs sequentially, scanning EEPROM for each one. This is suboptimal,
+//   but each PG is loaded/initialized exactly once and in defined order.
+bool loadEEPROM(void)
+{
+    PG_FOREACH(reg) {
+        configRecordFlags_e cls_start, cls_end;
+        if(pgIsSystem(reg)) {
+            cls_start = CR_CLASSICATION_SYSTEM;
+            cls_end = CR_CLASSICATION_SYSTEM;
+        } else {
+            cls_start = CR_CLASSICATION_PROFILE1;
+            cls_end = CR_CLASSICATION_PROFILE_LAST;
+        }
+        for (configRecordFlags_e cls = cls_start; cls <= cls_end; cls++) {
+            int profileIndex = cls - cls_start;
+            const configRecord_t *rec = findEEPROM(reg, cls);
+            if(rec) {
+                // config from EEPROM is available, use it to initialize PG. pgLoad will handle version mismatch
+                pgLoad(reg, profileIndex, rec->pg, rec->size, rec->version);
+            } else {
+                pgReset(reg, profileIndex);
+            }
+        }
+    }
+    return true;
+}
+
 bool isEEPROMContentValid(void)
 {
-    return scanEEPROM(false);
+    return scanEEPROM();
 }
 
 static bool writeSettingsToEEPROM(void)

--- a/src/main/config/config_eeprom.c
+++ b/src/main/config/config_eeprom.c
@@ -145,13 +145,13 @@ const configRecord_t *findEEPROM(const pgRegistry_t *reg, configRecordFlags_e cl
 {
     const uint8_t *p = &__config_start;
     p += sizeof(configHeader_t);             // skip header
-    while(true) {
+    while (true) {
         const configRecord_t *record = (const configRecord_t *)p;
-        if(record->size == 0
+        if (record->size == 0
            || p + record->size >= &__config_end
            || record->size < sizeof(*record))
             break;
-        if(pgN(reg) == record->pgn
+        if (pgN(reg) == record->pgn
            && (record->flags & CR_CLASSIFICATION_MASK) == classification)
             return record;
     }
@@ -166,7 +166,7 @@ bool loadEEPROM(void)
 {
     PG_FOREACH(reg) {
         configRecordFlags_e cls_start, cls_end;
-        if(pgIsSystem(reg)) {
+        if (pgIsSystem(reg)) {
             cls_start = CR_CLASSICATION_SYSTEM;
             cls_end = CR_CLASSICATION_SYSTEM;
         } else {
@@ -176,7 +176,7 @@ bool loadEEPROM(void)
         for (configRecordFlags_e cls = cls_start; cls <= cls_end; cls++) {
             int profileIndex = cls - cls_start;
             const configRecord_t *rec = findEEPROM(reg, cls);
-            if(rec) {
+            if (rec) {
                 // config from EEPROM is available, use it to initialize PG. pgLoad will handle version mismatch
                 pgLoad(reg, profileIndex, rec->pg, rec->size, rec->version);
             } else {

--- a/src/main/config/config_eeprom.h
+++ b/src/main/config/config_eeprom.h
@@ -18,6 +18,6 @@
 #pragma once
 
 bool isEEPROMContentValid(void);
-bool scanEEPROM(bool andLoad);
+bool loadEEPROM(void);
 void writeConfigToEEPROM(void);
 void activateProfile(uint8_t profileIndexToActivate);

--- a/src/main/config/parameter_group.c
+++ b/src/main/config/parameter_group.c
@@ -48,7 +48,7 @@ static void pgResetInstance(const pgRegistry_t *reg, uint8_t *base)
     const uint16_t regSize = pgSize(reg);
 
     memset(base, 0, regSize);
-    if(reg->reset.ptr >= (void*)__pg_resetdata_start && reg->reset.ptr < (void*)__pg_resetdata_end) {
+    if (reg->reset.ptr >= (void*)__pg_resetdata_start && reg->reset.ptr < (void*)__pg_resetdata_end) {
         // pointer points to resetdata section, to it is data template
         memcpy(base, reg->reset.ptr, regSize);
     } else if (reg->reset.fn) {
@@ -64,7 +64,7 @@ void pgReset(const pgRegistry_t* reg, int profileIndex)
 
 void pgResetCurrent(const pgRegistry_t *reg)
 {
-    if(pgIsSystem(reg)) {
+    if (pgIsSystem(reg)) {
         pgResetInstance(reg, reg->address);
     } else {
         pgResetInstance(reg, *reg->ptr);
@@ -75,7 +75,7 @@ void pgLoad(const pgRegistry_t* reg, int profileIndex, const void *from, int siz
 {
     pgResetInstance(reg, pgOffset(reg, profileIndex));
     // restore only matching version, keep defaults otherwise
-    if(version == pgVersion(reg)) {
+    if (version == pgVersion(reg)) {
         const int take = MIN(size, pgSize(reg));
         memcpy(pgOffset(reg, profileIndex), from, take);
     }

--- a/src/main/config/parameter_group.c
+++ b/src/main/config/parameter_group.c
@@ -59,12 +59,7 @@ static void pgResetInstance(const pgRegistry_t *reg, uint8_t *base)
 
 void pgReset(const pgRegistry_t* reg, int profileIndex)
 {
-    if (pgIsSystem(reg)) {
-        pgResetInstance(reg, reg->address);
-    } else {
-        // reset one instance for each profile
-        pgResetInstance(reg, pgOffset(reg, profileIndex));
-    }
+    pgResetInstance(reg, pgOffset(reg, profileIndex));
 }
 
 void pgResetCurrent(const pgRegistry_t *reg)

--- a/src/main/config/parameter_group.h
+++ b/src/main/config/parameter_group.h
@@ -219,12 +219,11 @@ extern const uint8_t __pg_resetdata_end[];
     }                                                                   \
     /**/
 
-typedef uint8_t (*pgMatcherFuncPtr)(const pgRegistry_t *candidate, const void *criteria);
-
 const pgRegistry_t* pgFind(pgn_t pgn);
-const pgRegistry_t* pgMatcher(pgMatcherFuncPtr matcher, const void *criteria);
-void pgLoad(const pgRegistry_t* reg, const void *from, int size, uint8_t profileIndex);
+
+void pgLoad(const pgRegistry_t* reg, int profileIndex, const void *from, int size, int version);
 int pgStore(const pgRegistry_t* reg, void *to, int size, uint8_t profileIndex);
-void pgResetAll(uint8_t profileCount);
-void pgActivateProfile(uint8_t profileIndexToActivate);
+void pgResetAll(int profileCount);
 void pgResetCurrent(const pgRegistry_t *reg);
+void pgReset(const pgRegistry_t* reg, int profileIndex);
+void pgActivateProfile(int profileIndex);

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -298,7 +298,7 @@ void readEEPROM(void)
     suspendRxSignal();
 
     // Sanity check, read flash
-    if (!scanEEPROM(true)) {
+    if (!loadEEPROM()) {
         failureMode(FAILURE_INVALID_EEPROM_CONTENTS);
     }
 

--- a/src/main/osd/config.c
+++ b/src/main/osd/config.c
@@ -96,7 +96,7 @@ static void validateAndFixConfig(void)
 void readEEPROM(void)
 {
     // Sanity check, read flash
-    if (!scanEEPROM(true)) {
+    if (!loadEEPROM()) {
         failureMode(FAILURE_INVALID_EEPROM_CONTENTS);
     }
 


### PR DESCRIPTION
All parameter groups  initialized, either from EEPROM or reset to
default.
Stored record version is checked, mismatched version is ignored