### PR TITLE
OSD - Add the baro altitude OSD element, with a unit test.

### DIFF
--- a/src/main/osd/fc_state.h
+++ b/src/main/osd/fc_state.h
@@ -62,6 +62,9 @@ typedef struct fcStatus_s {
     uint16_t amperage;                 // amperage in 0.01A steps, 12575 = 125.75A
     uint16_t mAhDrawn;                 // milliampere hours, 1300mAh
 
+    // MSP_ALTITUDE
+    uint16_t altitudeBaroM;            // altitude as reported by the baro (or sonar), in meters
+
     // calculated
     uint32_t armedDuration;
 } fcStatus_t;

--- a/src/main/osd/msp_client_osd.c
+++ b/src/main/osd/msp_client_osd.c
@@ -66,7 +66,8 @@ bool mspRequestFCSimpleCommandSender(mspPacket_t *request)
 static uint8_t commandsToSend[] = {
     MSP_STATUS,
     MSP_ANALOG,
-    MSP_MOTOR
+    MSP_MOTOR,
+    MSP_ALTITUDE,
 };
 
 mspClientStatus_t mspClientStatus;
@@ -129,7 +130,12 @@ int mspClientReplyHandler(mspPacket_t *reply)
             for (unsigned i = 0; i < 8 && i < OSD_MAX_MOTORS; i++) {
                 fcMotors[i] = sbufReadU16(src);
             }
-        break;
+            break;
+
+        case MSP_ALTITUDE:
+            fcStatus.altitudeBaroM = (uint16_t) (sbufReadU32(src) / 100); // value is in cm, convert to meters
+            // sbufReadU16(src); // vario - probably no interest in this for now
+            break;
 
         default:
             // we do not know how to handle the message

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -97,6 +97,7 @@ const uint16_t osdSupportedElementIds[] = {
     OSD_ELEMENT_VTX_RFPOWER,
 #endif
     OSD_ELEMENT_AVERAGE_SYSTEM_LOAD,
+    OSD_ELEMENT_ALTITUDE_BARO,
 };
 
 const uint8_t osdSupportedElementIdsCount = ARRAYLEN(osdSupportedElementIds);
@@ -123,6 +124,7 @@ static const element_t osdDefaultElements[] = {
     {  5, -5, EF_ENABLED, OSD_ELEMENT_VTX_RFPOWER },
 #endif
     { 22, 1, EF_ENABLED | EF_FLASH_ON_DISCONNECT, OSD_ELEMENT_AVERAGE_SYSTEM_LOAD },
+    { 22, -5, EF_ENABLED | EF_FLASH_ON_DISCONNECT, OSD_ELEMENT_ALTITUDE_BARO },
 };
 
 void pgResetFn_osdElementConfig(osdElementConfig_t *osdElementConfig) {

--- a/src/main/osd/osd_element.c
+++ b/src/main/osd/osd_element.c
@@ -177,6 +177,11 @@ intptr_t osdElementData_averageSystemLoad(void)
     return (intptr_t) fcStatus.averageSystemLoadPercent;
 }
 
+intptr_t osdElementData_altitudeBaro(void)
+{
+    return (intptr_t) fcStatus.altitudeBaroM;
+}
+
 elementHandlerConfig_t elementHandlers[] = {
     {OSD_ELEMENT_ON_DURATION, osdElementRender_duration, osdElementData_onDuration},
     {OSD_ELEMENT_ARMED_DURATION, osdElementRender_duration, osdElementData_armedDuration},
@@ -198,6 +203,7 @@ elementHandlerConfig_t elementHandlers[] = {
     {OSD_ELEMENT_VTX_RFPOWER, osdElementRender_vtxRfPower, osdElementData_vtxRfPower},
 #endif
     {OSD_ELEMENT_AVERAGE_SYSTEM_LOAD, osdElementRender_averageSystemLoad, osdElementData_averageSystemLoad},
+    {OSD_ELEMENT_ALTITUDE_BARO, osdElementRender_altitudeBaro, osdElementData_altitudeBaro},
 };
 
 static elementHandlerConfig_t *osdFindElementHandler(uint8_t id)

--- a/src/main/osd/osd_element.h
+++ b/src/main/osd/osd_element.h
@@ -51,6 +51,7 @@ enum osdElementIds_e {
     OSD_ELEMENT_VTX_RFPOWER = 18,
 
     OSD_ELEMENT_AVERAGE_SYSTEM_LOAD = 19,
+    OSD_ELEMENT_ALTITUDE_BARO = 20
 };
 
 // 16 bits.

--- a/src/main/osd/osd_element_render.c
+++ b/src/main/osd/osd_element_render.c
@@ -198,3 +198,11 @@ void osdElementRender_averageSystemLoad(const element_t *element, elementDataPro
     osdPrintAt(element->x, element->y, elementAsciiBuffer);
 }
 
+void osdElementRender_altitudeBaro(const element_t *element, elementDataProviderFn dataFn)
+{
+    uint16_t altitudeBaro = (uint32_t) dataFn();
+
+    tfp_sprintf(elementAsciiBuffer, "%4d m", altitudeBaro);
+    osdPrintAt(element->x, element->y, elementAsciiBuffer);
+}
+

--- a/src/main/osd/osd_element_render.h
+++ b/src/main/osd/osd_element_render.h
@@ -40,3 +40,4 @@ void osdElementRender_vtxChannel(const element_t *element, elementDataProviderFn
 void osdElementRender_vtxBand(const element_t *element, elementDataProviderFn dataFn);
 void osdElementRender_vtxRfPower(const element_t *element, elementDataProviderFn dataFn);
 void osdElementRender_averageSystemLoad(const element_t *element, elementDataProviderFn dataFn);
+void osdElementRender_altitudeBaro(const element_t *element, elementDataProviderFn dataFn);

--- a/src/test/unit/osd_screen_unittest.cc
+++ b/src/test/unit/osd_screen_unittest.cc
@@ -569,6 +569,25 @@ TEST_F(OsdScreenTest, TestOsdElement_AverageSystemLoad)
     compareScreen(0, 0, expectedContent, strlen(expectedAscii));
 }
 
+TEST_F(OsdScreenTest, TestOsdElement_AltitudeBaro)
+{
+    // given
+    fcStatus.altitudeBaroM = 75;
+
+    element_t element = {
+        0, 0, true, OSD_ELEMENT_ALTITUDE_BARO
+    };
+
+    // when
+    osdDrawTextElement(&element);
+
+    // then
+    char expectedAscii[] = "  75 m";
+    uint8_t *expectedContent = asciiToFontMap(expectedAscii);
+
+    compareScreen(0, 0, expectedContent, strlen(expectedAscii));
+}
+
 
 // STUBS
 extern "C" {


### PR DESCRIPTION
 The FC baro/sonar value in cm is converted to a value in meters.

I have tested this with a stationary quad (with the Evo FC running BF 3.1. with the baro enabled) but haven't done a real test flight yet.