### PR TITLE
OSD - Add the averageSystemLoadPercent OSD element

### DIFF
--- a/src/main/osd/fc_state.h
+++ b/src/main/osd/fc_state.h
@@ -52,14 +52,15 @@ typedef struct fcStatus_s {
     uint16_t cycleTime;
     uint16_t i2cErrors;
     uint16_t sensors;
-    uint32_t fcState;                // bitmask, see fcStateId_e
+    uint32_t fcState;                  // bitmask, see fcStateId_e
     uint8_t profile;
+    uint16_t averageSystemLoadPercent; // CPU load in %, 0-100
 
     // MSP_ANALOG
-    uint8_t vbat;                    // voltage in 0.1V steps, 168 = 16.8v
-    uint16_t rssi;                   // rssi in 0.1% steps, 505 = 50.5%
-    uint16_t amperage;               // amperage in 0.01A steps, 12575 = 125.75A
-    uint16_t mAhDrawn;               // milliampere hours, 1300mAh
+    uint8_t vbat;                      // voltage in 0.1V steps, 168 = 16.8v
+    uint16_t rssi;                     // rssi in 0.1% steps, 505 = 50.5%
+    uint16_t amperage;                 // amperage in 0.01A steps, 12575 = 125.75A
+    uint16_t mAhDrawn;                 // milliampere hours, 1300mAh
 
     // calculated
     uint32_t armedDuration;

--- a/src/main/osd/msp_client_osd.c
+++ b/src/main/osd/msp_client_osd.c
@@ -112,6 +112,10 @@ int mspClientReplyHandler(mspPacket_t *reply)
             fcStatus.sensors = sbufReadU16(src);
             fcStatus.fcState = sbufReadU32(src);
             fcStatus.profile = sbufReadU8(src);
+            // only available in CF and BF >= 3.1 (perhaps can be replaced with a version check?)
+            if (sbufBytesRemaining(src) >= 2) {
+                fcStatus.averageSystemLoadPercent = sbufReadU16(src);
+            }
         break;
 
         case MSP_ANALOG:

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -96,10 +96,12 @@ const uint16_t osdSupportedElementIds[] = {
     OSD_ELEMENT_VTX_BAND,
     OSD_ELEMENT_VTX_RFPOWER,
 #endif
+    OSD_ELEMENT_AVERAGE_SYSTEM_LOAD,
 };
 
 const uint8_t osdSupportedElementIdsCount = ARRAYLEN(osdSupportedElementIds);
 
+// X, Y, flags, element ID
 static const element_t osdDefaultElements[] = {
     { 13,  1, EF_ENABLED | EF_FLASH_ON_DISCONNECT, OSD_ELEMENT_RSSI_FC },
     { 11, -3, EF_ENABLED | EF_FLASH_ON_DISCONNECT, OSD_ELEMENT_INDICATOR_MAG },
@@ -120,6 +122,7 @@ static const element_t osdDefaultElements[] = {
     {  3, -5, EF_ENABLED, OSD_ELEMENT_VTX_CHANNEL },
     {  5, -5, EF_ENABLED, OSD_ELEMENT_VTX_RFPOWER },
 #endif
+    { 22, 1, EF_ENABLED | EF_FLASH_ON_DISCONNECT, OSD_ELEMENT_AVERAGE_SYSTEM_LOAD },
 };
 
 void pgResetFn_osdElementConfig(osdElementConfig_t *osdElementConfig) {

--- a/src/main/osd/osd_element.c
+++ b/src/main/osd/osd_element.c
@@ -172,6 +172,11 @@ intptr_t osdElementData_vtxRfPower(void)
 }
 #endif
 
+intptr_t osdElementData_averageSystemLoad(void)
+{
+    return (intptr_t) fcStatus.averageSystemLoadPercent;
+}
+
 elementHandlerConfig_t elementHandlers[] = {
     {OSD_ELEMENT_ON_DURATION, osdElementRender_duration, osdElementData_onDuration},
     {OSD_ELEMENT_ARMED_DURATION, osdElementRender_duration, osdElementData_armedDuration},
@@ -192,6 +197,7 @@ elementHandlerConfig_t elementHandlers[] = {
     {OSD_ELEMENT_VTX_BAND, osdElementRender_vtxBand, osdElementData_vtxBand},
     {OSD_ELEMENT_VTX_RFPOWER, osdElementRender_vtxRfPower, osdElementData_vtxRfPower},
 #endif
+    {OSD_ELEMENT_AVERAGE_SYSTEM_LOAD, osdElementRender_averageSystemLoad, osdElementData_averageSystemLoad},
 };
 
 static elementHandlerConfig_t *osdFindElementHandler(uint8_t id)

--- a/src/main/osd/osd_element.h
+++ b/src/main/osd/osd_element.h
@@ -50,6 +50,7 @@ enum osdElementIds_e {
     OSD_ELEMENT_VTX_BAND = 17,
     OSD_ELEMENT_VTX_RFPOWER = 18,
 
+    OSD_ELEMENT_AVERAGE_SYSTEM_LOAD = 19,
 };
 
 // 16 bits.

--- a/src/main/osd/osd_element_render.c
+++ b/src/main/osd/osd_element_render.c
@@ -189,3 +189,12 @@ void osdElementRender_vtxRfPower(const element_t *element, elementDataProviderFn
     tfp_sprintf(elementAsciiBuffer, "%d", vtxRfPower);
     osdPrintAt(element->x, element->y, elementAsciiBuffer);
 }
+
+void osdElementRender_averageSystemLoad(const element_t *element, elementDataProviderFn dataFn)
+{
+    uint16_t averageSystemLoad = (uint16_t) dataFn();
+
+    tfp_sprintf(elementAsciiBuffer, "%3d %%", averageSystemLoad);
+    osdPrintAt(element->x, element->y, elementAsciiBuffer);
+}
+

--- a/src/main/osd/osd_element_render.h
+++ b/src/main/osd/osd_element_render.h
@@ -39,3 +39,4 @@ void osdElementRender_motors(const element_t *element, elementDataProviderFn dat
 void osdElementRender_vtxChannel(const element_t *element, elementDataProviderFn dataFn);
 void osdElementRender_vtxBand(const element_t *element, elementDataProviderFn dataFn);
 void osdElementRender_vtxRfPower(const element_t *element, elementDataProviderFn dataFn);
+void osdElementRender_averageSystemLoad(const element_t *element, elementDataProviderFn dataFn);

--- a/src/test/unit/osd_screen_unittest.cc
+++ b/src/test/unit/osd_screen_unittest.cc
@@ -550,6 +550,25 @@ TEST_F(OsdScreenTest, TestOsdElement_VTX_RFPOWER)
     compareScreen(0, 0, expectedContent, strlen(expectedAscii));
 }
 
+TEST_F(OsdScreenTest, TestOsdElement_AverageSystemLoad)
+{
+    // given
+    fcStatus.averageSystemLoadPercent = 75;
+
+    element_t element = {
+        0, 0, true, OSD_ELEMENT_AVERAGE_SYSTEM_LOAD
+    };
+
+    // when
+    osdDrawTextElement(&element);
+
+    // then
+    char expectedAscii[] = " 75 %";
+    uint8_t *expectedContent = asciiToFontMap(expectedAscii);
+
+    compareScreen(0, 0, expectedContent, strlen(expectedAscii));
+}
+
 
 // STUBS
 extern "C" {


### PR DESCRIPTION
This is my first Cleanflight PR that adds a new feature, so please feel free to comment and let me know if I did anything wrong. I have included a unit test, let me know if I should expand it. Thanks.

I have tested this on my OSD board, in combination with my SP Racing F3 Evo running Betaflight 3.1 (today's master) - https://www.youtube.com/watch?v=jtsUIIeRwjQ

See #2399

If everything checks out, I will try to add other OSD elements as well in separate PRs, if that's OK.