### PR TITLE
Barometer calibration improvements

### DIFF
--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -174,17 +174,17 @@ int32_t baroCalculateAltitude(void)
 
 void performBaroCalibrationCycle(void)
 {
-    static int32_t savedGroundPressure=0;
+    static int32_t savedGroundPressure = 0;
 
     baroGroundPressure -= baroGroundPressure / 8;
     baroGroundPressure += baroPressureSum / PRESSURE_SAMPLE_COUNT;
     baroGroundAltitude = (1.0f - powf((baroGroundPressure / 8) / 101325.0f, 0.190295f)) * 4433000.0f;
 
-    if (baroGroundPressure==savedGroundPressure)
-      calibratingB=0;
+    if (baroGroundPressure == savedGroundPressure)
+      calibratingB = 0;
     else {
       calibratingB--;
-      savedGroundPressure=baroGroundPressure;
+      savedGroundPressure = baroGroundPressure;
     }
 }
 

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -181,10 +181,10 @@ void performBaroCalibrationCycle(void)
     baroGroundAltitude = (1.0f - powf((baroGroundPressure / 8) / 101325.0f, 0.190295f)) * 4433000.0f;
 
     if (baroGroundPressure == savedGroundPressure)
-      calibratingB = 0;
+        calibratingB = 0;
     else {
-      calibratingB--;
-      savedGroundPressure = baroGroundPressure;
+        calibratingB--;
+        savedGroundPressure = baroGroundPressure;
     }
 }
 


### PR DESCRIPTION
Assumes pressure to be 1 std atm (101325 Pa) before first calibration to
dampen overshoot.
Stops calibration early when measurements (moving average) are stable.