### PR TITLE
Fix invalid length of EEPROM record

### DIFF
--- a/src/main/config/config_eeprom.c
+++ b/src/main/config/config_eeprom.c
@@ -179,7 +179,7 @@ bool loadEEPROM(void)
             const configRecord_t *rec = findEEPROM(reg, cls);
             if (rec) {
                 // config from EEPROM is available, use it to initialize PG. pgLoad will handle version mismatch
-                pgLoad(reg, profileIndex, rec->pg, rec->size, rec->version);
+                pgLoad(reg, profileIndex, rec->pg, rec->size - offsetof(configRecord_t, pg), rec->version);
             } else {
                 pgReset(reg, profileIndex);
             }


### PR DESCRIPTION
Invalid length was passed to pgLoad, overwriting PG data when record
size was increased