### PR TITLE
Wider baro support for the SPRACINGF3 target

### DIFF
--- a/src/main/target/SPRACINGF3/target.h
+++ b/src/main/target/SPRACINGF3/target.h
@@ -47,6 +47,8 @@
 
 #define BARO
 #define USE_BARO_MS5611
+#define USE_BARO_BMP085
+#define USE_BARO_BMP280
 
 #define MAG
 #define USE_MAG_AK8975


### PR DESCRIPTION
Allows the use of external baro breakout boards like:

http://www.ebay.de/itm/BMP280-Luftdruck-Temperatur-Sensor-Modul-Nachfolger-von-BMP-085-180-I2C-SPI-/252389881101?hash=item3ac39bf50d:g:2qYAAOSwIgNXszcZ

on the SPRACINGF3 target.