### PR TITLE
removed non-existent extern variables and some unusable code, and added documentation

### DIFF
--- a/src/main/fc/cleanflight_fc.c
+++ b/src/main/fc/cleanflight_fc.c
@@ -132,7 +132,6 @@ static uint32_t disarmAt;     // Time of automatic disarm when "Don't spin the m
 
 extern uint32_t currentTime;
 extern uint8_t PIDweight[3];
-extern uint8_t dynP8[3], dynI8[3], dynD8[3];
 
 static bool isRXDataNew;
 
@@ -234,12 +233,6 @@ static void updateRcCommands(void)
             // YAW TPA disabled.
             PIDweight[axis] = 100;
         }
-#ifdef USE_PID_MW23
-        // FIXME axis indexes into pids.  use something like lookupPidIndex(rc_alias_e alias) to reduce coupling.
-        dynP8[axis] = (uint16_t)pidProfile()->P8[axis] * prop1 / 100;
-        dynI8[axis] = (uint16_t)pidProfile()->I8[axis] * prop1 / 100;
-        dynD8[axis] = (uint16_t)pidProfile()->D8[axis] * prop1 / 100;
-#endif
 
         if (rcData[axis] < rxConfig()->midrc) {
             rcCommand[axis] = -rcCommand[axis];

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -15,6 +15,15 @@
  * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+/*
+ * This module implements MSP functionality, i.e. the CleanFlight configurator
+ * communication. It is also used to enable CLI communication.
+ *
+ * MSP =  MultiWii Serial Protocol. The MSP consist of:
+ * - msp.c          (this module)
+ * - msp_serial.c
+ * - msp.server.c
+ */
 
 #include <stdbool.h>
 #include <stdint.h>


### PR DESCRIPTION
cleanflight_fc.c: Removed non-existent extern variable declarations. Removed non-usable code from inside of USE_PID_MW23 flags.

msp.c: added some documentation. 