### PR TITLE
Combine ibus serial rx and telemetry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,6 +319,7 @@ FC_COMMON_SRC = \
 		   rx/spektrum.c \
 		   rx/xbus.c \
 		   rx/ibus.c \
+		   telemetry/ibus_shared.c \
 		   rx/srxl.c \
 		   sensors/sensors.c \
 		   sensors/acceleration.c \

--- a/docs/Rx.md
+++ b/docs/Rx.md
@@ -150,6 +150,27 @@ These receivers are reported working (all gives 10 channels serial):
 - FlySky/Turnigy FS-iA10 10-Channel Receiver (http://www.flysky-cn.com/products_detail/productId=53.html)
 - FlySky/Turnigy FS-iA10B 10-Channel Receiver (http://www.flysky-cn.com/products_detail/productId=52.html)
 
+#### Combine flysky ibus telemetry and serial rx on the same FC serial port
+  
+  Connect Flysky FS-iA6B receiver like this
+```   
+    +---------+
+    | FS-iA6B |
+    |         |
+    | Ser RX  |---|<---\       +------------+
+    |         |        |       | FC         |
+    | Sensor  |--#==#--*-------| SerialTX   |
+    +---------+                +------------+
+```
+    Use a diode with cathode to receiver serial rx output,
+    the anode is connected to the FC serial _TX_ pin,                                          and also via a resistor (10K) to the receiver ibus sensor port.
+
+  Enable with cli:
+    serial 1 1088 115200 57600 115200 115200
+    feature RX_SERIAL
+    set serialrx_provider = IBUS
+    save
+
 ## MultiWii serial protocol (MSP)
 
 Allows you to use MSP commands as the RC input.  Only 8 channel support to maintain compatibility with MSP.

--- a/docs/Telemetry.md
+++ b/docs/Telemetry.md
@@ -269,6 +269,8 @@ It runs at a fixed baud rate of 115200.
 
 It should be possible to daisy chain multiple sensors with ibus. This is implemented but not tested because i don't have one of the sensors to test with, the FC shall always be the last sensor in the chain.
 
+It is possible to combine serial rx and ibus telemetry on the same uart pin on the flight controller, see [Rx](Rx.md).
+
 ### Configuration
 
 Ibus telemetry can be enabled in the firmware at build time using defines in target.h. It is enabled by default in those targets that have space left.

--- a/src/main/drivers/accgyro.h
+++ b/src/main/drivers/accgyro.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include "drivers/sensor.h"
+
 #define GYRO_LPF_256HZ      0
 #define GYRO_LPF_188HZ      1
 #define GYRO_LPF_98HZ       2

--- a/src/main/io/serial.h
+++ b/src/main/io/serial.h
@@ -17,6 +17,9 @@
 
 #pragma once
 
+#include "config/parameter_group.h"
+#include "config/parameter_group_ids.h"
+
 typedef enum {
     PORTSHARING_UNUSED = 0,
     PORTSHARING_NOT_SHARED,

--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -100,7 +100,7 @@
 #include "telemetry/telemetry.h"
 #include "telemetry/frsky.h"
 #include "telemetry/hott.h"
-#include "telemetry/ibus.h"
+#include "telemetry/ibus_shared.h"
 
 #include "msp/msp_server.h"
 

--- a/src/main/sensors/acceleration.h
+++ b/src/main/sensors/acceleration.h
@@ -17,6 +17,10 @@
 
 #pragma once
 
+#include "drivers/accgyro.h"
+#include "common/axis.h"
+#include "sensors/sensors.h"
+
 // Type of accelerometer used/detected
 typedef enum {
     ACC_DEFAULT = 0,

--- a/src/main/telemetry/ibus.c
+++ b/src/main/telemetry/ibus.c
@@ -21,6 +21,7 @@
  * PIC 12F1572 (also distributed under GPLv3) which was referenced to
  * clarify the protocol.
  */
+#include <stdio.h>
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -32,31 +33,15 @@
 
 #if defined(TELEMETRY) && defined(TELEMETRY_IBUS)
 
-#include "config/parameter_group.h"
-#include "config/parameter_group_ids.h"
-
-#include "common/axis.h"
-
-#include "drivers/system.h"
-#include "drivers/sensor.h"
-#include "drivers/accgyro.h"
 #include "drivers/serial.h"
-
-#include "sensors/sensors.h"
-#include "sensors/acceleration.h"
-#include "sensors/battery.h"
-#include "sensors/barometer.h"
-
 #include "io/serial.h"
-#include "fc/rc_controls.h"
-#include "fc/cleanflight_fc.h"
-
+#include "scheduler/scheduler.h"
+#include "fc/fc_tasks.h"
 
 #include "telemetry/telemetry.h"    
 #include "telemetry/ibus.h"
+#include "telemetry/ibus_shared.h"
 
-#include "scheduler/scheduler.h"
-#include "fc/fc_tasks.h"
 
 /*
  * iBus Telemetry is a half-duplex serial protocol. It shares 1 line for
@@ -165,11 +150,6 @@
  */
 
 
-PG_REGISTER_WITH_RESET_TEMPLATE(ibusTelemetryConfig_t, ibusTelemetryConfig, PG_IBUS_TELEMETRY_CONFIG, 0);
-
-PG_RESET_TEMPLATE(ibusTelemetryConfig_t, ibusTelemetryConfig,
-                  .report_cell_voltage = false,
-                 );
 
 #define IBUS_TASK_PERIOD_US (500)
 
@@ -177,37 +157,11 @@ PG_RESET_TEMPLATE(ibusTelemetryConfig_t, ibusTelemetryConfig,
 #define IBUS_BAUDRATE      (115200)
 #define IBUS_CYCLE_TIME_MS (8)
 
-#define IBUS_CHECKSUM_SIZE (2)
-
 #define IBUS_MIN_LEN       (2 + IBUS_CHECKSUM_SIZE)
 #define IBUS_MAX_TX_LEN    (6)
 #define IBUS_MAX_RX_LEN    (4)
 #define IBUS_RX_BUF_LEN    (IBUS_MAX_RX_LEN)
 
-#define IBUS_TEMPERATURE_OFFSET  (400)
-
-
-typedef uint8_t ibusAddress_t;
-
-typedef enum {
-    IBUS_COMMAND_DISCOVER_SENSOR      = 0x80,
-    IBUS_COMMAND_SENSOR_TYPE          = 0x90,
-    IBUS_COMMAND_MEASUREMENT          = 0xA0
-} ibusCommand_e;
-
-typedef enum {
-    IBUS_SENSOR_TYPE_TEMPERATURE      = 0x01,
-    IBUS_SENSOR_TYPE_RPM              = 0x02,
-    IBUS_SENSOR_TYPE_EXTERNAL_VOLTAGE = 0x03
-} ibusSensorType_e;
-
-/* Address lookup relative to the sensor base address which is the lowest address seen by the FC 
-   The actual lowest value is likely to change when sensors are daisy chained */
-static const uint8_t sensorAddressTypeLookup[] = {
-    IBUS_SENSOR_TYPE_EXTERNAL_VOLTAGE,
-    IBUS_SENSOR_TYPE_TEMPERATURE,
-    IBUS_SENSOR_TYPE_RPM
-};
 
 static serialPort_t *ibusSerialPort = NULL;
 static serialPortConfig_t *ibusSerialPortConfig;
@@ -219,131 +173,8 @@ static uint8_t outboundBytesToIgnoreOnRxCount = 0;
 static bool ibusTelemetryEnabled = false;
 static portSharing_e ibusPortSharing;
 
-#define INVALID_IBUS_ADDRESS 0
-static ibusAddress_t ibusBaseAddress = INVALID_IBUS_ADDRESS;
-
 static uint8_t ibusReceiveBuffer[IBUS_RX_BUF_LEN] = { 0x0 };
 
-static uint16_t calculateChecksum(const uint8_t *ibusPacket, size_t packetLength)
-{
-    uint16_t checksum = 0xFFFF;
-    for (size_t i = 0; i < packetLength - IBUS_CHECKSUM_SIZE; i++) {
-        checksum -= ibusPacket[i];
-    }
-
-    return checksum;
-}
-
-static bool isChecksumOk(const uint8_t *ibusPacket)
-{
-    uint16_t calculatedChecksum = calculateChecksum(ibusReceiveBuffer, IBUS_RX_BUF_LEN);
-
-    // Note that there's a byte order swap to little endian here
-    return (calculatedChecksum >> 8) == ibusPacket[IBUS_RX_BUF_LEN - 1]
-           && (calculatedChecksum & 0xFF) == ibusPacket[IBUS_RX_BUF_LEN - 2];
-}
-
-static void transmitIbusPacket(uint8_t *ibusPacket, size_t payloadLength)
-{
-    uint16_t checksum = calculateChecksum(ibusPacket, payloadLength + IBUS_CHECKSUM_SIZE);
-    for (size_t i = 0; i < payloadLength; i++) {
-        serialWrite(ibusSerialPort, ibusPacket[i]);
-    }
-    serialWrite(ibusSerialPort, checksum & 0xFF);
-    serialWrite(ibusSerialPort, checksum >> 8);
-    outboundBytesToIgnoreOnRxCount += payloadLength + IBUS_CHECKSUM_SIZE;
-}
-
-static void sendIbusDiscoverSensorReply(ibusAddress_t address)
-{
-    uint8_t sendBuffer[] = { 0x04, IBUS_COMMAND_DISCOVER_SENSOR | address};
-    transmitIbusPacket(sendBuffer, sizeof(sendBuffer));
-}
-
-static void sendIbusSensorType(ibusAddress_t address)
-{
-    uint8_t sendBuffer[] = {0x06,
-                            IBUS_COMMAND_SENSOR_TYPE | address,
-                            sensorAddressTypeLookup[address - ibusBaseAddress],
-                            0x02
-                           };
-    transmitIbusPacket(sendBuffer, sizeof(sendBuffer));
-}
-
-static void sendIbusMeasurement(ibusAddress_t address, uint16_t measurement)
-{
-    uint8_t sendBuffer[] = { 0x06, IBUS_COMMAND_MEASUREMENT | address, measurement & 0xFF, measurement >> 8};
-    transmitIbusPacket(sendBuffer, sizeof(sendBuffer));
-}
-
-static bool isCommand(ibusCommand_e expected, const uint8_t *ibusPacket)
-{
-    return (ibusPacket[1] & 0xF0) == expected;
-}
-
-static ibusAddress_t getAddress(const uint8_t *ibusPacket)
-{
-    return (ibusPacket[1] & 0x0F);
-}
-
-static void dispatchMeasurementReply(ibusAddress_t address)
-{
-    int value;
-    
-    switch (sensorAddressTypeLookup[address - ibusBaseAddress]) {
-    case IBUS_SENSOR_TYPE_EXTERNAL_VOLTAGE:
-        value = vbat * 10;
-        if (ibusTelemetryConfig()->report_cell_voltage) {
-            value /= batteryCellCount;
-        }
-        sendIbusMeasurement(address, value);
-        break;
-
-    case IBUS_SENSOR_TYPE_TEMPERATURE:
-        #ifdef BARO
-            value = (baroTemperature + 5) / 10; // +5 to make integer division rounding correct
-        #else
-            value = telemTemperature1 * 10;
-        #endif
-        sendIbusMeasurement(address, value + IBUS_TEMPERATURE_OFFSET);
-        break;
-
-    case IBUS_SENSOR_TYPE_RPM:
-        sendIbusMeasurement(address, (uint16_t) rcCommand[THROTTLE]);
-        break;
-    }
-}
-
-static void autodetectFirstReceivedAddressAsBaseAddress(ibusAddress_t returnAddress)
-{
-    if ((INVALID_IBUS_ADDRESS == ibusBaseAddress) &&
-        (INVALID_IBUS_ADDRESS != returnAddress)) {
-        ibusBaseAddress = returnAddress;
-    }
-}
-
-static bool theAddressIsWithinOurRange(ibusAddress_t returnAddress)
-{
-    return (returnAddress >= ibusBaseAddress) &&
-           (ibusAddress_t)(returnAddress - ibusBaseAddress) < ARRAYLEN(sensorAddressTypeLookup);
-}
-
-static void respondToIbusRequest(uint8_t ibusPacket[static IBUS_RX_BUF_LEN])
-{
-    ibusAddress_t returnAddress = getAddress(ibusPacket);
-
-    autodetectFirstReceivedAddressAsBaseAddress(returnAddress);
-
-    if (theAddressIsWithinOurRange(returnAddress)) {
-        if (isCommand(IBUS_COMMAND_DISCOVER_SENSOR, ibusPacket)) {
-            sendIbusDiscoverSensorReply(returnAddress);
-        } else if (isCommand(IBUS_COMMAND_SENSOR_TYPE, ibusPacket)) {
-            sendIbusSensorType(returnAddress);
-        } else if (isCommand(IBUS_COMMAND_MEASUREMENT, ibusPacket)) {
-            dispatchMeasurementReply(returnAddress);
-        }
-    }
-}
 
 static void pushOntoTail(uint8_t buffer[IBUS_MIN_LEN], size_t bufferLength, uint8_t value)
 {
@@ -355,8 +186,9 @@ void initIbusTelemetry(void)
 {
     ibusSerialPortConfig = findSerialPortConfig(FUNCTION_TELEMETRY_IBUS);
     ibusPortSharing = determinePortSharing(ibusSerialPortConfig, FUNCTION_TELEMETRY_IBUS);
-    ibusBaseAddress = INVALID_IBUS_ADDRESS;
+    ibusTelemetryEnabled = false;
 }
+
 
 void handleIbusTelemetry(void)
 {
@@ -366,7 +198,6 @@ void handleIbusTelemetry(void)
 
     while (serialRxBytesWaiting(ibusSerialPort) > 0) {
         uint8_t c = serialRead(ibusSerialPort);
-
         if (outboundBytesToIgnoreOnRxCount) {
             outboundBytesToIgnoreOnRxCount--;
             continue;
@@ -374,8 +205,8 @@ void handleIbusTelemetry(void)
 
         pushOntoTail(ibusReceiveBuffer, IBUS_RX_BUF_LEN, c);
 
-        if (isChecksumOk(ibusReceiveBuffer)) {
-            respondToIbusRequest(ibusReceiveBuffer);
+        if (isChecksumOk(ibusReceiveBuffer, IBUS_RX_BUF_LEN)) {
+            outboundBytesToIgnoreOnRxCount += respondToIbusRequest(ibusReceiveBuffer);
         }
     }
 }
@@ -400,21 +231,22 @@ bool checkIbusTelemetryState(void)
 
 void configureIbusTelemetryPort(void)
 {
-    portOptions_t portOptions;
-
     if (!ibusSerialPortConfig) {
         return;
     }
 
-    portOptions = SERIAL_BIDIR;
-
-    ibusSerialPort = openSerialPort(ibusSerialPortConfig->identifier, FUNCTION_TELEMETRY_IBUS, NULL, IBUS_BAUDRATE,
-                                    IBUS_UART_MODE, portOptions);
+    if (isSerialPortShared(ibusSerialPortConfig, FUNCTION_RX_SERIAL, FUNCTION_TELEMETRY_IBUS)) {
+        // serialRx will open port and handle telemetry
+        return;
+    }
+    
+    ibusSerialPort = openSerialPort(ibusSerialPortConfig->identifier, FUNCTION_TELEMETRY_IBUS, NULL, IBUS_BAUDRATE, IBUS_UART_MODE, SERIAL_BIDIR);
 
     if (!ibusSerialPort) {
         return;
     }
 
+    initSharedIbusTelemetry(ibusSerialPort);
     ibusTelemetryEnabled = true;
     outboundBytesToIgnoreOnRxCount = 0;
 }
@@ -423,8 +255,7 @@ void freeIbusTelemetryPort(void)
 {
     closeSerialPort(ibusSerialPort);
     ibusSerialPort = NULL;
-
     ibusTelemetryEnabled = false;
 }
 
-#endif
+#endif //defined(TELEMETRY) && defined(TELEMETRY_IBUS)

--- a/src/main/telemetry/ibus.h
+++ b/src/main/telemetry/ibus.h
@@ -17,12 +17,7 @@
 
 #pragma once
 
-
-typedef struct ibusTelemetryConfig_s {
-    uint8_t report_cell_voltage;            // report vbatt divided with cellcount
-} ibusTelemetryConfig_t;
-
-PG_DECLARE(ibusTelemetryConfig_t, ibusTelemetryConfig);
+#include <stdbool.h>
 
 void initIbusTelemetry(void);
 

--- a/src/main/telemetry/ibus_shared.c
+++ b/src/main/telemetry/ibus_shared.c
@@ -1,0 +1,224 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * FlySky iBus telemetry implementation by CraigJPerry.
+ * Unit tests and some additions by Unitware
+ *
+ * Many thanks to Dave Borthwick's iBus telemetry dongle converter for
+ * PIC 12F1572 (also distributed under GPLv3) which was referenced to
+ * clarify the protocol.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "platform.h"
+#include "common/utils.h"
+#include "telemetry/ibus_shared.h"
+
+#if defined(TELEMETRY) && defined(TELEMETRY_IBUS)
+
+#include "config/parameter_group.h"
+#include "config/parameter_group_ids.h"
+
+#include "sensors/acceleration.h"
+#include "sensors/battery.h"
+#include "fc/rc_controls.h"
+
+#ifdef BARO
+#include "sensors/barometer.h"
+#else
+#include "fc/cleanflight_fc.h"
+#endif
+
+
+
+
+
+#define IBUS_TEMPERATURE_OFFSET  (400)
+
+
+PG_REGISTER_WITH_RESET_TEMPLATE(ibusTelemetryConfig_t, ibusTelemetryConfig, PG_IBUS_TELEMETRY_CONFIG, 0);
+
+PG_RESET_TEMPLATE(ibusTelemetryConfig_t, ibusTelemetryConfig,
+                  .report_cell_voltage = false,
+                 );
+
+
+typedef uint8_t ibusAddress_t;
+
+typedef enum {
+    IBUS_COMMAND_DISCOVER_SENSOR      = 0x80,
+    IBUS_COMMAND_SENSOR_TYPE          = 0x90,
+    IBUS_COMMAND_MEASUREMENT          = 0xA0
+} ibusCommand_e;
+
+typedef enum {
+    IBUS_SENSOR_TYPE_TEMPERATURE      = 0x01,
+    IBUS_SENSOR_TYPE_RPM              = 0x02,
+    IBUS_SENSOR_TYPE_EXTERNAL_VOLTAGE = 0x03
+} ibusSensorType_e;
+
+/* Address lookup relative to the sensor base address which is the lowest address seen by the FC 
+   The actual lowest value is likely to change when sensors are daisy chained */
+static const uint8_t sensorAddressTypeLookup[] = {
+    IBUS_SENSOR_TYPE_EXTERNAL_VOLTAGE,
+    IBUS_SENSOR_TYPE_TEMPERATURE,
+    IBUS_SENSOR_TYPE_RPM
+};
+
+static serialPort_t *ibusSerialPort = NULL;
+
+#define INVALID_IBUS_ADDRESS 0
+static ibusAddress_t ibusBaseAddress = INVALID_IBUS_ADDRESS;
+
+
+static uint16_t calculateChecksum(const uint8_t *ibusPacket, size_t packetLength);
+
+
+static uint8_t transmitIbusPacket(uint8_t *ibusPacket, size_t payloadLength)
+{
+    uint16_t checksum = calculateChecksum(ibusPacket, payloadLength + IBUS_CHECKSUM_SIZE);
+    for (size_t i = 0; i < payloadLength; i++) {
+        serialWrite(ibusSerialPort, ibusPacket[i]);
+    }
+    serialWrite(ibusSerialPort, checksum & 0xFF);
+    serialWrite(ibusSerialPort, checksum >> 8);
+    return payloadLength + IBUS_CHECKSUM_SIZE;
+}
+
+static uint8_t sendIbusDiscoverSensorReply(ibusAddress_t address)
+{
+    uint8_t sendBuffer[] = { 0x04, IBUS_COMMAND_DISCOVER_SENSOR | address};
+    return transmitIbusPacket(sendBuffer, sizeof(sendBuffer));
+}
+
+static uint8_t sendIbusSensorType(ibusAddress_t address)
+{
+    uint8_t sendBuffer[] = {0x06,
+                            IBUS_COMMAND_SENSOR_TYPE | address,
+                            sensorAddressTypeLookup[address - ibusBaseAddress],
+                            0x02
+                           };
+    return transmitIbusPacket(sendBuffer, sizeof(sendBuffer));
+}
+
+static uint8_t sendIbusMeasurement(ibusAddress_t address, uint16_t measurement)
+{
+    uint8_t sendBuffer[] = { 0x06, IBUS_COMMAND_MEASUREMENT | address, measurement & 0xFF, measurement >> 8};
+    return transmitIbusPacket(sendBuffer, sizeof(sendBuffer));
+}
+
+static bool isCommand(ibusCommand_e expected, const uint8_t *ibusPacket)
+{
+    return (ibusPacket[1] & 0xF0) == expected;
+}
+
+static ibusAddress_t getAddress(const uint8_t *ibusPacket)
+{
+    return (ibusPacket[1] & 0x0F);
+}
+
+static uint8_t dispatchMeasurementReply(ibusAddress_t address)
+{
+    int value;
+    
+    switch (sensorAddressTypeLookup[address - ibusBaseAddress]) {
+    case IBUS_SENSOR_TYPE_EXTERNAL_VOLTAGE:
+        value = vbat * 10;
+        if (ibusTelemetryConfig()->report_cell_voltage) {
+            value /= batteryCellCount;
+        }
+        return sendIbusMeasurement(address, value);
+
+    case IBUS_SENSOR_TYPE_TEMPERATURE:
+        #ifdef BARO
+            value = (baroTemperature + 5) / 10; // +5 to make integer division rounding correct
+        #else
+            value = telemTemperature1 * 10;
+        #endif
+        return sendIbusMeasurement(address, value + IBUS_TEMPERATURE_OFFSET);
+
+    case IBUS_SENSOR_TYPE_RPM:
+        return sendIbusMeasurement(address, (uint16_t) rcCommand[THROTTLE]);
+    }
+    return 0;
+}
+
+static void autodetectFirstReceivedAddressAsBaseAddress(ibusAddress_t returnAddress)
+{
+    if ((INVALID_IBUS_ADDRESS == ibusBaseAddress) &&
+        (INVALID_IBUS_ADDRESS != returnAddress)) {
+        ibusBaseAddress = returnAddress;
+    }
+}
+
+static bool theAddressIsWithinOurRange(ibusAddress_t returnAddress)
+{
+    return (returnAddress >= ibusBaseAddress) &&
+           (ibusAddress_t)(returnAddress - ibusBaseAddress) < ARRAYLEN(sensorAddressTypeLookup);
+}
+
+uint8_t respondToIbusRequest(uint8_t const * const ibusPacket)
+{
+    ibusAddress_t returnAddress = getAddress(ibusPacket);
+    autodetectFirstReceivedAddressAsBaseAddress(returnAddress);
+
+    if (theAddressIsWithinOurRange(returnAddress)) {
+        if (isCommand(IBUS_COMMAND_DISCOVER_SENSOR, ibusPacket)) {
+            return sendIbusDiscoverSensorReply(returnAddress);
+        } else if (isCommand(IBUS_COMMAND_SENSOR_TYPE, ibusPacket)) {
+            return sendIbusSensorType(returnAddress);
+        } else if (isCommand(IBUS_COMMAND_MEASUREMENT, ibusPacket)) {
+            return dispatchMeasurementReply(returnAddress);
+        }
+    }
+
+    return 0;
+}
+
+
+void initSharedIbusTelemetry(serialPort_t *port)
+{
+	ibusSerialPort = port;
+    ibusBaseAddress = INVALID_IBUS_ADDRESS;
+}
+
+
+#endif //defined(TELEMETRY) && defined(TELEMETRY_IBUS)
+
+
+static uint16_t calculateChecksum(const uint8_t *ibusPacket, size_t packetLength)
+{
+    uint16_t checksum = 0xFFFF;
+    for (size_t i = 0; i < packetLength - IBUS_CHECKSUM_SIZE; i++) {
+        checksum -= ibusPacket[i];
+    }
+
+    return checksum;
+}
+
+bool isChecksumOk(const uint8_t *ibusPacket, const uint8_t length)
+{
+    uint16_t calculatedChecksum = calculateChecksum(ibusPacket, length);
+
+    // Note that there's a byte order swap to little endian here
+    return (calculatedChecksum >> 8) == ibusPacket[length - 1]
+           && (calculatedChecksum & 0xFF) == ibusPacket[length - 2];
+}
+

--- a/src/main/telemetry/ibus_shared.h
+++ b/src/main/telemetry/ibus_shared.h
@@ -1,0 +1,52 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * The ibus_shared module implements the ibus telemetry packet handling
+ * which is shared between the ibus serial rx and the ibus telemetry.
+ *
+ * There is only one 'user' active at any time, serial rx will open the 
+ * serial port if both functions are enabled at the same time 
+ */
+
+#pragma once
+
+#include "config/parameter_group.h"
+#include "config/parameter_group_ids.h"
+#include "drivers/serial.h"
+
+
+#define IBUS_CHECKSUM_SIZE (2)
+
+#if defined(TELEMETRY) && defined(TELEMETRY_IBUS)
+
+typedef struct ibusTelemetryConfig_s {
+    uint8_t report_cell_voltage;            // report vbatt divided with cellcount
+} ibusTelemetryConfig_t;
+
+PG_DECLARE(ibusTelemetryConfig_t, ibusTelemetryConfig);
+
+uint8_t respondToIbusRequest(uint8_t const * const ibusPacket);
+void initSharedIbusTelemetry(serialPort_t * port);
+
+#endif //defined(TELEMETRY) && defined(TELEMETRY_IBUS)
+
+
+bool isChecksumOk(const uint8_t *ibusPacket, const uint8_t length);
+
+
+

--- a/src/main/telemetry/telemetry.h
+++ b/src/main/telemetry/telemetry.h
@@ -17,6 +17,9 @@
 
 #pragma once
 
+#include "config/parameter_group.h"
+#include "config/parameter_group_ids.h"
+
 typedef enum {
     FRSKY_FORMAT_DMS = 0,
     FRSKY_FORMAT_NMEA

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -1025,6 +1025,14 @@ $(OBJECT_DIR)/osd_screen_unittest : \
 	$(CXX) $(CXX_FLAGS) $^ -o $(OBJECT_DIR)/$@
 
 
+$(OBJECT_DIR)/telemetry/ibus_shared.o : \
+	$(USER_DIR)/telemetry/ibus_shared.c \
+	$(USER_DIR)/telemetry/ibus_shared.h \
+	$(GTEST_HEADERS)
+
+	@mkdir -p $(dir $@)
+	$(CC) $(C_FLAGS) $(TEST_CFLAGS) -c $(USER_DIR)/telemetry/ibus_shared.c -o $@
+
 $(OBJECT_DIR)/telemetry/ibus.o : \
 	$(USER_DIR)/telemetry/ibus.c \
 	$(USER_DIR)/telemetry/ibus.h \
@@ -1042,6 +1050,7 @@ $(OBJECT_DIR)/telemetry_ibus_unittest.o : \
 
 $(OBJECT_DIR)/telemetry_ibus_unittest : \
 	$(OBJECT_DIR)/telemetry/ibus.o \
+	$(OBJECT_DIR)/telemetry/ibus_shared.o \
 	$(OBJECT_DIR)/telemetry_ibus_unittest.o \
 	$(OBJECT_DIR)/gtest_main.a
 
@@ -1051,6 +1060,7 @@ $(OBJECT_DIR)/telemetry_ibus_unittest : \
 $(OBJECT_DIR)/rx/ibus.o : \
 	$(USER_DIR)/rx/ibus.c \
 	$(USER_DIR)/rx/ibus.h \
+	$(USER_DIR)/telemetry/ibus_shared.h \
 	$(GTEST_HEADERS)
 
 	@mkdir -p $(dir $@)


### PR DESCRIPTION
It's now possible to combine the serial rx and ibus telemetry on the sam fc uart on a single pin.

I'm combining the ibus ports of the FS-iA6B receiver with a diode and a resistor.

```
+---------+
| FS-iA6B |
|         |
| Ser RX  |---|<---\       +------------+
|         |        |       | FC         |
| Sensor  |---[R]--*-------| SerialTX   |
+---------+                +------------+
```

R = 10Kohm, Diode 1N4148 or similar.

![2016-12-19 22 27 41](https://cloud.githubusercontent.com/assets/6065378/21365422/98982d5c-c6f5-11e6-9e36-3a51d7ca699b.jpg)

Both uart tx and rx channels are used so it's not possible to use the spare pin for rx of something else.

Discussion and how to connect here: https://github.com/cleanflight/cleanflight/issues/2545
