### PR TITLE
Add .vscode to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ obj/
 patches/
 startup_stm32f10x_md_gcc.s
 .vagrant/
+.vscode/
 
 # script-generated files
 docs/Manual.pdf


### PR DESCRIPTION
The Visual Studio Code IDE creates .vscode subfolders when opening a folder. Adding these to .gitignore to keep things clean.