### PR TITLE
Lcov coverage report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ sudo: false
 addons:
   apt:
     packages:
+      - lcov
       - build-essential
       - git
       - libc6-i386
@@ -46,11 +47,18 @@ language: cpp
 compiler: clang
 
 before_install:
+  - pip install --user cpp-coveralls
+  - gem install coveralls-lcov
   - curl --retry 10 --retry-max-time 120 -L "https://launchpad.net/gcc-arm-embedded/5.0/5-2016-q2-update/+download/gcc-arm-none-eabi-5_4-2016q2-20160622-linux.tar.bz2" | tar xfj -
 
 install:
   - export PATH=$PATH:$PWD/gcc-arm-none-eabi-5_4-2016q2/bin
-
+after_success:
+  - cd ${TRAVIS_BUILD_DIR}
+  - lcov --directory . -b src/test --capture --output-file coverage.info # capture coverage info
+  - lcov --remove coverage.info 'lib/test/*' 'src/test/*' '/usr/*' --output-file coverage.info # filter out system and test code
+  - lcov --list coverage.info # debug before upload
+  - coveralls-lcov coverage.info # uploads to coveralls
 before_script: arm-none-eabi-gcc --version
 script: ./.travis.sh
 

--- a/Makefile
+++ b/Makefile
@@ -1027,14 +1027,19 @@ help: Makefile
 	@echo ""
 	@sed -n 's/^## //p' $<
 
+LCOV := $(shell command lcov -v 2> /dev/null)
+
 ## test        : run the cleanflight test suite
 ## junittest   : run the cleanflight test suite, producing Junit XML result files.
 test junittest:
 	cd src/test && $(MAKE) $@
-	lcov --directory . -b src/test --capture --output-file coverage.info
-	lcov --remove coverage.info 'lib/test/*' 'src/test/*' '/usr/*' --output-file coverage.info
-	lcov --list coverage.info
-
+ifndef LCOV
+	$(info "install lcov to get a table with code coverage after tests")
+else
+	-lcov --directory . -b src/test --capture --output-file coverage.info
+	-lcov --remove coverage.info 'lib/test/*' 'src/test/*' '/usr/*' --output-file coverage.info
+	-lcov --list coverage.info
+endif
 
 # rebuild everything when makefile changes
 $(TARGET_OBJS) : Makefile

--- a/Makefile
+++ b/Makefile
@@ -1031,6 +1031,10 @@ help: Makefile
 ## junittest   : run the cleanflight test suite, producing Junit XML result files.
 test junittest:
 	cd src/test && $(MAKE) $@
+	lcov --directory . -b src/test --capture --output-file coverage.info
+	lcov --remove coverage.info 'lib/test/*' 'src/test/*' '/usr/*' --output-file coverage.info
+	lcov --list coverage.info
+
 
 # rebuild everything when makefile changes
 $(TARGET_OBJS) : Makefile

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This fork differs from baseflight in that it attempts to use modern software dev
 
 The MultiWii software, from which baseflight originated, violates many good software development best-practices. Hopefully this fork will go some way to address them. If you see any bad code in this fork please immediately raise an issue so it can be fixed, or better yet submit a pull request.
 
+[![Coverage Status](https://coveralls.io/repos/github/unitware/cleanflight/badge.svg?branch=master)](https://coveralls.io/github/unitware/cleanflight?branch=master)
+
 ## Additional Features
 
 Cleanflight also has additional features not found in baseflight.

--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ This fork differs from baseflight in that it attempts to use modern software dev
 
 The MultiWii software, from which baseflight originated, violates many good software development best-practices. Hopefully this fork will go some way to address them. If you see any bad code in this fork please immediately raise an issue so it can be fixed, or better yet submit a pull request.
 
-[![Coverage Status](https://coveralls.io/repos/github/unitware/cleanflight/badge.svg?branch=master)](https://coveralls.io/github/unitware/cleanflight?branch=master)
-
 ## Additional Features
 
 Cleanflight also has additional features not found in baseflight.
@@ -112,6 +110,10 @@ Please refer to the development section in the [docs/development](https://github
 TravisCI is used to run automatic builds: https://travis-ci.org/cleanflight/cleanflight
 
 [![Build Status](https://travis-ci.org/cleanflight/cleanflight.svg?branch=master)](https://travis-ci.org/cleanflight/cleanflight)
+
+Coveralls is used to monitor code coverage: https://coveralls.io/github/cleanflight/cleanflight
+
+[![Coverage Status](https://coveralls.io/repos/github/unitware/cleanflight/badge.svg?branch=master)](https://coveralls.io/github/unitware/cleanflight?branch=master)
 
 ## Cleanflight Releases
 https://github.com/cleanflight/cleanflight/releases


### PR DESCRIPTION
Merged some stuff from https://github.com/mkschreder/ninjaflight after reading the issue https://github.com/cleanflight/cleanflight/issues/2476

This pull request adds coverage reports as a list in the build output if lcov tool is installed 

It also publishes data to the server at https://coveralls.io which is free for open source projects.
(Example page from my account: https://coveralls.io/jobs/19911189)

Credits are due to @mkschreder

Stuff to do by the maintainer when merging:
 - Create account at coveralls.io and enable the cleanflight repository (it takes like five seconds)
 - Update the link for the status gadget in the end of README.md (https://github.com/unitware/cleanflight/blob/lcov-coverage-report/README.md)