### PR TITLE
Prevent serial overflow in BLHeli Passthrough

### DIFF
--- a/src/main/io/serial_4way.c
+++ b/src/main/io/serial_4way.c
@@ -314,6 +314,8 @@ static uint8_t readByteCrc(void)
 
 static void writeByte(uint8_t b)
 {
+    while (!serialTxBytesFree(instance)) {
+    };
     serialWrite(port, b);
 }
 

--- a/src/main/io/serial_4way.c
+++ b/src/main/io/serial_4way.c
@@ -314,7 +314,7 @@ static uint8_t readByteCrc(void)
 
 static void writeByte(uint8_t b)
 {
-    while (!serialTxBytesFree(instance)) {
+    while (!serialTxBytesFree(port)) {
     };
     serialWrite(port, b);
 }


### PR DESCRIPTION
BLHeli Suite and BLHeli Configurator use 256-byte reads during flashing operations, adding a 8-byte overhead per message theycan (and sometimes do) overflow the 256 byte TX buffer, leading to flashing failures.