### PR TITLE
CF/BF - Restore BST_API_VERSION and BST_BUILD_INFO

### DIFF
--- a/src/main/target/COLIBRI_RACE/i2c_bst.c
+++ b/src/main/target/COLIBRI_RACE/i2c_bst.c
@@ -82,9 +82,22 @@
 #define CROSSFIRE_RSSI_FRAME_ID             0x14
 #define CLEANFLIGHT_MODE_FRAME_ID           0x20
 
+#define BST_PROTOCOL_VERSION                0
+
+#define API_VERSION_MAJOR                   1 // increment when major changes are made
+#define API_VERSION_MINOR                   13 // increment when any change is made, reset to zero when major changes are released after changing API_VERSION_MAJOR
+
+#define API_VERSION_LENGTH                  2
+
 //
 // MSP commands for Cleanflight original features
 //
+
+#define BST_API_VERSION                 1    //out message
+#define BST_FC_VARIANT                  2    //out message
+#define BST_FC_VERSION                  3    //out message
+#define BST_BOARD_INFO                  4    //out message
+#define BST_BUILD_INFO                  5    //out message
 
 #define BST_MODE_RANGES                 34  //out message         Returns all mode ranges
 #define BST_SET_MODE_RANGE              35  //in message          Sets a single mode range
@@ -257,6 +270,24 @@ static bool bstSlaveProcessFeedbackCommand(uint8_t bstRequest)
     uint32_t i, tmp, junk;
 
     switch(bstRequest) {
+        case BST_API_VERSION:
+            bstWrite8(BST_PROTOCOL_VERSION);
+
+            bstWrite8(API_VERSION_MAJOR);
+            bstWrite8(API_VERSION_MINOR);
+            break;
+        case BST_BUILD_INFO:
+            for (i = 0; i < BUILD_DATE_LENGTH; i++) {
+                bstWrite8(buildDate[i]);
+            }
+            for (i = 0; i < BUILD_TIME_LENGTH; i++) {
+                bstWrite8(buildTime[i]);
+            }
+
+            for (i = 0; i < GIT_SHORT_REVISION_LENGTH; i++) {
+                bstWrite8(shortGitRevision[i]);
+            }
+            break;
         case BST_STATUS:
             bstWrite16(getTaskDeltaTime(TASK_GYROPID));
 #ifdef USE_I2C


### PR DESCRIPTION
Based on updated requirements from TBS engineers.

Larry Ho: "
BST_MAG_CALIBRATION,
BST_ACC_CALIBRATION,
BST_SET_PID,
BST_SET_RC_TUNING,
BST_SET_LOOP_TIME,
BST_SELECT_SETTING,
BST_SET_RX_MAP,
BST_SET_MISC,
BST_SET_DEADBAND,
BST_SET_FC_FILTERS,
BST_SET_FEATURE,
BST_SET_RX_CONFIG,
BST_SET_MODE_RANGE,
BST_SET_LED_COLORS,
BST_SET_LED_STRIP_CONFIG,
BST_EEPROM_WRITE,
BST_REBOOT,
BST_DISARM,
BST_ENABLE_ARM,

BST_PID,
BST_STATUS,
BST_RC_TUNING,
BST_LOOP_TIME,
BST_RX_MAP,
BST_MISC,
BST_DEADBAND,
BST_FC_FILTERS,
BST_FEATURE,
BST_RX_CONFIG,
BST_LED_COLORS,
BST_LED_STRIP_CONFIG,
BST_API_VERSION"

There was a required to keep `BST_BF_BUILD_INFO`, which is not on the
list above, but has been deprecated for ages.  Since it was never used
we will keep the replacement `BS_BUILD_INFO` instead.

Dominic Clifton: "I will keep BST_BUILD_INFO and BST_API_VERSION and all
the ones on your list above."