### PR TITLE
CF/BF - Fix AK8975 mag detection

### DIFF
--- a/src/main/drivers/accgyro_mpu6500.h
+++ b/src/main/drivers/accgyro_mpu6500.h
@@ -24,9 +24,14 @@
 #define ICM20602_WHO_AM_I_CONST             (0x12)
 
 #define MPU6500_BIT_RESET                   (0x80)
-#define MPU6500_BIT_INT_ANYRD_2CLEAR        (1 << 4)
-#define MPU6500_BIT_BYPASS_EN               (1 << 0)
-#define MPU6500_BIT_I2C_IF_DIS              (1 << 4)
+
+// Register 0x37/55 - INT_PIN_CFG / Pin Bypass Enable Configuration
+#define MPU6500_BIT_RESERVED                1 << 0
+#define MPU6500_BIT_BYPASS_EN               1 << 1
+#define MPU6500_BIT_INT_ANYRD_2CLEAR        1 << 4
+
+// Register 0x6a/106 - USER_CTRL / User Control
+#define MPU6500_BIT_I2C_IF_DIS              1 << 4
 #define MPU6500_BIT_RAW_RDY_EN              (0x01)
 
 bool mpu6500AccDetect(accDev_t *acc);


### PR DESCRIPTION
was broken by 196baa4e8715de8edd0ef0a8f0bd8c4d34ebf828.

The bit to enable bypass mode was incorrect.

@blckmn @borisbstyle you'll probably want to pull this into betaflight to close https://github.com/betaflight/betaflight/issues/2555