### PR TITLE
Fix compile issues deactivating led strip

### DIFF
--- a/src/main/drivers/timer_def.h
+++ b/src/main/drivers/timer_def.h
@@ -20,6 +20,12 @@
 #include <platform.h>
 #include "common/utils.h"
 
+#if defined(USE_DSHOT) || defined(LED_STRIP)
+# define DEF_TIM_DMA_COND(...) __VA_ARGS__
+#else
+# define DEF_TIM_DMA_COND(...)
+#endif
+
 #if defined(STM32F1)
 
 #define DEF_TIM(tim, chan, pin, flags, out) {\
@@ -28,8 +34,10 @@
     EXPAND(DEF_CHAN_ ## chan),\
     flags,\
     (DEF_CHAN_ ## chan ## _OUTPUT | out),\
-    CONCAT(EXPAND(DEF_TIM_DMA__ ## tim ## _ ## chan), _CHANNEL),\
-    CONCAT(EXPAND(DEF_TIM_DMA__ ## tim ## _ ## chan), _HANDLER)\
+    DEF_TIM_DMA_COND( \
+        CONCAT(EXPAND(DEF_TIM_DMA__ ## tim ## _ ## chan), _CHANNEL),\
+        CONCAT(EXPAND(DEF_TIM_DMA__ ## tim ## _ ## chan), _HANDLER)\
+    )\
     }
 
 #define DEF_DMA_CHANNEL(tim, chan) CONCAT(EXPAND(DEF_TIM_DMA__ ## tim ## _ ## chan), _CHANNEL)
@@ -65,8 +73,10 @@
     flags,\
     (DEF_CHAN_ ## chan ## _OUTPUT | out),\
     EXPAND(GPIO_AF__ ## pin ## _ ## tim ## _ ## chan),\
-    CONCAT(EXPAND(DEF_TIM_DMA__ ## tim ## _ ## chan), _CHANNEL),\
-    CONCAT(EXPAND(DEF_TIM_DMA__ ## tim ## _ ## chan), _HANDLER)\
+    DEF_TIM_DMA_COND( \
+        CONCAT(EXPAND(DEF_TIM_DMA__ ## tim ## _ ## chan), _CHANNEL),\
+        CONCAT(EXPAND(DEF_TIM_DMA__ ## tim ## _ ## chan), _HANDLER)\
+    )\
     }
 
 #define DEF_DMA_CHANNEL(tim, chan) CONCAT(EXPAND(DEF_TIM_DMA__ ## tim ## _ ## chan), _CHANNEL)
@@ -266,9 +276,11 @@
     flags,\
     (DEF_CHAN_ ## chan ## _OUTPUT | out),\
     EXPAND(GPIO_AF_## tim),\
-    CONCAT(EXPAND(DEF_TIM_DMA_STR_ ## dmaopt ## __ ## tim ## _ ## chan), _STREAM),\
-    EXPAND(DEF_TIM_DMA_CHN_ ## dmaopt ## __ ## tim ## _ ## chan),\
-    CONCAT(EXPAND(DEF_TIM_DMA_STR_ ## dmaopt ## __ ## tim ## _ ## chan), _HANDLER)\
+    DEF_TIM_DMA_COND(\
+        CONCAT(EXPAND(DEF_TIM_DMA_STR_ ## dmaopt ## __ ## tim ## _ ## chan), _STREAM),\
+        EXPAND(DEF_TIM_DMA_CHN_ ## dmaopt ## __ ## tim ## _ ## chan),\
+        CONCAT(EXPAND(DEF_TIM_DMA_STR_ ## dmaopt ## __ ## tim ## _ ## chan), _HANDLER)\
+    )\
     }
 
 #define DEF_DMA_CHANNEL(tim, chan, dmaopt) EXPAND(DEF_TIM_DMA_CHN_ ## dmaopt ## __ ## tim ## _ ## chan)
@@ -438,9 +450,11 @@
     flags,\
     (DEF_CHAN_ ## chan ## _OUTPUT | out),\
     EXPAND(GPIO_AF__ ## pin ## _ ## tim ## _ ## chan),\
-    CONCAT(EXPAND(DEF_TIM_DMA_STR_ ## dmaopt ## __ ## tim ## _ ## chan), _STREAM),\
-    EXPAND(DEF_TIM_DMA_CHN_ ## dmaopt ## __ ## tim ## _ ## chan),\
-    CONCAT(EXPAND(DEF_TIM_DMA_STR_ ## dmaopt ## __ ## tim ## _ ## chan), _HANDLER)\
+    DEF_TIM_DMA_COND(\
+        CONCAT(EXPAND(DEF_TIM_DMA_STR_ ## dmaopt ## __ ## tim ## _ ## chan), _STREAM),\
+        EXPAND(DEF_TIM_DMA_CHN_ ## dmaopt ## __ ## tim ## _ ## chan),\
+        CONCAT(EXPAND(DEF_TIM_DMA_STR_ ## dmaopt ## __ ## tim ## _ ## chan), _HANDLER)\
+    )\
     }
 
 #define DEF_DMA_CHANNEL(tim, chan, dmaopt) EXPAND(DEF_TIM_DMA_CHN_ ## dmaopt ## __ ## tim ## _ ## chan)

--- a/src/main/target/CC3D/target.c
+++ b/src/main/target/CC3D/target.c
@@ -21,19 +21,22 @@
 #include "drivers/io.h"
 
 #include "drivers/timer.h"
+#include "drivers/timer_def.h"
 
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
-    { TIM4, IO_TAG(PB6), TIM_Channel_1, TIM_USE_PWM, 0, },   // S1_IN
-    { TIM3, IO_TAG(PB5), TIM_Channel_2, TIM_USE_PWM, 0, },   // S2_IN - SoftSerial TX - GPIO_PartialRemap_TIM3 / Sonar trigger
-    { TIM3, IO_TAG(PB0), TIM_Channel_3, TIM_USE_PWM, 0, },   // S3_IN - SoftSerial RX / Sonar echo / RSSI ADC
-    { TIM3, IO_TAG(PB1), TIM_Channel_4, TIM_USE_PWM, 0, },   // S4_IN - Current
-    { TIM2, IO_TAG(PA0), TIM_Channel_1, TIM_USE_PWM, 0, },   // S5_IN - Vbattery
-    { TIM2, IO_TAG(PA1), TIM_Channel_2, TIM_USE_PWM | TIM_USE_PPM, 0, },   // S6_IN - PPM IN
-    { TIM4, IO_TAG(PB9), TIM_Channel_4, TIM_USE_MOTOR, 1, }, // S1_OUT
-    { TIM4, IO_TAG(PB8), TIM_Channel_3, TIM_USE_MOTOR, 1, }, // S2_OUT
-    { TIM4, IO_TAG(PB7), TIM_Channel_2, TIM_USE_MOTOR, 1, }, // S3_OUT
-    { TIM1, IO_TAG(PA8), TIM_Channel_1, TIM_USE_MOTOR, 1, }, // S4_OUT
-    { TIM3, IO_TAG(PB4), TIM_Channel_1, TIM_USE_MOTOR, 1, }, // S5_OUT - GPIO_PartialRemap_TIM3 - LED Strip
-    { TIM2, IO_TAG(PA2), TIM_Channel_3, TIM_USE_MOTOR, 1, }  // S6_OUT
+
+    DEF_TIM(TIM4, CH1, PB6, TIM_USE_PWM,               0),   // S1_IN/
+    DEF_TIM(TIM3, CH2, PB5, TIM_USE_PWM,               0),   // S2_IN - SoftSerial TX - GPIO_PartialRemap_TIM3 / Sonar trigger
+    DEF_TIM(TIM3, CH3, PB0, TIM_USE_PWM,               0),   // S3_IN - SoftSerial RX / Sonar echo / RSSI ADC
+    DEF_TIM(TIM3, CH4, PB1, TIM_USE_PWM,               0),   // S4_IN - Current
+    DEF_TIM(TIM2, CH1, PA0, TIM_USE_PWM,               0),   // S5_IN - Vbattery
+    DEF_TIM(TIM2, CH2, PA1, TIM_USE_PWM | TIM_USE_PPM, 0),   // S6_IN - PPM IN
+    DEF_TIM(TIM4, CH4, PB9, TIM_USE_MOTOR,             1), // S1_OUT
+    DEF_TIM(TIM4, CH3, PB8, TIM_USE_MOTOR,             1), // S2_OUT
+    DEF_TIM(TIM4, CH2, PB7, TIM_USE_MOTOR,             1), // S3_OUT
+    DEF_TIM(TIM1, CH1, PA8, TIM_USE_MOTOR,             1), // S4_OUT
+    DEF_TIM(TIM3, CH1, PB4, TIM_USE_MOTOR,             1), // S5_OUT - GPIO_PartialRemap_TIM3 - LED Strip
+    DEF_TIM(TIM2, CH3, PA2, TIM_USE_MOTOR,             1)  // S6_OUT
+
 };
 

--- a/src/main/target/CJMCU/target.c
+++ b/src/main/target/CJMCU/target.c
@@ -21,21 +21,24 @@
 #include "drivers/io.h"
 
 #include "drivers/timer.h"
+#include "drivers/timer_def.h"
 
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
-    { TIM2, IO_TAG(PA0), TIM_Channel_1, TIM_USE_PWM,   0 }, // PWM1 - RC1
-    { TIM2, IO_TAG(PA1), TIM_Channel_2, TIM_USE_PWM,   0 }, // PWM2 - RC2
-    { TIM2, IO_TAG(PA2), TIM_Channel_3, TIM_USE_PWM,   0 }, // PWM3 - RC3
-    { TIM2, IO_TAG(PA3), TIM_Channel_4, TIM_USE_PWM,   0 }, // PWM4 - RC4
-    { TIM3, IO_TAG(PA6), TIM_Channel_1, TIM_USE_PWM,   0 }, // PWM5 - RC5
-    { TIM3, IO_TAG(PA7), TIM_Channel_2, TIM_USE_PWM,   0 }, // PWM6 - RC6
-    { TIM3, IO_TAG(PB0), TIM_Channel_3, TIM_USE_PWM,   0 }, // PWM7 - RC7
-    { TIM3, IO_TAG(PB1), TIM_Channel_4, TIM_USE_PWM,   0 }, // PWM8 - RC8
-    { TIM1, IO_TAG(PA8), TIM_Channel_1, TIM_USE_MOTOR, 1 }, // PWM9 - OUT1
-    { TIM1, IO_TAG(PA11),TIM_Channel_4, TIM_USE_MOTOR, 1 }, // PWM10 - OUT2
-    { TIM4, IO_TAG(PB6), TIM_Channel_1, TIM_USE_MOTOR, 0 }, // PWM11 - OUT3
-    { TIM4, IO_TAG(PB7), TIM_Channel_2, TIM_USE_MOTOR, 0 }, // PWM12 - OUT4
-    { TIM4, IO_TAG(PB8), TIM_Channel_3, TIM_USE_MOTOR, 0 }, // PWM13 - OUT5
-    { TIM4, IO_TAG(PB9), TIM_Channel_4, TIM_USE_MOTOR, 0 }  // PWM14 - OUT6
+
+    DEF_TIM(TIM2, CH1, PA0, TIM_USE_PWM,   0 ), // PWM1 - RC1
+    DEF_TIM(TIM2, CH2, PA1, TIM_USE_PWM,   0 ), // PWM2 - RC2
+    DEF_TIM(TIM2, CH3, PA2, TIM_USE_PWM,   0 ), // PWM3 - RC3
+    DEF_TIM(TIM2, CH4, PA3, TIM_USE_PWM,   0 ), // PWM4 - RC4
+    DEF_TIM(TIM3, CH1, PA6, TIM_USE_PWM,   0 ), // PWM5 - RC5
+    DEF_TIM(TIM3, CH2, PA7, TIM_USE_PWM,   0 ), // PWM6 - RC6
+    DEF_TIM(TIM3, CH3, PB0, TIM_USE_PWM,   0 ), // PWM7 - RC7
+    DEF_TIM(TIM3, CH4, PB1, TIM_USE_PWM,   0 ), // PWM8 - RC8
+    DEF_TIM(TIM1, CH1, PA8, TIM_USE_MOTOR, 1 ), // PWM9 - OUT1
+    DEF_TIM(TIM1, CH4, PA11,TIM_USE_MOTOR, 1 ), // PWM10 - OUT2
+    DEF_TIM(TIM4, CH1, PB6, TIM_USE_MOTOR, 0 ), // PWM11 - OUT3
+    DEF_TIM(TIM4, CH2, PB7, TIM_USE_MOTOR, 0 ), // PWM12 - OUT4
+    DEF_TIM(TIM4, CH3, PB8, TIM_USE_MOTOR, 0 ), // PWM13 - OUT5
+    DEF_TIM(TIM4, CH4, PB9, TIM_USE_MOTOR, 0 )  // PWM14 - OUT6
+
 };
 

--- a/src/main/target/COLIBRI_RACE/target.c
+++ b/src/main/target/COLIBRI_RACE/target.c
@@ -22,6 +22,7 @@
 #include "drivers/io.h"
 #include "drivers/dma.h"
 #include "drivers/timer.h"
+#include "drivers/timer_def.h"
 
 #ifdef USE_BST
 #include "bus_bst.h"
@@ -29,18 +30,20 @@
 
 
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
-    { TIM1,  IO_TAG(PA8),  TIM_Channel_1, TIM_USE_PPM,   0, GPIO_AF_6, NULL, 0 }, // PWM1 - PA8
-    { TIM3,  IO_TAG(PC6),  TIM_Channel_1, TIM_USE_MOTOR, 1, GPIO_AF_2, DMA1_Channel6, DMA1_CH6_HANDLER }, // PWM2 - PC6
-    { TIM8,  IO_TAG(PC7),  TIM_Channel_2, TIM_USE_MOTOR, 1, GPIO_AF_4, DMA2_Channel5, DMA2_CH5_HANDLER }, // PWM3 - PC7
-    { TIM8,  IO_TAG(PC8),  TIM_Channel_3, TIM_USE_MOTOR, 1, GPIO_AF_4, DMA2_Channel1, DMA2_CH1_HANDLER }, // PMW4 - PC8
-    { TIM8,  IO_TAG(PC9),  TIM_Channel_4, TIM_USE_MOTOR, 1, GPIO_AF_4, DMA2_Channel2, DMA2_CH2_HANDLER }, // PWM5 - PC9
-    { TIM2,  IO_TAG(PA0),  TIM_Channel_1, TIM_USE_MOTOR, 1, GPIO_AF_1, NULL, 0 }, // PWM6 - PA0
-    { TIM2,  IO_TAG(PA1),  TIM_Channel_2, TIM_USE_MOTOR, 1, GPIO_AF_1, NULL, 0 }, // PWM7 - PA1
-    { TIM2,  IO_TAG(PA2),  TIM_Channel_3, TIM_USE_MOTOR, 1, GPIO_AF_1, NULL, 0 }, // PWM8 - PA2
-    { TIM2,  IO_TAG(PA3),  TIM_Channel_4, TIM_USE_MOTOR, 1, GPIO_AF_1, NULL, 0 }, // PWM9 - PA3
-    { TIM15, IO_TAG(PB14), TIM_Channel_1, TIM_USE_MOTOR, 1, GPIO_AF_1, NULL, 0 }, // PWM10 - PB14
-    { TIM15, IO_TAG(PB15), TIM_Channel_2, TIM_USE_MOTOR, 1, GPIO_AF_1, NULL, 0 }, // PWM11 - PB15
-    { TIM16, IO_TAG(PA6),  TIM_Channel_1, TIM_USE_LED,   1, GPIO_AF_1, DMA1_Channel3, DMA1_CH3_HANDLER }, // PWM11 - PB15
+
+    DEF_TIM(TIM1,  CH1, PA8,  TIM_USE_PPM,   0), // PWM1 - PA8
+    DEF_TIM(TIM3,  CH1, PC6,  TIM_USE_MOTOR, 1), // PWM2 - PC6
+    DEF_TIM(TIM8,  CH2, PC7,  TIM_USE_MOTOR, 1), // PWM3 - PC7
+    DEF_TIM(TIM8,  CH3, PC8,  TIM_USE_MOTOR, 1), // PMW4 - PC8
+    DEF_TIM(TIM8,  CH4, PC9,  TIM_USE_MOTOR, 1), // PWM5 - PC9
+    DEF_TIM(TIM2,  CH1, PA0,  TIM_USE_MOTOR, 1), // PWM6 - PA0
+    DEF_TIM(TIM2,  CH2, PA1,  TIM_USE_MOTOR, 1), // PWM7 - PA1
+    DEF_TIM(TIM2,  CH3, PA2,  TIM_USE_MOTOR, 1), // PWM8 - PA2
+    DEF_TIM(TIM2,  CH4, PA3,  TIM_USE_MOTOR, 1), // PWM9 - PA3
+    DEF_TIM(TIM15, CH1, PB14, TIM_USE_MOTOR, 1), // PWM10 - PB14
+    DEF_TIM(TIM15, CH2, PB15, TIM_USE_MOTOR, 1), // PWM11 - PB15
+    DEF_TIM(TIM16, CH1, PA6,  TIM_USE_LED,   1), // PWM11 - PB15
+
 };
 
 

--- a/src/main/target/FURYF7/target.c
+++ b/src/main/target/FURYF7/target.c
@@ -23,14 +23,17 @@
 #include "drivers/dma.h"
 
 #include "drivers/timer.h"
+#include "drivers/timer_def.h"
 
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
-    { TIM8, IO_TAG(PC9), TIM_CHANNEL_4, TIM_USE_PPM,   0, GPIO_AF3_TIM8,  NULL,         0,             0 },          // PPM_IN
 
-    { TIM3, IO_TAG(PB0), TIM_CHANNEL_3, TIM_USE_MOTOR, 1, GPIO_AF2_TIM3, DMA1_Stream7, DMA_CHANNEL_5, DMA1_ST7_HANDLER },          // S1_OUT
-    { TIM3, IO_TAG(PB1), TIM_CHANNEL_4, TIM_USE_MOTOR, 1, GPIO_AF2_TIM3, DMA1_Stream2, DMA_CHANNEL_5, DMA1_ST2_HANDLER },          // S2_OUT
-    { TIM2, IO_TAG(PA3), TIM_CHANNEL_4, TIM_USE_MOTOR, 1, GPIO_AF1_TIM2, DMA1_Stream6, DMA_CHANNEL_3, DMA1_ST6_HANDLER },          // S3_OUT
-    { TIM2, IO_TAG(PA2), TIM_CHANNEL_3, TIM_USE_MOTOR, 1, GPIO_AF1_TIM2, DMA1_Stream1, DMA_CHANNEL_3, DMA1_ST1_HANDLER },          // S4_OUT
+    DEF_TIM(TIM8, CH4, PC9, TIM_USE_PPM, TIMER_INPUT_ENABLED,    0),          // PPM_IN
+
+    DEF_TIM(TIM3, CH3, PB0, TIM_USE_MOTOR, TIMER_OUTPUT_ENABLED, 0),          // S1_OUT
+    DEF_TIM(TIM3, CH4, PB1, TIM_USE_MOTOR, TIMER_OUTPUT_ENABLED, 0),          // S2_OUT
+    DEF_TIM(TIM2, CH4, PA3, TIM_USE_MOTOR, TIMER_OUTPUT_ENABLED, 1),          // S3_OUT
+    DEF_TIM(TIM2, CH3, PA2, TIM_USE_MOTOR, TIMER_OUTPUT_ENABLED, 0),          // S4_OUT
 
 //  { TIM5, GPIOA, Pin_0, TIM_Channel_1, TIM5_IRQn, 1, GPIO_Mode_AF, GPIO_PinSource0, GPIO_AF_TIM5 },    // LED Strip
+
 };

--- a/src/main/target/LUX_RACE/target.c
+++ b/src/main/target/LUX_RACE/target.c
@@ -21,22 +21,25 @@
 #include "drivers/io.h"
 
 #include "drivers/timer.h"
+#include "drivers/timer_def.h"
 #include "drivers/dma.h"
 
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
-    { TIM1,  IO_TAG(PA8),  TIM_Channel_1, TIM_USE_PPM,   0, GPIO_AF_6, NULL, 0 }, // PWM1 - PA8
-    { TIM3,  IO_TAG(PC6),  TIM_Channel_1, TIM_USE_MOTOR, 1, GPIO_AF_2, DMA1_Channel6, DMA1_CH6_HANDLER }, // PWM2 - PC6
-    { TIM8,  IO_TAG(PC7),  TIM_Channel_2, TIM_USE_MOTOR, 1, GPIO_AF_4, DMA2_Channel5, DMA2_CH5_HANDLER }, // PWM3 - PC7
-    { TIM8,  IO_TAG(PC8),  TIM_Channel_3, TIM_USE_MOTOR, 1, GPIO_AF_4, DMA2_Channel1, DMA2_CH1_HANDLER }, // PMW4 - PC8
-    { TIM8,  IO_TAG(PC9),  TIM_Channel_4, TIM_USE_MOTOR, 1, GPIO_AF_4, DMA2_Channel2, DMA2_CH2_HANDLER }, // PWM5 - PC9
+
+    DEF_TIM(TIM1,  CH1, PA8,  TIM_USE_PPM,   0), // PWM1 - PA8
+    DEF_TIM(TIM3,  CH1, PC6,  TIM_USE_MOTOR, 1), // PWM2 - PC6
+    DEF_TIM(TIM8,  CH2, PC7,  TIM_USE_MOTOR, 1), // PWM3 - PC7
+    DEF_TIM(TIM8,  CH3, PC8,  TIM_USE_MOTOR, 1), // PMW4 - PC8
+    DEF_TIM(TIM8,  CH4, PC9,  TIM_USE_MOTOR, 1), // PWM5 - PC9
 #ifndef LUXV2_RACE
-    { TIM2,  IO_TAG(PA0),  TIM_Channel_1, TIM_USE_MOTOR, 1, GPIO_AF_1, NULL, 0 }, // PWM6 - PA0
-    { TIM2,  IO_TAG(PA1),  TIM_Channel_2, TIM_USE_MOTOR, 1, GPIO_AF_1, NULL, 0 }, // PWM7 - PA1
-    { TIM2,  IO_TAG(PA2),  TIM_Channel_3, TIM_USE_MOTOR, 1, GPIO_AF_1, NULL, 0 }, // PWM8 - PA2
-    { TIM2,  IO_TAG(PA3),  TIM_Channel_4, TIM_USE_MOTOR, 1, GPIO_AF_1, NULL, 0 }, // PWM9 - PA3
-    { TIM15, IO_TAG(PB14), TIM_Channel_1, TIM_USE_MOTOR, 1, GPIO_AF_1, NULL, 0 }, // PWM10 - PB14
-    { TIM15, IO_TAG(PB15), TIM_Channel_2, TIM_USE_MOTOR, 1, GPIO_AF_1, NULL, 0 }, // PWM11 - PB15
+    DEF_TIM(TIM2,  CH1, PA0,  TIM_USE_MOTOR, 1), // PWM6 - PA0
+    DEF_TIM(TIM2,  CH2, PA1,  TIM_USE_MOTOR, 1), // PWM7 - PA1
+    DEF_TIM(TIM2,  CH3, PA2,  TIM_USE_MOTOR, 1), // PWM8 - PA2
+    DEF_TIM(TIM2,  CH4, PA3,  TIM_USE_MOTOR, 1), // PWM9 - PA3
+    DEF_TIM(TIM15, CH1, PB14, TIM_USE_MOTOR, 1), // PWM10 - PB14
+    DEF_TIM(TIM15, CH2, PB15, TIM_USE_MOTOR, 1), // PWM11 - PB15
 #endif
-    { TIM16, IO_TAG(PA6),  TIM_Channel_1, TIM_USE_LED, 1, GPIO_AF_1, DMA1_Channel3, DMA1_CH3_HANDLER },
+    DEF_TIM(TIM16, CH1, PA6,  TIM_USE_LED,   1),
+
 };
 

--- a/src/main/target/MICROSCISKY/target.c
+++ b/src/main/target/MICROSCISKY/target.c
@@ -21,21 +21,24 @@
 #include "drivers/io.h"
 
 #include "drivers/timer.h"
+#include "drivers/timer_def.h"
 #include "drivers/dma.h"
 
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
-    { TIM2, IO_TAG(PA0),  TIM_Channel_1, TIM_USE_PWM | TIM_USE_PPM, 0, NULL, 0 }, // PWM1 - RC1
-    { TIM2, IO_TAG(PA1),  TIM_Channel_2, TIM_USE_PWM,   0, NULL, 0 }, // PWM2 - RC2
-    { TIM2, IO_TAG(PA2),  TIM_Channel_3, TIM_USE_PWM,   0, NULL, 0 }, // PWM3 - RC3
-    { TIM2, IO_TAG(PA3),  TIM_Channel_4, TIM_USE_PWM,   0, NULL, 0 }, // PWM4 - RC4
-    { TIM3, IO_TAG(PA6),  TIM_Channel_1, TIM_USE_PWM | TIM_USE_LED, 0, DMA1_Channel6, DMA1_CH6_HANDLER }, // PWM5 - RC5
-    { TIM3, IO_TAG(PA7),  TIM_Channel_2, TIM_USE_PWM,   0, NULL, 0 }, // PWM6 - RC6
-    { TIM3, IO_TAG(PB0),  TIM_Channel_3, TIM_USE_PWM,   0, NULL, 0 }, // PWM7 - RC7
-    { TIM3, IO_TAG(PB1),  TIM_Channel_4, TIM_USE_PWM,   0, NULL, 0 }, // PWM8 - RC8
-    { TIM1, IO_TAG(PA8),  TIM_Channel_1, TIM_USE_MOTOR, 1, NULL, 0 }, // PWM9 - OUT1
-    { TIM1, IO_TAG(PA11), TIM_Channel_4, TIM_USE_MOTOR, 1, NULL, 0 }, // PWM10 - OUT2
-    { TIM4, IO_TAG(PB6),  TIM_Channel_1, TIM_USE_MOTOR, 1, NULL, 0 }, // PWM11 - OUT3
-    { TIM4, IO_TAG(PB7),  TIM_Channel_2, TIM_USE_MOTOR, 1, NULL, 0 }, // PWM12 - OUT4
-    { TIM4, IO_TAG(PB8),  TIM_Channel_3, TIM_USE_MOTOR, 1, NULL, 0 }, // PWM13 - OUT5
-    { TIM4, IO_TAG(PB9),  TIM_Channel_4, TIM_USE_MOTOR, 1, NULL, 0 }  // PWM14 - OUT6
+
+    DEF_TIM(TIM2, CH1, PA0,  TIM_USE_PWM | TIM_USE_PPM, 0), // PWM1 - RC1
+    DEF_TIM(TIM2, CH2, PA1,  TIM_USE_PWM,               0), // PWM2 - RC2
+    DEF_TIM(TIM2, CH3, PA2,  TIM_USE_PWM,               0), // PWM3 - RC3
+    DEF_TIM(TIM2, CH4, PA3,  TIM_USE_PWM,               0), // PWM4 - RC4
+    DEF_TIM(TIM3, CH1, PA6,  TIM_USE_PWM | TIM_USE_LED, 0), // PWM5 - RC5
+    DEF_TIM(TIM3, CH2, PA7,  TIM_USE_PWM,               0), // PWM6 - RC6
+    DEF_TIM(TIM3, CH3, PB0,  TIM_USE_PWM,               0), // PWM7 - RC7
+    DEF_TIM(TIM3, CH4, PB1,  TIM_USE_PWM,               0), // PWM8 - RC8
+    DEF_TIM(TIM1, CH1, PA8,  TIM_USE_MOTOR,             1), // PWM9 - OUT1
+    DEF_TIM(TIM1, CH4, PA11, TIM_USE_MOTOR,             1), // PWM10 - OUT2
+    DEF_TIM(TIM4, CH1, PB6,  TIM_USE_MOTOR,             1), // PWM11 - OUT3
+    DEF_TIM(TIM4, CH2, PB7,  TIM_USE_MOTOR,             1), // PWM12 - OUT4
+    DEF_TIM(TIM4, CH3, PB8,  TIM_USE_MOTOR,             1), // PWM13 - OUT5
+    DEF_TIM(TIM4, CH4, PB9,  TIM_USE_MOTOR,             1)  // PWM14 - OUT6
+
 };

--- a/src/main/target/NUCLEOF7/target.c
+++ b/src/main/target/NUCLEOF7/target.c
@@ -22,37 +22,42 @@
 #include "drivers/dma.h"
 
 #include "drivers/timer.h"
+#include "drivers/timer_def.h"
 
 #if defined(USE_DSHOT)
 // DSHOT TEST
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
-    { TIM12, IO_TAG(PB15), TIM_CHANNEL_2, TIM_USE_PWM | TIM_USE_PPM,   0,  GPIO_AF9_TIM12,  NULL,         0,             0  }, // S2_IN
-    { TIM8,  IO_TAG(PC6),  TIM_CHANNEL_1, TIM_USE_PWM,   0,  GPIO_AF3_TIM8,  NULL,         0,             0  }, // S3_IN
-    { TIM8,  IO_TAG(PC7),  TIM_CHANNEL_2, TIM_USE_PWM,   0,  GPIO_AF3_TIM8,  NULL,         0,             0  }, // S4_IN
-    { TIM8,  IO_TAG(PC9),  TIM_CHANNEL_4, TIM_USE_PWM,   0,  GPIO_AF3_TIM8,  NULL,         0,             0  }, // S5_IN
-    { TIM8,  IO_TAG(PC8),  TIM_CHANNEL_3, TIM_USE_PWM,   0,  GPIO_AF3_TIM8,  NULL,         0,             0  }, // S6_IN
 
-    { TIM4,  IO_TAG(PB8),  TIM_CHANNEL_3, TIM_USE_MOTOR, 1,  GPIO_AF2_TIM4, DMA1_Stream7, DMA_CHANNEL_2, DMA1_ST7_HANDLER  }, // S10_OUT 1
-    { TIM2,  IO_TAG(PA3),  TIM_CHANNEL_4, TIM_USE_MOTOR, 1,  GPIO_AF1_TIM2, DMA1_Stream6, DMA_CHANNEL_3, DMA1_ST6_HANDLER  }, // S1_OUT  4
-    { TIM3,  IO_TAG(PB5),  TIM_CHANNEL_2, TIM_USE_MOTOR, 1,  GPIO_AF2_TIM3, DMA1_Stream5, DMA_CHANNEL_5, DMA1_ST5_HANDLER  }, // S4_OUT
-    { TIM4,  IO_TAG(PB9),  TIM_CHANNEL_4, TIM_USE_MOTOR, 1,  GPIO_AF2_TIM4,  NULL,         0,             0  }, // S5_OUT  3
-    { TIM9,  IO_TAG(PE6),  TIM_CHANNEL_2, TIM_USE_MOTOR, 1,  GPIO_AF3_TIM9,  NULL,         0,             0  }, // S3_OUT
-    { TIM3,  IO_TAG(PB4),  TIM_CHANNEL_1, TIM_USE_MOTOR, 1,  GPIO_AF2_TIM3,  NULL,         0,             0  }, // S9_OUT
+    DEF_TIM(TIM12, CH2, PB15, TIM_USE_PWM | TIM_USE_PPM,   0, 0), // S2_IN
+    DEF_TIM(TIM8,  CH1, PC6,  TIM_USE_PWM,                 0, 0), // S3_IN
+    DEF_TIM(TIM8,  CH2, PC7,  TIM_USE_PWM,                 0, 0), // S4_IN
+    DEF_TIM(TIM8,  CH4, PC9,  TIM_USE_PWM,                 0, 0), // S5_IN
+    DEF_TIM(TIM8,  CH3, PC8,  TIM_USE_PWM,                 0, 0), // S6_IN
+
+    DEF_TIM(TIM4,  CH3, PB8,  TIM_USE_MOTOR,               1, 0), // S10_OUT 1
+    DEF_TIM(TIM2,  CH4, PA3,  TIM_USE_MOTOR,               1, 1), // S1_OUT  4
+    DEF_TIM(TIM3,  CH2, PB5,  TIM_USE_MOTOR,               1, 0), // S4_OUT
+    DEF_TIM(TIM4,  CH4, PB9,  TIM_USE_MOTOR,               1, 0), // S5_OUT  3
+    DEF_TIM(TIM9,  CH2, PE6,  TIM_USE_MOTOR,               1, 0), // S3_OUT
+    DEF_TIM(TIM3,  CH1, PB4,  TIM_USE_MOTOR,               1, 0), // S9_OUT
+
 };
 #else
 // STANDARD LAYOUT
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
-    { TIM12, IO_TAG(PB15), TIM_CHANNEL_2, TIM_USE_PWM | TIM_USE_PPM, 0, GPIO_AF9_TIM12, NULL, 0, 0 }, // S2_IN
-    { TIM8,  IO_TAG(PC6),  TIM_CHANNEL_1, TIM_USE_PWM, 0, GPIO_AF3_TIM8, NULL, 0, 0 }, // S3_IN
-    { TIM8,  IO_TAG(PC7),  TIM_CHANNEL_2, TIM_USE_PWM, 0, GPIO_AF3_TIM8, NULL, 0, 0 }, // S4_IN
-    { TIM8,  IO_TAG(PC9),  TIM_CHANNEL_4, TIM_USE_PWM, 0, GPIO_AF3_TIM8, NULL, 0, 0 }, // S5_IN
-    { TIM8,  IO_TAG(PC8),  TIM_CHANNEL_3, TIM_USE_PWM, 0, GPIO_AF3_TIM8, NULL, 0, 0 }, // S6_IN
 
-    { TIM4,  IO_TAG(PB8),  TIM_CHANNEL_3, TIM_USE_MOTOR | TIM_USE_LED, 1, GPIO_AF2_TIM4, DMA1_Stream7, DMA_CHANNEL_2, DMA1_ST7_HANDLER  }, // S10_OUT 1
-    { TIM4,  IO_TAG(PB9),  TIM_CHANNEL_4, TIM_USE_MOTOR, 1, GPIO_AF2_TIM4, NULL, 0, 0 }, // S5_OUT  3
-    { TIM2,  IO_TAG(PA3),  TIM_CHANNEL_4, TIM_USE_MOTOR, 1, GPIO_AF1_TIM2, NULL, 0, 0 }, // S1_OUT  4
-    { TIM9,  IO_TAG(PE6),  TIM_CHANNEL_2, TIM_USE_MOTOR, 1, GPIO_AF3_TIM9, NULL, 0, 0 }, // S3_OUT
-    { TIM3,  IO_TAG(PB5),  TIM_CHANNEL_2, TIM_USE_MOTOR, 1, GPIO_AF2_TIM3, NULL, 0, 0 }, // S4_OUT
-    { TIM3,  IO_TAG(PB4),  TIM_CHANNEL_1, TIM_USE_MOTOR, 1, GPIO_AF2_TIM3, NULL, 0, 0 }, // S9_OUT
+    DEF_TIM(TIM12, CH2, PB15, TIM_USE_PWM | TIM_USE_PPM,   0, 0), // S2_IN
+    DEF_TIM(TIM8,  CH1, PC6,  TIM_USE_PWM,                 0, 0), // S3_IN
+    DEF_TIM(TIM8,  CH2, PC7,  TIM_USE_PWM,                 0, 0), // S4_IN
+    DEF_TIM(TIM8,  CH4, PC9,  TIM_USE_PWM,                 0, 0), // S5_IN
+    DEF_TIM(TIM8,  CH3, PC8,  TIM_USE_PWM,                 0, 0), // S6_IN
+
+    DEF_TIM(TIM4,  CH3, PB8,  TIM_USE_MOTOR | TIM_USE_LED, 1, 0), // S10_OUT 1
+    DEF_TIM(TIM4,  CH4, PB9,  TIM_USE_MOTOR,               1, 0), // S5_OUT  3
+    DEF_TIM(TIM2,  CH4, PA3,  TIM_USE_MOTOR,               1, 0), // S1_OUT  4
+    DEF_TIM(TIM9,  CH2, PE6,  TIM_USE_MOTOR,               1, 0), // S3_OUT
+    DEF_TIM(TIM3,  CH2, PB5,  TIM_USE_MOTOR,               1, 0), // S4_OUT
+    DEF_TIM(TIM3,  CH1, PB4,  TIM_USE_MOTOR,               1, 0), // S9_OUT
+
 };
 #endif

--- a/src/main/target/OMNIBUS/target.c
+++ b/src/main/target/OMNIBUS/target.c
@@ -21,22 +21,24 @@
 #include "drivers/io.h"
 
 #include "drivers/timer.h"
+#include "drivers/timer_def.h"
 #include "drivers/dma.h"
 
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
-    // PPM Pad
-    { TIM3,  IO_TAG(PB4),  TIM_Channel_1, TIM_USE_PPM,   0, GPIO_AF_2, NULL, 0 }, // PPM - PB4
-    // PB5 / TIM3 CH2 is connected to USBPresent
 
-    { TIM8,  IO_TAG(PB8),  TIM_Channel_2, TIM_USE_MOTOR, 1, GPIO_AF_10, DMA2_Channel5, DMA2_CH5_HANDLER },  // PWM1 - PB8
-    { TIM8,  IO_TAG(PB9),  TIM_Channel_3, TIM_USE_MOTOR, 1, GPIO_AF_10, DMA2_Channel1, DMA2_CH1_HANDLER },  // PWM2 - PB9
-    { TIM2,  IO_TAG(PA3),  TIM_Channel_4, TIM_USE_MOTOR, 1, GPIO_AF_1,  DMA1_Channel7, DMA1_CH7_HANDLER },  // PWM3 - PA3
-    { TIM15, IO_TAG(PA2),  TIM_Channel_1, TIM_USE_MOTOR, 1, GPIO_AF_9,  DMA1_Channel5, DMA1_CH5_HANDLER },  // PWM4 - PA2
+    // PPM Pad
+    DEF_TIM(TIM3,  CH1, PB4,  TIM_USE_PPM,                     0), // PPM - PB4
+    // PB5 / TIM3 CH2 is connected to USBPresent
+    DEF_TIM(TIM8,  CH2, PB8,  TIM_USE_MOTOR,                   1),  // PWM1 - PB8
+    DEF_TIM(TIM8,  CH3, PB9,  TIM_USE_MOTOR,                   1),  // PWM2 - PB9
+    DEF_TIM(TIM2,  CH4, PA3,  TIM_USE_MOTOR,                   1),  // PWM3 - PA3
+    DEF_TIM(TIM15, CH1, PA2,  TIM_USE_MOTOR,                   1),  // PWM4 - PA2
 
     // UART3 RX/TX
     //{ TIM2,  IO_TAG(PB10), TIM_Channel_3, TIM_USE_MOTOR, 1, GPIO_AF_1, NULL, 0 }, // PWM5  - PB10 - TIM2_CH3 / UART3_TX (AF7)
     //{ TIM2,  IO_TAG(PB11), TIM_Channel_4, TIM_USE_MOTOR, 1, GPIO_AF_1, NULL, 0 }, // PWM6 - PB11 - TIM2_CH4 / UART3_RX (AF7)
-    { TIM4,  IO_TAG(PB7),  TIM_Channel_2, TIM_USE_MOTOR, 1, GPIO_AF_2, NULL, 0 },  // PWM7 - PB7
-    { TIM4,  IO_TAG(PB6),  TIM_Channel_1, TIM_USE_MOTOR, 1, GPIO_AF_2, NULL, 0 },  // PWM8 - PB6
-    { TIM1,  IO_TAG(PA8),  TIM_Channel_1, TIM_USE_LED|TIM_USE_TRANSPONDER,   1, GPIO_AF_6, DMA1_Channel2, DMA1_CH2_HANDLER },  // GPIO_TIMER / LED_STRIP
+    DEF_TIM(TIM4,  CH2, PB7,  TIM_USE_MOTOR,                   1),  // PWM7 - PB7
+    DEF_TIM(TIM4,  CH1, PB6,  TIM_USE_MOTOR,                   1),  // PWM8 - PB6
+    DEF_TIM(TIM1,  CH1, PA8,  TIM_USE_LED|TIM_USE_TRANSPONDER, 1),  // GPIO_TIMER / LED_STRIP
+
 };

--- a/src/main/target/STM32F3DISCOVERY/target.c
+++ b/src/main/target/STM32F3DISCOVERY/target.c
@@ -21,22 +21,25 @@
 #include "drivers/io.h"
 
 #include "drivers/timer.h"
+#include "drivers/timer_def.h"
 #include "drivers/dma.h"
 
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
-    { TIM16, IO_TAG(PB8),  TIM_Channel_1, TIM_USE_PPM | TIM_USE_LED, 0, GPIO_AF_1, DMA1_Channel3, DMA1_CH3_HANDLER },
-    { TIM17, IO_TAG(PB9),  TIM_Channel_1, 0, 0, GPIO_AF_1, NULL, 0 },
-    { TIM1,  IO_TAG(PA8),  TIM_Channel_1, TIM_USE_MOTOR, 1, GPIO_AF_6, DMA1_Channel2, DMA1_CH2_HANDLER },
-    { TIM8,  IO_TAG(PC6),  TIM_Channel_1, TIM_USE_MOTOR, 1, GPIO_AF_4, DMA2_Channel3, DMA2_CH3_HANDLER },
-    { TIM8,  IO_TAG(PC7),  TIM_Channel_2, TIM_USE_MOTOR, 1, GPIO_AF_4, DMA2_Channel5, DMA2_CH5_HANDLER },
-    { TIM8,  IO_TAG(PC8),  TIM_Channel_3, TIM_USE_MOTOR, 1, GPIO_AF_4, DMA2_Channel1, DMA2_CH1_HANDLER },
-    { TIM3,  IO_TAG(PB1),  TIM_Channel_4, 0, 0, GPIO_AF_2, NULL, 0 },
-    { TIM3,  IO_TAG(PA4),  TIM_Channel_2, 0, 0, GPIO_AF_2, NULL, 0 },
-    { TIM4,  IO_TAG(PD12), TIM_Channel_1, 0, 0, GPIO_AF_2, NULL, 0 },
-    { TIM4,  IO_TAG(PD13), TIM_Channel_2, 0, 0, GPIO_AF_2, NULL, 0 },
-    { TIM4,  IO_TAG(PD14), TIM_Channel_3, 0, 0, GPIO_AF_2, NULL, 0 },
-    { TIM4,  IO_TAG(PD15), TIM_Channel_4, 0, 0, GPIO_AF_2, NULL, 0 },
-    { TIM2,  IO_TAG(PA1),  TIM_Channel_2, 0, 0, GPIO_AF_1, NULL, 0 },
-    { TIM2,  IO_TAG(PA2),  TIM_Channel_3, 0, 0, GPIO_AF_1, NULL, 0 }
+
+    DEF_TIM(TIM16, CH1, PB8,  TIM_USE_PPM | TIM_USE_LED, 0),
+    DEF_TIM(TIM17, CH1, PB9,  0,                         0),
+    DEF_TIM(TIM1,  CH1, PA8,  TIM_USE_MOTOR,             1),
+    DEF_TIM(TIM8,  CH1, PC6,  TIM_USE_MOTOR,             1),
+    DEF_TIM(TIM8,  CH2, PC7,  TIM_USE_MOTOR,             1),
+    DEF_TIM(TIM8,  CH3, PC8,  TIM_USE_MOTOR,             1),
+    DEF_TIM(TIM3,  CH4, PB1,  0,                         0),
+    DEF_TIM(TIM3,  CH2, PA4,  0,                         0),
+    DEF_TIM(TIM4,  CH1, PD12, 0,                         0),
+    DEF_TIM(TIM4,  CH2, PD13, 0,                         0),
+    DEF_TIM(TIM4,  CH3, PD14, 0,                         0),
+    DEF_TIM(TIM4,  CH4, PD15, 0,                         0),
+    DEF_TIM(TIM2,  CH2, PA1,  0,                         0),
+    DEF_TIM(TIM2,  CH3, PA2,  0,                         0)
+
 };
 


### PR DESCRIPTION
This PR solves https://github.com/cleanflight/cleanflight/issues/2674

Thanks to @ledvinap for the code to make the `DEF_TIM` accept variable args.

Trying to make a customized version of CleanFlight, I found a problem: if I commented the LED_STRIP feature to get some free space, the compiler shows some issues. This PR makes all the targets compile with and without the LED_STRIP feature.

Please, these code needs some review because:
- I've only a NAZE32 board, without leds. So I only can be sure that the code compiles in ALL targets with and without the LED_STRIP feature and it works in the NAZE32. I've not tested it in other boards.
- I've a doubt when the values are NULL. For example, in the FURYF4 (that I've not touch in this PR), appears this code commented:
```{ TIM8,  IO_TAG(PC9),  TIM_Channel_4, TIM_USE_PPM,   0, GPIO_AF_TIM8,  NULL,         0,             0  }```
The actual code is like this:
```DEF_TIM(TIM8, CH4, PC9, TIM_USE_PPM,   TIMER_INPUT_ENABLED,  0 )```
If I expand the macros manually, the result of this latest line is:
```{ TIM8,  IO_TAG(PC9),  TIM_Channel_4, TIM_USE_PPM,   0, GPIO_AF_TIM8, DMA2_ST7_STREAM, DMA_Channel_7, DMA2_ST7_HANDLER }```
As you can see there's no *NULL* value for example. Maybe this parameters are ignored in this case and it's not important, but I've found other boards (changed in this PR) with *NULL* values that the `DEF_TIM` changes. Sorry if it's a silly question, but I'm newbie in C code.

Regards!