### PR TITLE
CF/BF - SPRACINGF3EVO - remove the two #undefs to enable softserial

### DIFF
--- a/src/main/target/SPRACINGF3EVO/target.h
+++ b/src/main/target/SPRACINGF3EVO/target.h
@@ -77,9 +77,6 @@
 #define USE_ESCSERIAL
 #define ESCSERIAL_TIMER_TX_HARDWARE 0 // PWM 1
 
-#undef USE_SOFTSERIAL1
-#undef USE_SOFTSERIAL2
-
 #define UART1_TX_PIN            PA9
 #define UART1_RX_PIN            PA10
 


### PR DESCRIPTION
…the serial port count was mismatched and causing duplicate serial ports to appear in the configurator.