### PR TITLE
Feature irqhandlers

### DIFF
--- a/src/main/drivers/bus_i2c_stm32f10x.c
+++ b/src/main/drivers/bus_i2c_stm32f10x.c
@@ -26,6 +26,7 @@
 
 #include "gpio.h"
 #include "system.h"
+#include "drivers/irq.h"
 
 #include "bus_i2c.h"
 #include "nvic.h"
@@ -69,22 +70,22 @@ void i2cSetOverclock(uint8_t OverClock)
     i2cOverClock = (OverClock) ? true : false;
 }
 
-void I2C1_ER_IRQHandler(void)
+IRQHANDLER(I2C1_ER_IRQ)
 {
     i2c_er_handler();
 }
 
-void I2C1_EV_IRQHandler(void)
+IRQHANDLER(I2C1_EV_IRQ)
 {
     i2c_ev_handler();
 }
 
-void I2C2_ER_IRQHandler(void)
+IRQHANDLER(I2C2_ER_IRQ)
 {
     i2c_er_handler();
 }
 
-void I2C2_EV_IRQHandler(void)
+IRQHANDLER(I2C2_EV_IRQ)
 {
     i2c_ev_handler();
 }

--- a/src/main/drivers/dma.c
+++ b/src/main/drivers/dma.c
@@ -25,12 +25,13 @@
 
 #include "drivers/dma.h"
 #include "drivers/nvic.h"
+#include "drivers/irq.h"
 
 #define DEFINE_DMA_CHANNEL(d, c, f, i, r) \
     {.dma = d, .channel = c, .handler = NULL, .flagsShift = f, .irqn = i, .rcc = r}
 
 #define DEFINE_DMA_IRQ_HANDLER(d, c, h) \
-    void DMA ## d ## _Channel ## c ## _IRQHandler(void) {\
+    IRQHANDLER(DMA ## d ## _Channel ## c ## _IRQ) {\
         DMA_IRQHandler(h);\
     } \
     struct dummy

--- a/src/main/drivers/exti.c
+++ b/src/main/drivers/exti.c
@@ -6,6 +6,7 @@
 
 #include "drivers/nvic.h"
 #include "drivers/io_impl.h"
+#include "drivers/irq.h"
 
 #include "exti.h"
 
@@ -150,25 +151,25 @@ void EXTI_IRQHandler(void)
 }
 
 #define _EXTI_IRQ_HANDLER(name)                 \
-    void name(void) {                           \
+    IRQHANDLER(name) {                          \
         EXTI_IRQHandler();                      \
     }                                           \
     struct dummy                                \
     /**/
 
 
-_EXTI_IRQ_HANDLER(EXTI0_IRQHandler);
-_EXTI_IRQ_HANDLER(EXTI1_IRQHandler);
+_EXTI_IRQ_HANDLER(EXTI0_IRQ);
+_EXTI_IRQ_HANDLER(EXTI1_IRQ);
 #if defined(STM32F10X)
-_EXTI_IRQ_HANDLER(EXTI2_IRQHandler);
+_EXTI_IRQ_HANDLER(EXTI2_IRQ);
 #elif defined(STM32F303xC)
-_EXTI_IRQ_HANDLER(EXTI2_TS_IRQHandler);
+_EXTI_IRQ_HANDLER(EXTI2_TS_IRQ);
 #else
 # warning "Unsupported CPU"
 #endif
-_EXTI_IRQ_HANDLER(EXTI3_IRQHandler);
-_EXTI_IRQ_HANDLER(EXTI4_IRQHandler);
-_EXTI_IRQ_HANDLER(EXTI9_5_IRQHandler);
-_EXTI_IRQ_HANDLER(EXTI15_10_IRQHandler);
+_EXTI_IRQ_HANDLER(EXTI3_IRQ);
+_EXTI_IRQ_HANDLER(EXTI4_IRQ);
+_EXTI_IRQ_HANDLER(EXTI9_5_IRQ);
+_EXTI_IRQ_HANDLER(EXTI15_10_IRQ);
 
 #endif

--- a/src/main/drivers/irq.h
+++ b/src/main/drivers/irq.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "common/utils.h"
+
+// check that `name` is valid handler name (corresponding IRQ number is defined) and emit handler definition
+// `IRQHANDLER(TIM1_UP_IRQ)` will expand to `void TIM1_UP_IRQHandler(void)` on F1, but generate compile-time error on F3 target
+
+#define IRQHANDLER(name) \
+    extern char handler_name_check[CONCAT(name, n) * 0 + 1]; \
+    void CONCAT(name, Handler)(void)

--- a/src/main/drivers/serial_uart_stm32f10x.c
+++ b/src/main/drivers/serial_uart_stm32f10x.c
@@ -34,6 +34,7 @@
 #include "gpio.h"
 #include "nvic.h"
 #include "dma.h"
+#include "drivers/irq.h"
 
 #include "serial.h"
 #include "serial_uart.h"
@@ -185,7 +186,7 @@ uartPort_t *serialUART1(uint32_t baudRate, portMode_t mode, portOptions_t option
 }
 
 // UART1 Rx/Tx IRQ Handler
-void USART1_IRQHandler(void)
+IRQHANDLER(USART1_IRQ)
 {
     uartPort_t *s = &uartPort1;
     usartIrqHandler(s);
@@ -259,7 +260,7 @@ uartPort_t *serialUART2(uint32_t baudRate, portMode_t mode, portOptions_t option
 
 
 // UART2 Rx/Tx IRQ Handler
-void USART2_IRQHandler(void)
+IRQHANDLER(USART2_IRQ)
 {
     uartPort_t *s = &uartPort2;
     usartIrqHandler(s);
@@ -329,7 +330,7 @@ uartPort_t *serialUART3(uint32_t baudRate, portMode_t mode, portOptions_t option
 }
 
 // UART2 Rx/Tx IRQ Handler
-void USART3_IRQHandler(void)
+IRQHANDLER(USART3_IRQ)
 {
     uartPort_t *s = &uartPort3;
     usartIrqHandler(s);
@@ -398,7 +399,7 @@ uartPort_t *serialUART4(uint32_t baudRate, portMode_t mode, portOptions_t option
 }
 
 // UART4 Rx/Tx IRQ Handler
-void UART4_IRQHandler(void)
+IRQHANDLER(UART4_IRQ)
 {
     uartPort_t *s = &uartPort4;
     usartIrqHandler(s);
@@ -470,7 +471,7 @@ uartPort_t *serialUART5(uint32_t baudRate, portMode_t mode, portOptions_t option
 }
 
 // UART5 Rx/Tx IRQ Handler
-void UART5_IRQHandler(void)
+IRQHANDLER(UART5_IRQ)
 {
     uartPort_t *s = &uartPort5;
     usartIrqHandler(s);

--- a/src/main/drivers/serial_uart_stm32f30x.c
+++ b/src/main/drivers/serial_uart_stm32f30x.c
@@ -36,6 +36,7 @@
 #include "gpio.h"
 #include "nvic.h"
 #include "dma.h"
+#include "drivers/irq.h"
 
 #include "serial.h"
 #include "serial_uart.h"
@@ -343,7 +344,7 @@ void usartIrqHandler(uartPort_t *s)
 }
 
 #ifdef USE_UART1
-void USART1_IRQHandler(void)
+IRQHANDLER(USART1_IRQ)
 {
     uartPort_t *s = &uartPort1;
 
@@ -352,7 +353,7 @@ void USART1_IRQHandler(void)
 #endif
 
 #ifdef USE_UART2
-void USART2_IRQHandler(void)
+IRQHANDLER(USART2_IRQ)
 {
     uartPort_t *s = &uartPort2;
 
@@ -361,7 +362,7 @@ void USART2_IRQHandler(void)
 #endif
 
 #ifdef USE_UART3
-void USART3_IRQHandler(void)
+IRQHANDLER(USART3_IRQ)
 {
     uartPort_t *s = &uartPort3;
 
@@ -436,7 +437,7 @@ uartPort_t *serialUART4(uint32_t baudRate, portMode_t mode, portOptions_t option
 }
 
 // UART4 Rx/Tx IRQ Handler
-void UART4_IRQHandler(void)
+IRQHANDLER(UART4_IRQ)
 {
     uartPort_t *s = &uartPort4;
     usartIrqHandler(s);
@@ -513,7 +514,7 @@ uartPort_t *serialUART5(uint32_t baudRate, portMode_t mode, portOptions_t option
 }
 
 // UART5 Rx/Tx IRQ Handler
-void UART5_IRQHandler(void)
+IRQHANDLER(UART5_IRQ)
 {
     uartPort_t *s = &uartPort5;
     usartIrqHandler(s);

--- a/src/main/drivers/timer.c
+++ b/src/main/drivers/timer.c
@@ -29,6 +29,8 @@
 #include "gpio.h"
 #include "system.h"
 
+#include "drivers/irq.h"
+
 #include "timer.h"
 #include "timer_impl.h"
 
@@ -935,56 +937,56 @@ static void timCCxHandler(TIM_TypeDef *tim, timerConfig_t *timerConfig)
 
 // handler for shared interrupts when both timers need to check status bits
 #define _TIM_IRQ_HANDLER2(name, i, j)                                   \
-    void name(void)                                                     \
+    IRQHANDLER(name)                                                    \
     {                                                                   \
         timCCxHandler(TIM ## i, &timerConfig[TIMER_INDEX(i)]);          \
         timCCxHandler(TIM ## j, &timerConfig[TIMER_INDEX(j)]);          \
     } struct dummy
 
 #define _TIM_IRQ_HANDLER(name, i)                                       \
-    void name(void)                                                     \
+    IRQHANDLER(name)                                                    \
     {                                                                   \
         timCCxHandler(TIM ## i, &timerConfig[TIMER_INDEX(i)]);          \
     } struct dummy
 
 #if USED_TIMERS & TIM_N(1)
-_TIM_IRQ_HANDLER(TIM1_CC_IRQHandler, 1);
+_TIM_IRQ_HANDLER(TIM1_CC_IRQ, 1);
 # if defined(STM32F10X)
-_TIM_IRQ_HANDLER(TIM1_UP_IRQHandler, 1);       // timer can't be shared
+_TIM_IRQ_HANDLER(TIM1_UP_IRQ, 1);       // timer can't be shared
 # endif
 # ifdef STM32F303xC
 #  if USED_TIMERS & TIM_N(16)
-_TIM_IRQ_HANDLER2(TIM1_UP_TIM16_IRQHandler, 1, 16);  // both timers are in use
+_TIM_IRQ_HANDLER2(TIM1_UP_TIM16_IRQ, 1, 16);  // both timers are in use
 #  else
-_TIM_IRQ_HANDLER(TIM1_UP_TIM16_IRQHandler, 1);       // timer16 is not used
+_TIM_IRQ_HANDLER(TIM1_UP_TIM16_IRQ, 1);       // timer16 is not used
 #  endif
 # endif
 #endif
 #if USED_TIMERS & TIM_N(2)
-_TIM_IRQ_HANDLER(TIM2_IRQHandler, 2);
+_TIM_IRQ_HANDLER(TIM2_IRQ, 2);
 #endif
 #if USED_TIMERS & TIM_N(3)
-_TIM_IRQ_HANDLER(TIM3_IRQHandler, 3);
+_TIM_IRQ_HANDLER(TIM3_IRQ, 3);
 #endif
 #if USED_TIMERS & TIM_N(4)
-_TIM_IRQ_HANDLER(TIM4_IRQHandler, 4);
+_TIM_IRQ_HANDLER(TIM4_IRQ, 4);
 #endif
 #if USED_TIMERS & TIM_N(8)
-_TIM_IRQ_HANDLER(TIM8_CC_IRQHandler, 8);
+_TIM_IRQ_HANDLER(TIM8_CC_IRQ, 8);
 # if defined(STM32F10X_XL)
-_TIM_IRQ_HANDLER(TIM8_UP_TIM13_IRQHandler, 8);
+_TIM_IRQ_HANDLER(TIM8_UP_TIM13_IRQ, 8);
 # else  // f10x_hd, f30x
-_TIM_IRQ_HANDLER(TIM8_UP_IRQHandler, 8);
+_TIM_IRQ_HANDLER(TIM8_UP_IRQ, 8);
 # endif
 #endif
 #if USED_TIMERS & TIM_N(15)
-_TIM_IRQ_HANDLER(TIM1_BRK_TIM15_IRQHandler, 15);
+_TIM_IRQ_HANDLER(TIM1_BRK_TIM15_IRQ, 15);
 #endif
 #if defined(STM32F303xC) && ((USED_TIMERS & (TIM_N(1)|TIM_N(16))) == (TIM_N(16)))
-_TIM_IRQ_HANDLER(TIM1_UP_TIM16_IRQHandler, 16);    // only timer16 is used, not timer1
+_TIM_IRQ_HANDLER(TIM1_UP_TIM16_IRQ, 16);    // only timer16 is used, not timer1
 #endif
 #if USED_TIMERS & TIM_N(17)
-_TIM_IRQ_HANDLER(TIM1_TRG_COM_TIM17_IRQHandler, 17);
+_TIM_IRQ_HANDLER(TIM1_TRG_COM_TIM17_IRQ, 17);
 #endif
 
 void timerInit(void)


### PR DESCRIPTION
IRQHANDLER(name)
Check that `name` is valid handler name (corresponding IRQ number is defined) and emit handler definition
`IRQHANDLER(TIM1_UP_IRQ)` will expand to `void TIM1_UP_IRQHandler(void)` on F1, but generate compile-time error on F3 target (correct name is TIM1_UP_TIM16_IRQ)