### PR TITLE
Changed code for accelerometer handling

### DIFF
--- a/src/main/fc/boot.c
+++ b/src/main/fc/boot.c
@@ -742,6 +742,22 @@ void configureScheduler(void)
 
     if (sensors(SENSOR_ACC)) {
         setTaskEnabled(TASK_ACCEL, true);
+        switch (gyroPeriodUs) {  // Switch statement kept in place to change acc rates in the future
+        case 500:
+        case 375:
+        case 250:
+        case 125:
+            accTargetLooptime = 1000;
+            break;
+        default:
+        case 1000:
+#ifdef STM32F10X
+            accTargetLooptime = 1000;
+#else
+            accTargetLooptime = 1000;
+#endif
+        }
+        rescheduleTask(TASK_ACCEL, accTargetLooptime);
     }
 
     setTaskEnabled(TASK_ATTITUDE, sensors(SENSOR_ACC));

--- a/src/main/flight/imu.h
+++ b/src/main/flight/imu.h
@@ -21,7 +21,6 @@ extern int16_t throttleAngleCorrection;
 extern uint32_t accTimeSum;
 extern int accSumCount;
 extern float accVelScale;
-extern int16_t accSmooth[XYZ_AXIS_COUNT];
 extern int32_t accSum[XYZ_AXIS_COUNT];
 
 #define DEGREES_TO_DECIDEGREES(angle) (angle * 10)

--- a/src/main/sensors/acceleration.h
+++ b/src/main/sensors/acceleration.h
@@ -37,6 +37,8 @@ extern sensor_align_e accAlign;
 extern acc_t acc;
 
 extern int32_t accADC[XYZ_AXIS_COUNT];
+extern int32_t accSmooth[XYZ_AXIS_COUNT];
+uint32_t accTargetLooptime;
 
 typedef struct rollAndPitchTrims_s {
     int16_t roll;

--- a/src/test/unit/flight_imu_unittest.cc
+++ b/src/test/unit/flight_imu_unittest.cc
@@ -169,6 +169,7 @@ int32_t sonarAlt;
 int16_t sonarCfAltCm;
 int16_t sonarMaxAltWithTiltCm;
 int32_t accADC[XYZ_AXIS_COUNT];
+int32_t accSmooth[XYZ_AXIS_COUNT];
 int32_t gyroADC[XYZ_AXIS_COUNT];
 
 int16_t GPS_speed;

--- a/src/test/unit/msp_fc_unittest.cc
+++ b/src/test/unit/msp_fc_unittest.cc
@@ -503,7 +503,7 @@ uint8_t GPS_svinfo_cno[GPS_SV_MAXSATS];     // Carrier to Noise Ratio (Signal St
 int32_t gyroADC[XYZ_AXIS_COUNT];
 // form imu.c
 attitudeEulerAngles_t attitude = { { 0, 0, 0 } };     // absolute angle inclination in multiple of 0.1 degree    180 deg = 1800
-int16_t accSmooth[XYZ_AXIS_COUNT];
+int32_t accSmooth[XYZ_AXIS_COUNT];
 // from ledstrip.c
 void reevaluateLedConfig(void) {}
 bool setModeColor(ledModeIndex_e , int , int ) { return true; }


### PR DESCRIPTION
Filtering is now done in acceleration.c, using the biquad filter, like in betaflight. Changed imu and boot.c accordingly. Fixed issues with unit-test flight_imu_* and msp_fc_* due to changes in accelerometer filtering. This is the same a PR #2505, but this time under a proper branch name, since i messed it up the first time.

Test flight in horizon and angle mode was OK for me, although i could do only limited testing.
