### PR TITLE
Increase MSP and serial separation

### DIFF
--- a/src/main/fc/boot.c
+++ b/src/main/fc/boot.c
@@ -562,8 +562,7 @@ void init(void)
 
     flashLedsAndBeep();
 
-    mspInit();
-    mspSerialInit();
+    mspSerialInit(mspFcInit());
 
     const uint16_t pidPeriodUs = US_FROM_HZ(gyro.sampleFrequencyHz);
     pidSetTargetLooptime(pidPeriodUs * gyroConfig()->pid_process_denom);

--- a/src/main/fc/msp_server_fc.c
+++ b/src/main/fc/msp_server_fc.c
@@ -486,7 +486,7 @@ static void serializeDataflashReadReply(mspPacket_t *reply, uint32_t address, in
 #endif
 
 // return positive for ACK, negative on error, zero for no reply
-int mspServerCommandHandler(mspPacket_t *cmd, mspPacket_t *reply)
+static int mspServerCommandHandler(mspPacket_t *cmd, mspPacket_t *reply)
 {
     sbuf_t *dst = &reply->buf;
     sbuf_t *src = &cmd->buf;
@@ -1515,7 +1515,24 @@ int mspServerCommandHandler(mspPacket_t *cmd, mspPacket_t *reply)
     return 1;     // message was handled successfully
 }
 
-void mspInit(void)
+// handle received command, possibly generate reply.
+// return nonzero when reply was generated (including reported error)
+static int mspProcessCommand(mspPacket_t *command, mspPacket_t *reply)
+{
+    // initialize reply by default
+    reply->cmd = command->cmd;
+
+    int status = mspServerCommandHandler(command, reply);
+    reply->result = status;
+
+    return status;
+}
+
+/*
+ * Return a pointer to the process command function
+ */
+mspProcessCommandFnPtr mspFcInit(void)
 {
     initActiveBoxIds();
+    return mspProcessCommand;
 }

--- a/src/main/fc/msp_server_fc.h
+++ b/src/main/fc/msp_server_fc.h
@@ -16,3 +16,7 @@
  */
 
 #pragma once
+
+#include "msp/msp.h"
+
+mspProcessCommandFnPtr mspFcInit(void);

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -38,19 +38,6 @@
 
 #include "msp/msp.h"
 
-// handle received command, possibly generate reply.
-// return nonzero when reply was generated (including reported error)
-int mspProcessCommand(mspPacket_t *command, mspPacket_t *reply)
-{
-    // initialize reply by default
-    reply->cmd = command->cmd;
-
-    int status = mspServerCommandHandler(command, reply);
-    reply->result = status;
-
-    return status;
-}
-
 #ifdef USE_MSP_CLIENT
 void mspProcessReply(mspPacket_t *reply)
 {

--- a/src/main/msp/msp.h
+++ b/src/main/msp/msp.h
@@ -23,15 +23,7 @@ typedef struct mspPacket_s {
     int16_t result;
 } mspPacket_t;
 
-void mspInit(void);
-
-//
-// server
-//
-int mspProcessCommand(mspPacket_t *command, mspPacket_t *reply);
-
-// return positive for ACK, negative on error, zero for no reply
-int mspServerCommandHandler(mspPacket_t *cmd, mspPacket_t *reply);
+typedef int (*mspProcessCommandFnPtr)(mspPacket_t *command, mspPacket_t *reply);
 
 //
 // client

--- a/src/main/msp/msp_serial.c
+++ b/src/main/msp/msp_serial.c
@@ -41,7 +41,7 @@
 #include "msp/msp.h"
 #include "msp/msp_serial.h"
 
-static mspProcessCommandFnPtr mspProcessCommandFn;
+STATIC_UNIT_TESTED mspProcessCommandFnPtr mspProcessCommandFn;
 mspPostProcessFuncPtr mspPostProcessFn = NULL;
 
 mspPort_t mspPorts[MAX_MSP_PORT_COUNT];

--- a/src/main/msp/msp_serial.h
+++ b/src/main/msp/msp_serial.h
@@ -96,7 +96,7 @@ typedef void (*mspPostProcessFuncPtr)(mspPort_t *); // msp post process function
 
 extern mspPostProcessFuncPtr mspPostProcessFn;
 
-void mspSerialInit(void);
+void mspSerialInit(mspProcessCommandFnPtr mspProcessCommandFn);
 void mspSerialProcess();
 void mspSerialAllocatePorts(void);
 void mspSerialReleasePortIfAllocated(serialPort_t *serialPort);

--- a/src/main/osd/boot.c
+++ b/src/main/osd/boot.c
@@ -188,8 +188,7 @@ void init(void)
 
     flashLed();
 
-    mspInit();
-    mspSerialInit();
+    mspSerialInit(mspOsdInit());
 
 #ifdef TRANSPONDER
     if (feature(FEATURE_TRANSPONDER)) {

--- a/src/main/osd/msp_server_osd.c
+++ b/src/main/osd/msp_server_osd.c
@@ -416,6 +416,7 @@ int mspServerCommandHandler(mspPacket_t *cmd, mspPacket_t *reply)
     return 1;     // message was handled successfully
 }
 
-void mspInit(void)
+mspProcessCommandFnPtr mspOsdInit(void)
 {
+    return mspServerCommandHandler;
 }

--- a/src/main/osd/msp_server_osd.h
+++ b/src/main/osd/msp_server_osd.h
@@ -17,3 +17,6 @@
 
 #pragma once
 
+#include "msp/msp.h"
+
+mspProcessCommandFnPtr mspOsdInit(void);

--- a/src/test/unit/msp_serial_unittest.cc
+++ b/src/test/unit/msp_serial_unittest.cc
@@ -59,6 +59,7 @@ extern "C" {
 extern "C" {
     void mspSerialProcessReceivedCommand(mspPort_t *msp);
     extern mspPort_t mspPorts[];
+    extern mspProcessCommandFnPtr mspProcessCommandFn;
 
     PG_REGISTER(serialConfig_t, serialConfig, PG_SERIAL_CONFIG, 0);
 }
@@ -154,7 +155,7 @@ uint8_t msp_echo_data[]="PING\0PONG";
 uint8_t msp_request_data[]={0xbe, 0xef};
 uint8_t msp_reply_data[]={0x55,0xaa};
 
-int mspServerCommandHandler(mspPacket_t *command, mspPacket_t *reply)
+static int mspServerCommandHandler(mspPacket_t *command, mspPacket_t *reply)
 {
     sbuf_t *src = &command->buf;
     sbuf_t *dst = &reply->buf;
@@ -207,6 +208,7 @@ static uint8_t csumData(uint8_t csum, uint8_t* data, int len)
 
 TEST_F(SerialMspUnitTest, Test_MspSerialOutFraming)
 {
+    mspProcessCommandFn = mspServerCommandHandler;
     mspPort->cmdMSP = MSP_TEST_REPLY;
     mspPort->dataSize = 0;
     mspSerialProcessReceivedCommand(mspPort);


### PR DESCRIPTION
Increases separation between MSP and serial code by avoiding hardcoded `mspProcessCommand` in `msp_serial.c`. Instead a function pointer is passed into `mspSerialInit`.

Only done for the `MSP_SERVER` side, but a similar thing could be done for the `MSP_CLIENT`.

@hydra - what do you think?
