### PR TITLE
smartport: added MSP/SPORT bridge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,7 +225,7 @@ endif
 # Use bidirectional feature of F3 processor for smartport, for F1 targets always use two pins to allow external inverter.
 # This behavior will likely need modifying if softserial is updated to suport bidirectional communication on F3 targets. 
 ifeq ($(TARGET),$(filter $(TARGET),$(F3_TARGETS)))
-TARGET_FLAGS := $(TARGET_FLAGS) -DUSE_SMARTPORT_ONEWIRE
+TARGET_FLAGS := $(TARGET_FLAGS) -DUSE_SMARTPORT_ONEWIRE -DUSE_SMARTPORT_MSP_BRIDGE
 endif
 
 # OSDs

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -13,6 +13,11 @@
 #include "common/axis.h"
 #include "common/maths.h"
 
+#ifdef USE_SMARTPORT_MSP_BRIDGE
+#include "common/streambuf.h"
+#include "common/utils.h"
+#endif
+
 #include "config/parameter_group.h"
 #include "config/feature.h"
 
@@ -48,6 +53,9 @@
 #include "fc/runtime_config.h"
 #include "fc/config.h"
 
+#ifdef USE_SMARTPORT_MSP_BRIDGE
+#include "msp/msp.h"
+#endif
 
 enum
 {
@@ -60,7 +68,16 @@ enum
 enum
 {
     FSSP_START_STOP = 0x7E,
+
+    FSSP_DLE        = 0x7D,
+    FSSP_DLE_XOR    = 0x20,
+
     FSSP_DATA_FRAME = 0x10,
+
+#ifdef USE_SMARTPORT_MSP_BRIDGE
+    FSSP_MSPC_FRAME = 0x30, // MSP client frame
+    FSSP_MSPS_FRAME = 0x32, // MSP server frame
+#endif
 
     // ID of sensor. Must be something that is polled by FrSky RX
     FSSP_SENSOR_ID1 = 0x1B,
@@ -142,33 +159,135 @@ static uint8_t smartPortHasRequest = 0;
 static uint8_t smartPortIdCnt = 0;
 static uint32_t smartPortLastRequestTime = 0;
 
+typedef struct smartPortFrame_s {
+    uint8_t  sensorId;
+    uint8_t  frameId;
+    uint16_t valueId;
+    uint32_t data;
+    uint8_t  crc;
+} __attribute__((packed)) smartPortFrame_t;
+
+#define SMARTPORT_FRAME_SIZE  sizeof(smartPortFrame_t)
+#define SMARTPORT_TX_BUF_SIZE 256
+
+#define SMARTPORT_PAYLOAD_OFFSET offsetof(smartPortFrame_t, valueId)
+#define SMARTPORT_PAYLOAD_SIZE   (SMARTPORT_FRAME_SIZE - SMARTPORT_PAYLOAD_OFFSET - 1)
+
+#ifdef USE_SMARTPORT_MSP_BRIDGE
+
+static smartPortFrame_t smartPortRxBuffer;
+static uint8_t smartPortRxBytes = 0;
+static bool smartPortFrameReceived = false;
+
+#define SMARTPORT_MSP_VERSION    1
+#define SMARTPORT_MSP_VER_SHIFT  5
+#define SMARTPORT_MSP_VER_MASK   (0x7 << SMARTPORT_MSP_VER_SHIFT)
+#define SMARTPORT_MSP_VERSION_S  (SMARTPORT_MSP_VERSION << SMARTPORT_MSP_VER_SHIFT)
+
+#define SMARTPORT_MSP_ERROR_FLAG (1 << 5)
+#define SMARTPORT_MSP_START_FLAG (1 << 4)
+#define SMARTPORT_MSP_SEQ_MASK   0x0F
+
+#define SMARTPORT_MSP_RX_BUF_SIZE 64
+
+static uint8_t smartPortMspTxBuffer[SMARTPORT_TX_BUF_SIZE];
+static mspPacket_t smartPortMspReply;
+static bool smartPortMspReplyPending = false;
+
+#define SMARTPORT_MSP_RES_ERROR (-10)
+
+enum {
+    SMARTPORT_MSP_VER_MISMATCH=0,
+    SMARTPORT_MSP_CRC_ERROR=1,
+    SMARTPORT_MSP_ERROR=2
+};
+#endif
+
 static void smartPortDataReceive(uint16_t c)
 {
+    static bool skipUntilStart = true;
+#ifdef USE_SMARTPORT_MSP_BRIDGE
+    static bool byteStuffing = false;
+    static uint16_t checksum = 0;
+#endif
+
     uint32_t now = millis();
 
-    // look for a valid request sequence
-    static uint8_t lastChar;
-    if (lastChar == FSSP_START_STOP) {
-        smartPortState = SPSTATE_WORKING;
-        if (c == FSSP_SENSOR_ID1 && (serialRxBytesWaiting(smartPortSerialPort) == 0)) {
+    if (c == FSSP_START_STOP) {
+#ifdef USE_SMARTPORT_MSP_BRIDGE
+        smartPortRxBytes = 0;
+#endif
+        smartPortHasRequest = 0;
+        skipUntilStart = false;
+        return;
+    } else if (skipUntilStart) {
+        return;
+    }
+
+#ifndef USE_SMARTPORT_MSP_BRIDGE
+    if ((c == FSSP_SENSOR_ID1) && (serialRxBytesWaiting(smartPortSerialPort) == 0)) {
+
+        // our slot is starting...
+        smartPortLastRequestTime = now;
+        smartPortHasRequest = 1;    
+    }
+    skipUntilStart = true;    
+#else
+
+    uint8_t* rxBuffer = (uint8_t*)&smartPortRxBuffer;
+    if (smartPortRxBytes == 0) {
+        if ((c == FSSP_SENSOR_ID1) && (serialRxBytesWaiting(smartPortSerialPort) == 0)) {
+
+            // our slot is starting...
             smartPortLastRequestTime = now;
             smartPortHasRequest = 1;
-            // we only responde to these IDs
-            // the X4R-SB does send other IDs, we ignore them, but take note of the time
+
+        } else if (c == FSSP_SENSOR_ID2) {
+            rxBuffer[smartPortRxBytes++] = c;
+            checksum = 0;
+        }
+        else {
+            skipUntilStart = true;
         }
     }
-    lastChar = c;
+    else {
+
+        if (c == FSSP_DLE) {
+            byteStuffing = true;
+            return;
+        }
+
+        if (byteStuffing) {
+            c ^= FSSP_DLE_XOR;
+            byteStuffing = false;
+        }
+
+        rxBuffer[smartPortRxBytes++] = c;
+
+        if(smartPortRxBytes == SMARTPORT_FRAME_SIZE) {
+            if (c == (0xFF - checksum)) {
+                smartPortFrameReceived = true;
+            }
+            skipUntilStart = true;
+        } else if (smartPortRxBytes < SMARTPORT_FRAME_SIZE) {
+            checksum += c;
+            checksum += checksum >> 8;
+            checksum &= 0x00FF;
+        }
+    }
+#endif
 }
 
 static void smartPortSendByte(uint8_t c, uint16_t *crcp)
 {
     // smart port escape sequence
-    if (c == 0x7D || c == 0x7E) {
-        serialWrite(smartPortSerialPort, 0x7D);
-        c ^= 0x20;
+    if (c == FSSP_DLE || c == FSSP_START_STOP) {
+        serialWrite(smartPortSerialPort, FSSP_DLE);
+        serialWrite(smartPortSerialPort, c ^ FSSP_DLE_XOR);
     }
-
-    serialWrite(smartPortSerialPort, c);
+    else {
+        serialWrite(smartPortSerialPort, c);
+    }
 
     if (crcp == NULL)
         return;
@@ -180,19 +299,28 @@ static void smartPortSendByte(uint8_t c, uint16_t *crcp)
     *crcp = crc;
 }
 
-static void smartPortSendPackage(uint16_t id, uint32_t val)
+static void smartPortSendPackageEx(uint8_t frameId, uint8_t* data)
 {
     uint16_t crc = 0;
-    smartPortSendByte(FSSP_DATA_FRAME, &crc);
-    uint8_t *u8p = (uint8_t*)&id;
-    smartPortSendByte(u8p[0], &crc);
-    smartPortSendByte(u8p[1], &crc);
-    u8p = (uint8_t*)&val;
-    smartPortSendByte(u8p[0], &crc);
-    smartPortSendByte(u8p[1], &crc);
-    smartPortSendByte(u8p[2], &crc);
-    smartPortSendByte(u8p[3], &crc);
+    smartPortSendByte(frameId, &crc);
+    for(unsigned i = 0; i < SMARTPORT_PAYLOAD_SIZE; i++) {
+        smartPortSendByte(*data++, &crc);
+    }
     smartPortSendByte(0xFF - (uint8_t)crc, NULL);
+}
+
+static void smartPortSendPackage(uint16_t id, uint32_t val)
+{
+    uint8_t payload[SMARTPORT_PAYLOAD_SIZE];
+    uint8_t *dst = payload;
+    *dst++ = id & 0xFF;
+    *dst++ = id >> 8;
+    *dst++ = val & 0xFF;
+    *dst++ = (val >> 8) & 0xFF;
+    *dst++ = (val >> 16) & 0xFF;
+    *dst++ = (val >> 24) & 0xFF;
+
+    smartPortSendPackageEx(FSSP_DATA_FRAME,payload);
 }
 
 void initSmartPortTelemetry(void)
@@ -263,6 +391,201 @@ bool checkSmartPortTelemetryState(void)
     return true;
 }
 
+#ifdef USE_SMARTPORT_MSP_BRIDGE
+
+static void initSmartPortMspReply(int16_t cmd)
+{
+    smartPortMspReply.buf.ptr    = smartPortMspTxBuffer;
+    smartPortMspReply.buf.end    = ARRAYEND(smartPortMspTxBuffer);
+
+    smartPortMspReply.cmd    = cmd;
+    smartPortMspReply.result = 0;
+}
+
+static void processMspPacket(mspPacket_t* packet)
+{
+    initSmartPortMspReply(0);
+    smartPortMspReply.cmd = packet->cmd;
+
+    if (mspServerCommandHandler(packet, &smartPortMspReply) < 0) {
+        sbufWriteU8(&smartPortMspReply.buf, SMARTPORT_MSP_ERROR);
+        smartPortMspReply.result = -1;
+    }
+
+    // change streambuf direction
+    sbufSwitchToReader(&smartPortMspReply.buf, smartPortMspTxBuffer);
+    smartPortMspReplyPending = true;
+}
+
+/**
+ * Request frame format:
+ * - Header: 1 byte
+ *   - Reserved: 2 bits (future use)
+ *   - Error-flag: 1 bit
+ *   - Start-flag: 1 bit
+ *   - CSeq: 4 bits
+ *
+ * - MSP payload:
+ *   - if Error-flag == 0:
+ *     - size: 1 byte
+ *     - payload
+ *     - CRC (request type included)
+ *   - if Error-flag == 1:
+ *     - size: 1 byte (== 1)
+ *     - error: 1 Byte
+ *       - 0: Version mismatch (type=0)
+ *       - 1: Sequence number error
+ *       - 2: MSP error
+ *     - CRC (request type included)
+ */
+bool smartPortSendMspReply()
+{
+    static uint8_t checksum = 0;
+    static uint8_t seq = 0;
+
+    uint8_t packet[SMARTPORT_PAYLOAD_SIZE];
+    uint8_t* p = packet;
+    uint8_t* end = p + SMARTPORT_PAYLOAD_SIZE;
+
+    sbuf_t* txBuf = &smartPortMspReply.buf;
+
+    // detect first reply packet
+    if (txBuf->ptr == smartPortMspTxBuffer) {
+
+        // header
+        uint8_t head = SMARTPORT_MSP_START_FLAG | (seq++ & SMARTPORT_MSP_SEQ_MASK);
+        if (smartPortMspReply.result < 0) {
+            head |= SMARTPORT_MSP_ERROR_FLAG;
+        }
+        *p++ = head;
+
+        uint8_t size = sbufBytesRemaining(txBuf);
+        *p++ = size;
+
+        checksum = size ^ smartPortMspReply.cmd;
+    }
+    else {
+        // header
+        *p++ = (seq++ & SMARTPORT_MSP_SEQ_MASK);
+    }
+
+    while ((p < end) && (sbufBytesRemaining(txBuf) > 0)) {
+        *p = sbufReadU8(txBuf);
+        checksum ^= *p++; // MSP checksum
+    }
+
+    // to be continued...
+    if (p == end) {
+        smartPortSendPackageEx(FSSP_MSPS_FRAME,packet);
+        return true;
+    }
+
+    // nothing left in txBuf,
+    // append the MSP checksum
+    *p++ = checksum;
+
+    // pad with zeros
+    while (p < end)
+        *p++ = 0;
+
+    smartPortSendPackageEx(FSSP_MSPS_FRAME,packet);
+    return false;
+}
+
+void smartPortSendErrorReply(uint8_t error, int16_t cmd)
+{
+    initSmartPortMspReply(cmd);
+    sbufWriteU8(&smartPortMspReply.buf,error);
+    smartPortMspReply.result = SMARTPORT_MSP_RES_ERROR;
+
+    sbufSwitchToReader(&smartPortMspReply.buf, smartPortMspTxBuffer);
+    smartPortMspReplyPending = true;
+}
+
+/**
+ * Request frame format:
+ * - Header: 1 byte
+ *   - Version: 3 bits
+ *   - Start-flag: 1 bit
+ *   - CSeq: 4 bits
+ *
+ * - MSP payload:
+ *   - Size: 1 Byte
+ *   - Type: 1 Byte
+ *   - payload...
+ *   - CRC
+ */
+void handleSmartPortMspFrame(smartPortFrame_t* sp_frame)
+{
+    static uint8_t mspBuffer[SMARTPORT_MSP_RX_BUF_SIZE];
+    static uint8_t mspStarted = 0;
+    static uint8_t lastSeq = 0;
+    static uint8_t checksum = 0;
+    static mspPacket_t cmd;
+
+    // re-assemble MSP frame & forward to MSP port when complete
+    uint8_t* p = ((uint8_t*)sp_frame) + SMARTPORT_PAYLOAD_OFFSET;
+    uint8_t* end = p + SMARTPORT_PAYLOAD_SIZE;
+
+    uint8_t head = *p++;
+    uint8_t seq = head & SMARTPORT_MSP_SEQ_MASK;
+    uint8_t version = (head & SMARTPORT_MSP_VER_MASK) >> SMARTPORT_MSP_VER_SHIFT;
+
+    if (version != SMARTPORT_MSP_VERSION) {
+        mspStarted = 0;
+        smartPortSendErrorReply(SMARTPORT_MSP_VER_MISMATCH,0);
+        return;
+    }
+
+    // check start-flag
+    if (head & SMARTPORT_MSP_START_FLAG) {
+
+        //TODO: if (p_size > SMARTPORT_MSP_RX_BUF_SIZE) error!
+        uint8_t p_size = *p++;
+        cmd.cmd = *p++;
+        cmd.result = 0;
+
+        cmd.buf.ptr = mspBuffer;
+        cmd.buf.end = mspBuffer + p_size;
+
+        checksum = p_size ^ cmd.cmd;
+        mspStarted = 1;
+    } else if (!mspStarted) {
+        // no start packet yet, throw this one away
+        return;
+    } else if (((lastSeq + 1) & SMARTPORT_MSP_SEQ_MASK) != seq) {
+        // packet loss detected!
+        mspStarted = 0;
+        return;
+    }
+
+    // copy payload bytes
+    while ((p < end) && sbufBytesRemaining(&cmd.buf)) {
+        checksum ^= *p;
+        sbufWriteU8(&cmd.buf,*p++);
+    }
+
+    // reached end of smart port frame
+    if (p == end) {
+        lastSeq = seq;
+        return;
+    }
+
+    // last byte must be the checksum
+    if (checksum != *p) {
+        mspStarted = 0;
+        smartPortSendErrorReply(SMARTPORT_MSP_CRC_ERROR,cmd.cmd);
+        return;
+    }
+
+    // end of MSP packet reached
+    mspStarted = 0;
+    sbufSwitchToReader(&cmd.buf,mspBuffer);
+
+    processMspPacket(&cmd);
+}
+#endif
+
 void handleSmartPortTelemetry(void)
 {
     uint32_t smartPortLastServiceTime = millis();
@@ -288,12 +611,33 @@ void handleSmartPortTelemetry(void)
         return;
     }
 
+#ifdef USE_SMARTPORT_MSP_BRIDGE
+    if(smartPortFrameReceived) {
+        smartPortFrameReceived = false;
+        // do not check the physical ID here again
+        // unless we start receiving other sensors' packets
+        if(smartPortRxBuffer.frameId == FSSP_MSPC_FRAME) {
+
+            // Pass only the payload: skip sensorId & frameId
+            handleSmartPortMspFrame(&smartPortRxBuffer);
+        }
+    }
+#endif
+
     while (smartPortHasRequest) {
         // Ensure we won't get stuck in the loop if there happens to be nothing available to send in a timely manner - dump the slot if we loop in there for too long.
         if ((millis() - smartPortLastServiceTime) > SMARTPORT_SERVICE_TIMEOUT_MS) {
             smartPortHasRequest = 0;
             return;
         }
+
+#ifdef USE_SMARTPORT_MSP_BRIDGE
+        if(smartPortMspReplyPending) {
+            smartPortMspReplyPending = smartPortSendMspReply();
+            smartPortHasRequest = 0;
+            return;
+        }
+#endif
 
         // we can send back any data we want, our table keeps track of the order and frequency of each data type we send
         uint16_t id = frSkyDataIdTable[smartPortIdCnt];

--- a/support/opentx/CFSetup.lua
+++ b/support/opentx/CFSetup.lua
@@ -1,0 +1,622 @@
+--
+-- PID configuration script using MSP/SPORT
+--
+-- Buttons:
+--  - 'menu' short: switch to the next page.
+--  - 'menu' long: menu (save, reload).
+--  - 'enter' short: edit value.
+--  - '+'/'-': navigation, increase / decrease value
+--  - 'exit' long: exit.
+--
+
+--
+-- MSP/SPORT code
+--
+
+-- Protocol version
+SPORT_MSP_VERSION = bit32.lshift(1,5)
+
+SPORT_MSP_STARTFLAG = bit32.lshift(1,4)
+
+-- Sensor ID used by the local LUA script
+LOCAL_SENSOR_ID  = 0x0D
+
+-- Sensor ID used by the MSP server (BF, CF, MW, etc...)
+REMOTE_SENSOR_ID = 0x1B
+
+REQUEST_FRAME_ID = 0x30
+REPLY_FRAME_ID   = 0x32
+
+-- Sequence number for next MSP/SPORT packet
+local sportMspSeq = 0
+local sportMspRemoteSeq = 0
+
+local mspRxBuf = {}
+local mspRxIdx = 1
+local mspRxCRC = 0
+local mspStarted = false
+local mspLastReq = 0
+
+-- Stats
+mspRequestsSent    = 0
+mspRepliesReceived = 0
+mspPkRxed = 0
+mspErrorPk = 0
+mspStartPk = 0
+mspOutOfOrder = 0
+mspCRCErrors = 0
+
+local function mspResetStats()
+   mspRequestsSent    = 0
+   mspRepliesReceived = 0
+   mspPkRxed = 0
+   mspErrorPk = 0
+   mspStartPk = 0
+   mspOutOfOrderPk = 0
+   mspCRCErrors = 0
+end
+
+local mspTxBuf = {}
+local mspTxIdx = 1
+local mspTxCRC = 0
+
+local mspTxPk = 0
+
+local function mspSendSport(payload)
+
+   local dataId = 0
+   dataId = payload[1] + bit32.lshift(payload[2],8)
+
+   local value = 0
+   value = payload[3] + bit32.lshift(payload[4],8)
+      + bit32.lshift(payload[5],16) + bit32.lshift(payload[6],24)
+
+   local ret = sportTelemetryPush(LOCAL_SENSOR_ID, REQUEST_FRAME_ID, dataId, value)
+   if ret then
+      mspTxPk = mspTxPk + 1
+   end
+end
+
+local function mspProcessTxQ()
+
+   if (#(mspTxBuf) == 0) then
+      return false
+   end
+
+   if not sportTelemetryPush() then
+      return true
+   end
+
+   local payload = {}
+   payload[1] = sportMspSeq + SPORT_MSP_VERSION
+   sportMspSeq = bit32.band(sportMspSeq + 1, 0x0F)
+
+   if mspTxIdx == 1 then
+      -- start flag
+      payload[1] = payload[1] + SPORT_MSP_STARTFLAG
+   end
+
+   local i = 2
+   while (i <= 6) do
+      payload[i] = mspTxBuf[mspTxIdx]
+      mspTxIdx = mspTxIdx + 1
+      mspTxCRC = bit32.bxor(mspTxCRC,payload[i])
+      i = i + 1
+      if mspTxIdx > #(mspTxBuf) then
+         break
+      end
+   end
+
+   if i <= 6 then
+      payload[i] = mspTxCRC
+      i = i + 1
+
+      -- zero fill
+      while i <= 6 do
+         payload[i] = 0
+         i = i + 1
+      end
+
+      mspSendSport(payload)
+      
+      mspTxBuf = {}
+      mspTxIdx = 1
+      mspTxCRC = 0
+      
+      return false
+   end
+      
+   mspSendSport(payload)
+   return true
+end
+
+local function mspSendRequest(cmd,payload)
+
+   -- busy
+   if #(mspTxBuf) ~= 0 then
+      return nil
+   end
+
+   mspTxBuf[1] = #(payload)
+   mspTxBuf[2] = bit32.band(cmd,0xFF)  -- MSP command
+
+   for i=1,#(payload) do
+      mspTxBuf[i+2] = payload[i]
+   end
+   
+   mspLastReq = cmd
+   mspRequestsSent = mspRequestsSent + 1
+   return mspProcessTxQ()
+end
+
+local function mspReceivedReply(payload)
+
+   mspPkRxed = mspPkRxed + 1
+   
+   local idx      = 1
+   local head     = payload[idx]
+   local err_flag = (bit32.band(head,0x20) ~= 0)
+   idx = idx + 1
+
+   if err_flag then
+      -- error flag set
+      mspStarted = false
+
+      mspErrorPk = mspErrorPk + 1
+
+      -- return error
+      -- CRC checking missing
+
+      --return payload[idx]
+      return nil
+   end
+   
+   local start = (bit32.band(head,0x10) ~= 0)
+   local seq   = bit32.band(head,0x0F)
+
+   if start then
+      -- start flag set
+      mspRxIdx = 1
+      mspRxBuf = {}
+
+      mspRxSize = payload[idx]
+      mspRxCRC  = bit32.bxor(mspRxSize,mspLastReq)
+      idx = idx + 1
+      mspStarted = true
+      
+      mspStartPk = mspStartPk + 1
+
+   elseif not mspStarted then
+      mspOutOfOrder = mspOutOfOrder + 1
+      return nil
+
+   elseif bit32.band(sportMspRemoteSeq + 1, 0x0F) ~= seq then
+      mspOutOfOrder = mspOutOfOrder + 1
+      mspStarted = false
+      return nil
+   end
+
+   while (idx <= 6) and (mspRxIdx <= mspRxSize) do
+      mspRxBuf[mspRxIdx] = payload[idx]
+      mspRxCRC = bit32.bxor(mspRxCRC,payload[idx])
+      mspRxIdx = mspRxIdx + 1
+      idx = idx + 1
+   end
+
+   if idx > 6 then
+      sportMspRemoteSeq = seq
+      return true
+   end
+
+   -- check CRC
+   if mspRxCRC ~= payload[idx] then
+      mspStarted = false
+      mspCRCErrors = mspCRCErrors + 1
+      return nil
+   end
+
+   mspRepliesReceived = mspRepliesReceived + 1
+   mspStarted = false
+   return mspRxBuf
+end
+
+local function mspPollReply()
+   while true do
+      local sensorId, frameId, dataId, value = sportTelemetryPop()
+      if sensorId == REMOTE_SENSOR_ID and frameId == REPLY_FRAME_ID then
+
+         local payload = {}
+         payload[1] = bit32.band(dataId,0xFF)
+         dataId = bit32.rshift(dataId,8)
+         payload[2] = bit32.band(dataId,0xFF)
+
+         payload[3] = bit32.band(value,0xFF)
+         value = bit32.rshift(value,8)
+         payload[4] = bit32.band(value,0xFF)
+         value = bit32.rshift(value,8)
+         payload[5] = bit32.band(value,0xFF)
+         value = bit32.rshift(value,8)
+         payload[6] = bit32.band(value,0xFF)
+
+         local ret = mspReceivedReply(payload)
+         if type(ret) == "table" then
+            return mspLastReq,ret
+         end
+      else
+         break
+      end
+   end
+
+   return nil
+end
+
+--
+-- End of MSP/SPORT code
+--
+
+-- getter
+local MSP_RC_TUNING     = 111
+local MSP_PID           = 112
+
+-- setter
+local MSP_SET_PID       = 202
+local MSP_SET_RC_TUNING = 204
+
+local MSP_EEPROM_WRITE = 250
+
+local REQ_TIMEOUT = 80 -- 800ms request timeout
+
+--local PAGE_REFRESH = 1
+local PAGE_DISPLAY = 2
+local EDITING      = 3
+local PAGE_SAVING  = 4
+local MENU_DISP    = 5
+
+local gState = PAGE_DISPLAY
+
+local SetupPages = {
+   {
+      title = "PIDs",
+      text = {
+         { t = "Roll",  x = 21,  y = 14 },
+         { t = "Pitch", x = 75,  y = 14 },
+         { t = "Yaw",   x = 129, y = 14 },
+      },
+      fields = {
+         -- ROLL
+         { t = "P", x = 25,  y = 24, i=1 },
+         { t = "I", x = 25,  y = 34, i=2 },
+         { t = "D", x = 25,  y = 44, i=3 },
+         -- PITCH
+         { t = "P", x = 80,  y = 24, i=4 },
+         { t = "I", x = 80,  y = 34, i=5 },
+         { t = "D", x = 80,  y = 44, i=6 },
+         -- YAW
+         { t = "P", x = 135, y = 24, i=7 },
+         { t = "I", x = 135, y = 34, i=8 },
+         { t = "D", x = 135, y = 44, i=9 },
+      },
+      read  = MSP_PID,
+      write = MSP_SET_PID,
+   },
+   {
+      title = "Rates",
+      text = {
+         { t = "Rates",    x = 5,  y = 14 },
+         { t = "RC-rates", x = 80, y = 14 }
+      },
+      fields = {
+         -- Super Rate
+         { t = "Roll",  x = 10,  y = 24, sp = 40, i=3 },
+         { t = "Pitch", x = 10,  y = 34, sp = 40, i=4 },
+
+         -- Roll + Pitch
+         { t = "Rate",  x = 75,  y = 29, sp = 30, i=1 },
+         { t = "Expo",  x = 135, y = 29, sp = 30, i=2 },
+
+         -- Yaw
+         { t = "Yaw",   x = 10,  y = 48, sp = 40, i=5 },
+         { t = "Rate",  x = 75,  y = 48, sp = 30, i=12 },
+         { t = "Expo",  x = 135, y = 48, sp = 30, i=11 },
+      },
+      read  = MSP_RC_TUNING,
+      write = MSP_SET_RC_TUNING,
+   }
+}
+
+local currentPage = 1
+local currentLine = 1
+local saveTS = 0
+local saveRetries = 0
+
+local function saveSettings(new)
+   local page = SetupPages[currentPage]
+   if page.values then
+      mspSendRequest(page.write,page.values)
+      saveTS = getTime()
+      if gState == PAGE_SAVING then
+         saveRetries = saveRetries + 1
+      else
+         gState = PAGE_SAVING
+      end
+   end
+end
+
+local function invalidatePages()
+   for i=1,#(SetupPages) do
+      local page = SetupPages[i]
+      page.values = nil
+   end
+   gState = PAGE_DISPLAY
+   saveTS = 0
+end
+
+local menuList = {
+
+   { t = "save page",
+     f = saveSettings },
+
+   { t = "reload",
+     f = invalidatePages }
+}
+
+local telemetryScreenActive = false
+local menuActive = false
+
+local function processMspReply(cmd,rx_buf)
+
+   if cmd == nil or rx_buf == nil then
+      return
+   end
+
+   local page = SetupPages[currentPage]
+
+   -- ignore replies to write requests for now
+   if cmd == page.write then
+      mspSendRequest(MSP_EEPROM_WRITE,{})
+      return
+   end
+
+   if cmd == MSP_EEPROM_WRITE then
+      gState = PAGE_DISPLAY
+      page.values = nil
+      saveTS = 0
+      return
+   end
+   
+   if cmd ~= page.read then
+      return
+   end
+
+   if #(rx_buf) > 0 then
+      page.values = {}
+      for i=1,#(rx_buf) do
+         page.values[i] = rx_buf[i]
+      end
+   end
+end
+   
+local function MaxLines()
+   return #(SetupPages[currentPage].fields)
+end
+
+local function incPage(inc)
+   currentPage = currentPage + inc
+   if currentPage > #(SetupPages) then
+      currentPage = 1
+   elseif currentPage < 1 then
+      currentPage = #(SetupPages)
+   end
+   currentLine = 1
+end
+
+local function incLine(inc)
+   currentLine = currentLine + inc
+   if currentLine > MaxLines() then
+      currentLine = 1
+   elseif currentLine < 1 then
+      currentLine = MaxLines()
+   end
+end
+
+local function incMenu(inc)
+   menuActive = menuActive + inc
+   if menuActive > #(menuList) then
+      menuActive = 1
+   elseif menuActive < 1 then
+      menuActive = #(menuList)
+   end
+end
+
+local function requestPage(page)
+   if page.read and ((page.reqTS == nil) or (page.reqTS + REQ_TIMEOUT <= getTime())) then
+      page.reqTS = getTime()
+      mspSendRequest(page.read,{})
+   end
+end
+
+local function drawScreen(page,page_locked)
+
+   local screen_title = page.title
+
+   lcd.drawScreenTitle('Cleanflight setup: '..screen_title,currentPage,#(SetupPages))
+
+   for i=1,#(page.text) do
+      local f = page.text[i]
+      lcd.drawText(f.x, f.y, f.t, text_options)
+   end
+   
+   for i=1,#(page.fields) do
+      local f = page.fields[i]
+
+      local text_options = 0
+      if i == currentLine then
+         text_options = INVERS
+         if gState == EDITING then
+            text_options = text_options + BLINK
+         end
+      end
+
+      lcd.drawText(f.x, f.y, f.t .. ":", 0)
+
+      -- draw some value
+      local spacing = 20
+      if f.sp ~= nil then
+         spacing = f.sp
+      end
+
+      local idx = f.i or i
+      if page.values and page.values[idx] then
+         lcd.drawText(f.x + spacing, f.y, page.values[idx], text_options)
+      else
+         lcd.drawText(f.x + spacing, f.y, "---", text_options)
+      end
+   end
+end
+
+local function clipValue(val)
+   if val < 0 then
+      val = 0
+   elseif val > 255 then
+      val = 255
+   end
+
+   return val
+end
+
+local function getCurrentField()
+   local page = SetupPages[currentPage]
+   return page.fields[currentLine]
+end
+
+local function incValue(inc)
+   local page = SetupPages[currentPage]
+   local field = page.fields[currentLine]
+   local idx = field.i or currentLine
+   page.values[idx] = clipValue(page.values[idx] + inc)
+end
+
+local function drawMenu()
+   local x = 40
+   local y = 12
+   local w = 120
+   local h = #(menuList) * 8 + 6
+   lcd.drawFilledRectangle(x,y,w,h,ERASE)
+   lcd.drawRectangle(x,y,w-1,h-1,SOLID)
+   lcd.drawText(x+4,y+3,"Menu:")
+
+   for i,e in ipairs(menuList) do
+      if menuActive == i then
+         lcd.drawText(x+36,y+(i-1)*8+3,e.t,INVERS)
+      else
+         lcd.drawText(x+36,y+(i-1)*8+3,e.t)
+      end
+   end
+end
+
+local EVT_MENU_LONG = bit32.bor(bit32.band(EVT_MENU_BREAK,0x1f),0x80)
+
+local lastRunTS = 0
+
+local function run(event)
+
+   local now = getTime()
+
+   -- if lastRunTS old than 500ms
+   if lastRunTS + 50 < now then
+      invalidatePages()
+   end
+   lastRunTS = now
+
+   -- TODO: implement retry + retry counter
+   if (gState == PAGE_SAVING) and (saveTS + 150 < now) then
+      if saveRetries < 2 then
+         saveSettings()
+      else
+         -- two retries and still no success
+         gState = PAGE_DISPLAY
+         saveTS = 0
+      end
+   end
+   
+   if #(mspTxBuf) > 0 then
+      mspProcessTxQ()
+   end
+
+   -- navigation
+   if event == EVT_MENU_LONG then
+      menuActive = 1
+      gState = MENU_DISP
+
+   -- menu is currently displayed
+   elseif gState == MENU_DISP then
+      if event == EVT_EXIT_BREAK then
+         gState = PAGE_DISPLAY
+      elseif event == EVT_PLUS_BREAK then
+         incMenu(-1)
+      elseif event == EVT_MINUS_BREAK then
+         incMenu(1)
+      elseif event == EVT_ENTER_BREAK then
+         gState = PAGE_DISPLAY
+         menuList[menuActive].f()
+      end
+   -- normal page viewing
+   elseif gState <= PAGE_DISPLAY then
+      if event == EVT_MENU_BREAK then
+         incPage(1)
+      elseif event == EVT_PLUS_BREAK then
+         incLine(-1)
+      elseif event == EVT_MINUS_BREAK then
+         incLine(1)
+      elseif event == EVT_ENTER_BREAK then
+         local page = SetupPages[currentPage]
+         local field = page.fields[currentLine]
+         local idx = field.i or currentLine
+         if page.values and page.values[idx] then
+            gState = EDITING
+         end
+      end
+   -- editing value
+   elseif gState == EDITING then
+      if (event == EVT_EXIT_BREAK) or (event == EVT_ENTER_BREAK) then
+         gState = PAGE_DISPLAY
+      elseif event == EVT_PLUS_FIRST or event == EVT_PLUS_REPT then
+         incValue(1)
+      elseif event == EVT_MINUS_FIRST or event == EVT_MINUS_REPT then
+         incValue(-1)
+      end
+   end
+
+   local page = SetupPages[currentPage]
+   local page_locked = false
+
+   if not page.values then
+      -- request values
+      requestPage(page)
+      page_locked = true
+   end
+
+   -- draw screen
+   lcd.clear()
+   drawScreen(page,page_locked)
+   
+   -- do we have valid telemetry data?
+   if getValue("RSSI") == 0 then
+      -- No!
+      lcd.drawText(70,55,"No telemetry",BLINK)
+      invalidatePages()
+   end
+
+   if gState == MENU_DISP then
+      drawMenu()
+   elseif gState == PAGE_SAVING then
+      lcd.drawFilledRectangle(40,12,120,30,ERASE)
+      lcd.drawRectangle(40,12,120,30,SOLID)
+      lcd.drawText(44,15,"Saving...",DBLSIZE + BLINK)
+   end
+
+   processMspReply(mspPollReply())
+   return 0
+end
+
+return {run=run}


### PR DESCRIPTION
This new feature allows for using the MSP interface over smart port, for example from a LUA script.
Please note that it has not been tested with cleanflight, only with betaflight. I need to shrink the naze target first, so that I can test it on my devel board.

This PR is related to issue #2474.