### PR TITLE
Fix compile linking issues when USE_PWM is disabled

### DIFF
--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -294,11 +294,15 @@ void init(void)
     }
 #endif
 
-#if defined(USE_PWM) || defined(USE_PPM)
-    if (feature(FEATURE_RX_PPM)) {
-        ppmRxInit(ppmConfig(), motorConfig()->dev.motorPwmProtocol);
-    } else if (feature(FEATURE_RX_PARALLEL_PWM)) {
-        pwmRxInit(pwmConfig());
+    if (0) {}
+#if defined(USE_PPM)
+    else if (feature(FEATURE_RX_PPM)) {
+          ppmRxInit(ppmConfig(), motorConfig()->dev.motorPwmProtocol);
+    }
+#endif
+#if defined(USE_PWM)
+    else if (feature(FEATURE_RX_PARALLEL_PWM)) {
+          pwmRxInit(pwmConfig());
     }
 #endif
 


### PR DESCRIPTION
This solves https://github.com/cleanflight/cleanflight/issues/2685

When compiling a target with `#undef USE_PWM` the linker fails with this message:
```
Linking NAZE
/tmp/ccCHoCnV.ltrans1.ltrans.o: In function `servoDevInit':
/mnt/d/git/cleanflight-2.x/./src/main/drivers/pwm_output.c:354: undefined reference to `pwmConfig_System'
collect2: error: ld returned 1 exit status
make[1]: *** [obj/main/cleanflight_NAZE.elf] Error 1
make[1]: se sale del directorio «/mnt/d/git/cleanflight-2.x»
make: *** [hex] Error 2
```
This PR solves the problem. Maybe is not the better code, but I didn't wanted to modify the condition. Reviews are welcome.