### PR TITLE
Enable msp control pwm fallback

### DIFF
--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -505,9 +505,9 @@ static void readRxChannelsApplyRanges(void)
     }
     // filter through buddy-box
     for(channel = 0; channel < rxRuntimeConfig.channelCount; channel++){
-        if((channel == ROLL || channel == PITCH || channel == YAW) && RC_channels[AUX1] > 1500){ // allow MSP to take control if AUX1 is high
+        if((channel == ROLL || channel == PITCH || channel == YAW) && RC_channels[AUX2] < 1300){ // allow MSP to take control if AUX2 is low
             rcRaw[channel]  = (abs(RC_channels[channel] - 1500) < 50) ? MSP_channels[channel] : RC_channels[channel]; // allow RC override if sticks are moved
-        } else if(channel == THROTTLE && RC_channels[AUX1] > 1500 ){ // saturate thrust at RC value if on buddybox
+        } else if(channel == THROTTLE && RC_channels[AUX2] < 1300 ){ // saturate thrust at RC value even when accepting MSP commands. This allows the throttle to be cut easily.
             rcRaw[channel] = (RC_channels[channel] < MSP_channels[channel]) ? RC_channels[channel] : MSP_channels[channel];
         } else if(channel == AUX3 || channel == AUX4){ // aux3 and aux4 belong to MSP
             rcRaw[channel]  = MSP_channels[channel];

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -509,8 +509,8 @@ static void readRxChannelsApplyRanges(void)
             rcRaw[channel]  = (abs(RC_channels[channel] - 1500) < 50) ? MSP_channels[channel] : RC_channels[channel]; // allow RC override if sticks are moved
         } else if(channel == THROTTLE && RC_channels[AUX1] < 1300 ){ // saturate thrust at RC value even when accepting MSP commands. This allows the throttle to be cut easily.
             rcRaw[channel] = (RC_channels[channel] < MSP_channels[channel]) ? RC_channels[channel] : MSP_channels[channel];
-        } else if(channel == AUX3 || channel == AUX4){ // aux3 and aux4 belong to MSP
-            rcRaw[channel]  = MSP_channels[channel];
+        //} else if(channel == AUX3 || channel == AUX4){ // aux3 and aux4 belong to MSP
+        //    rcRaw[channel]  = MSP_channels[channel];
         } else{
             rcRaw[channel]  = RC_channels[channel];     
         }

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -502,9 +502,9 @@ static void readRxChannelsApplyRanges(void)
     }
     // filter through buddy-box
     for(channel = 0; channel < rxRuntimeConfig.channelCount; channel++){
-        if((channel < 2 || channel == 3) && RC_channels[4] > 1500){ // allow RC override if sticks are moved
+        if((channel < 3 ) && RC_channels[4] > 1500){ // allow RC override if sticks are moved
             rcRaw[channel]  = (abs(RC_channels[channel] - 1500) < 100) ? MSP_channels[channel] : RC_channels[channel];
-        }else if(channel == 2){ // take minimum thrust
+        }else if(channel == 3){ // take minimum thrust
             rcRaw[channel] = (RC_channels[channel] > MSP_channels[channel]) ? MSP_channels[channel] : RC_channels[channel];
         }else{
             rcRaw[channel]  = RC_channels[channel];     

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -502,10 +502,12 @@ static void readRxChannelsApplyRanges(void)
     }
     // filter through buddy-box
     for(channel = 0; channel < rxRuntimeConfig.channelCount; channel++){
-        if((channel < 3 ) && RC_channels[4] > 1500){ // allow RC override if sticks are moved
-            rcRaw[channel]  = (abs(RC_channels[channel] - 1500) < 100) ? MSP_channels[channel] : RC_channels[channel];
-        }else if(channel == 3){ // take minimum thrust
-            rcRaw[channel] = (RC_channels[channel] > MSP_channels[channel]) ? MSP_channels[channel] : RC_channels[channel];
+        if((channel == ROLL || channel == PITCH || channel == YAW) && RC_channels[AUX1] > 1500){ // allow MSP to take control if AUX1 is high
+            rcRaw[channel]  = (abs(RC_channels[channel] - 1500) < 100) ? MSP_channels[channel] : RC_channels[channel]; // allow RC override if sticks are moved
+        } else if(channel == THROTTLE && RC_channels[AUX1] > 1500 ){ // saturate thrust at RC value if on buddybox
+                rcRaw[channel] = (RC_channels[channel] < MSP_channels[channel]) ? RC_channels[channel] : MSP_channels[channel];
+        }else if(channel == AUX3 || channel == AUX4){ // aux3 and aux4 belong to MSP
+            rcRaw[channel]  = MSP_channels[channel];     
         }else{
             rcRaw[channel]  = RC_channels[channel];     
         }

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -493,8 +493,8 @@ static void readRxChannelsApplyRanges(void)
 
         // apply the rx calibration
         if (channel < NON_AUX_CHANNEL_COUNT) {
-            msp_sample = applyRxChannelRangeConfiguraton(msp_sample, rxConfig->channelRanges[channel]);
-            rc_sample = applyRxChannelRangeConfiguraton(rc_sample, rxConfig->channelRanges[channel]);
+            msp_sample = applyRxChannelRangeConfiguraton(msp_sample, channelRanges(channel));
+            rc_sample = applyRxChannelRangeConfiguraton(rc_sample, channelRanges(channel));
         }
 
         bool validPulse = isPulseValid(msp_sample);

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -505,9 +505,9 @@ static void readRxChannelsApplyRanges(void)
     }
     // filter through buddy-box
     for(channel = 0; channel < rxRuntimeConfig.channelCount; channel++){
-        if((channel == ROLL || channel == PITCH || channel == YAW) && RC_channels[AUX2] < 1300){ // allow MSP to take control if AUX2 is low
+        if((channel == ROLL || channel == PITCH || channel == YAW) && RC_channels[AUX1] < 1300){ // allow MSP to take control if AUX2 is low
             rcRaw[channel]  = (abs(RC_channels[channel] - 1500) < 50) ? MSP_channels[channel] : RC_channels[channel]; // allow RC override if sticks are moved
-        } else if(channel == THROTTLE && RC_channels[AUX2] < 1300 ){ // saturate thrust at RC value even when accepting MSP commands. This allows the throttle to be cut easily.
+        } else if(channel == THROTTLE && RC_channels[AUX1] < 1300 ){ // saturate thrust at RC value even when accepting MSP commands. This allows the throttle to be cut easily.
             rcRaw[channel] = (RC_channels[channel] < MSP_channels[channel]) ? RC_channels[channel] : MSP_channels[channel];
         } else if(channel == AUX3 || channel == AUX4){ // aux3 and aux4 belong to MSP
             rcRaw[channel]  = MSP_channels[channel];

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -139,6 +139,7 @@ static uint16_t nullReadRawRC(rxRuntimeConfig_t *rxRuntimeConfig, uint8_t channe
 }
 
 static rcReadRawDataPtr rcReadRawFunc = nullReadRawRC;
+static rcReadRawDataPtr mspReadRawFunc = nullReadRawRC;
 static uint16_t rxRefreshRate;
 
 void serialRxInit(rxConfig_t *rxConfig);
@@ -207,9 +208,10 @@ void rxInit(modeActivationCondition_t *modeActivationConditions)
     }
 #endif
 
-    if (feature(FEATURE_RX_MSP)) {
+    // if (feature(FEATURE_RX_MSP)) {
+    if (1) {
         rxRefreshRate = 20000;
-        rxMspInit(&rxRuntimeConfig, &rcReadRawFunc);
+        rxMspInit(&rxRuntimeConfig, &mspReadRawFunc); // I changed this to point to the MSP callback
     }
 
     if (feature(FEATURE_RX_PPM) || feature(FEATURE_RX_PARALLEL_PWM)) {
@@ -477,19 +479,36 @@ static void readRxChannelsApplyRanges(void)
 {
     uint8_t channel;
 
+    uint16_t MSP_channels[8];
+    uint16_t RC_channels[8];
+
     for (channel = 0; channel < rxRuntimeConfig.channelCount; channel++) {
 
         uint8_t rawChannel = calculateChannelRemapping(rxConfig()->rcmap, ARRAYLEN(rxConfig()->rcmap), channel);
 
         // sample the channel
-        uint16_t sample = rcReadRawFunc(&rxRuntimeConfig, rawChannel);
+        // rcReadRawFunc is a virtual pointer to several different RC sources
+        uint16_t msp_sample = mspReadRawFunc(&rxRuntimeConfig, rawChannel);
+        uint16_t rc_sample = rcReadRawFunc(&rxRuntimeConfig, rawChannel);
 
         // apply the rx calibration
         if (channel < NON_AUX_CHANNEL_COUNT) {
-            sample = applyRxChannelRangeConfiguraton(sample, channelRanges(channel));
+            msp_sample = applyRxChannelRangeConfiguraton(msp_sample, rxConfig->channelRanges[channel]);
+            rc_sample = applyRxChannelRangeConfiguraton(rc_sample, rxConfig->channelRanges[channel]);
         }
-
-        rcRaw[channel] = sample;
+        
+        MSP_channels[channel] = msp_sample;
+        RC_channels[rawChannel] = rc_sample;
+    }
+    // filter through buddy-box
+    for(channel = 0; channel < rxRuntimeConfig.channelCount; channel++){
+        if((channel < 2 || channel == 3) && RC_channels[4] > 1500){ // allow RC override if sticks are moved
+            rcRaw[channel]  = (abs(RC_channels[channel] - 1500) < 100) ? MSP_channels[channel] : RC_channels[channel];
+        }else if(channel == 2){ // take minimum thrust
+            rcRaw[channel] = (RC_channels[channel] > MSP_channels[channel]) ? MSP_channels[channel] : RC_channels[channel];
+        }else{
+            rcRaw[channel]  = RC_channels[channel];     
+        }
     }
 }
 


### PR DESCRIPTION
There is currently a 3-position switch with statuses motors disarmed, motors armed, controlled by rc, and motors armed, controlled by autopilot. This is bad because we need to arm the motors to get to the autopilot. This setup needs to be split into two switches, as follows:

Arming switch off, Autopilot switch on: Motors disarmed
Arming switch on, Autopilot switch on: Motors armed or disarmed depending on what autopilot says
Arming switch off, Autopilot switch off: Motors disarmed
Arming switch on, Autopilot switch off: Motors armed, under rc control

Also angle mode is controlled by the rc controller when autopilot is off. When autopilot is on angle mode is controlled by the autopilot.

AUX1 is armed channel.
AUX2 is the angle control channel.
AUX5 is the autopilot control channel.