### PR TITLE
Add HMC5883 compass support to RMDO target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -673,6 +673,7 @@ RMDO_SRC = \
 		   drivers/accgyro_mpu.c \
 		   drivers/accgyro_mpu6050.c \
 		   drivers/barometer_bmp280.c \
+		   drivers/compass_hmc5883l.c \
 		   drivers/display_ug2864hsweg01.h \
 		   drivers/flash_m25p16.c \
 		   drivers/light_ws2811strip.c \

--- a/src/main/target/RMDO/target.h
+++ b/src/main/target/RMDO/target.h
@@ -48,6 +48,10 @@
 #define BARO
 #define USE_BARO_BMP280
 
+#define MAG
+#define USE_MAG_HMC5883
+#define MAG_HMC5883_ALIGN CW270_DEG
+
 #define USE_FLASHFS
 #define USE_FLASH_M25P16
 


### PR DESCRIPTION
Tested this on RMRC Dodo board with HolyBro M8N GPS (HMC5983L part on I2C).