### PR TITLE
Simplify timer DMA definition

### DIFF
--- a/src/main/common/utils.h
+++ b/src/main/common/utils.h
@@ -34,6 +34,18 @@
 #define EXPAND_I(x) x
 #define EXPAND(x) EXPAND_I(x)
 
+// expand to t if bit is 1, f when bit is 0. Other bit values are not supported
+#define PP_IIF(bit, t, f) PP_IIF_I(bit, t, f)
+#define PP_IIF_I(bit, t, f) PP_IIF_ ## bit(t, f)
+#define PP_IIF_0(t, f) f
+#define PP_IIF_1(t, f) t
+
+// Expand all argumens and call macro with them. When expansion of some argument contains ',', it will be passed as multiple arguments
+// #define TAKE3(_1,_2,_3) CONCAT3(_1,_2,_3)
+// #define MULTI2 A,B
+// PP_CALL(TAKE3, MULTI2, C) expands to ABC
+#define PP_CALL(macro, ...) macro(__VA_ARGS__)
+
 #if !defined(UNUSED)
 #define UNUSED(x) (void)(x)
 #endif

--- a/src/main/common/utils.h
+++ b/src/main/common/utils.h
@@ -27,6 +27,9 @@
 
 #define CONCAT_HELPER(x,y) x ## y
 #define CONCAT(x,y) CONCAT_HELPER(x, y)
+#define CONCAT2(_1,_2) CONCAT(_1, _2)
+#define CONCAT3(_1,_2,_3)  CONCAT(CONCAT(_1, _2), _3)
+#define CONCAT4(_1,_2,_3,_4)  CONCAT(CONCAT3(_1, _2, _3), _4)
 
 #define STR_HELPER(x) #x
 #define STR(x) STR_HELPER(x)

--- a/src/main/drivers/timer_def.h
+++ b/src/main/drivers/timer_def.h
@@ -1,3 +1,4 @@
+
 /*
  * This file is part of Cleanflight.
  *
@@ -20,766 +21,626 @@
 #include <platform.h>
 #include "common/utils.h"
 
+// allow conditional definition of DMA related members
 #if defined(USE_DSHOT) || defined(LED_STRIP) || defined(TRANSPONDER)
 # define DEF_TIM_DMA_COND(...) __VA_ARGS__
 #else
 # define DEF_TIM_DMA_COND(...)
 #endif
 
+
+// map to base channel (strip N from channel); works only when channel N exists
+#define DEF_TIM_TCH2BTCH(timch) CONCAT(B, timch)
+#define BTCH_TIM1_CH1N BTCH_TIM1_CH1
+#define BTCH_TIM1_CH2N BTCH_TIM1_CH2
+#define BTCH_TIM1_CH3N BTCH_TIM1_CH3
+
+#define BTCH_TIM8_CH1N BTCH_TIM8_CH1
+#define BTCH_TIM8_CH2N BTCH_TIM8_CH2
+#define BTCH_TIM8_CH3N BTCH_TIM8_CH3
+
+#define BTCH_TIM20_CH1N BTCH_TIM20_CH1
+#define BTCH_TIM20_CH2N BTCH_TIM20_CH2
+#define BTCH_TIM20_CH3N BTCH_TIM20_CH3
+
+#define BTCH_TIM15_CH1N BTCH_TIM15_CH1
+#define BTCH_TIM16_CH1N BTCH_TIM16_CH1
+#define BTCH_TIM17_CH1N BTCH_TIM17_CH1
+
+// channel table D(chan_n, n_type)
+#define DEF_TIM_CH_GET(ch) CONCAT2(DEF_TIM_CH__, ch)
+#define DEF_TIM_CH__CH_CH1  D(1, 0)
+#define DEF_TIM_CH__CH_CH2  D(2, 0)
+#define DEF_TIM_CH__CH_CH3  D(3, 0)
+#define DEF_TIM_CH__CH_CH4  D(4, 0)
+#define DEF_TIM_CH__CH_CH1N D(1, 1)
+#define DEF_TIM_CH__CH_CH2N D(2, 1)
+#define DEF_TIM_CH__CH_CH3N D(3, 1)
+
+// timer table D(tim_n)
+#define DEF_TIM_TIM_GET(tim) CONCAT2(DEF_TIM_TIM__, tim)
+#define DEF_TIM_TIM__TIM_TIM1  D(1)
+#define DEF_TIM_TIM__TIM_TIM2  D(2)
+#define DEF_TIM_TIM__TIM_TIM3  D(3)
+#define DEF_TIM_TIM__TIM_TIM4  D(4)
+#define DEF_TIM_TIM__TIM_TIM5  D(5)
+#define DEF_TIM_TIM__TIM_TIM6  D(6)
+#define DEF_TIM_TIM__TIM_TIM7  D(7)
+#define DEF_TIM_TIM__TIM_TIM8  D(8)
+#define DEF_TIM_TIM__TIM_TIM9  D(9)
+#define DEF_TIM_TIM__TIM_TIM10 D(10)
+#define DEF_TIM_TIM__TIM_TIM11 D(11)
+#define DEF_TIM_TIM__TIM_TIM12 D(12)
+#define DEF_TIM_TIM__TIM_TIM13 D(13)
+#define DEF_TIM_TIM__TIM_TIM14 D(14)
+#define DEF_TIM_TIM__TIM_TIM15 D(15)
+#define DEF_TIM_TIM__TIM_TIM16 D(16)
+#define DEF_TIM_TIM__TIM_TIM17 D(17)
+#define DEF_TIM_TIM__TIM_TIM18 D(18)
+#define DEF_TIM_TIM__TIM_TIM19 D(19)
+#define DEF_TIM_TIM__TIM_TIM20 D(20)
+#define DEF_TIM_TIM__TIM_TIM21 D(21)
+#define DEF_TIM_TIM__TIM_TIM22 D(22)
+
+// get record from DMA table
+// DMA table is identical for all targets for consistency, only variant 0 is defined on F1,F3
+// DMA table entry for TIMx Channel y, with two variants:
+//  #define DEF_TIM_DMA__BTCH_TIMx_CHy  D(var0),D(var1)
+//  Parameters in D(...) are target-specific
+// DMA table for channel without DMA
+//  #define DEF_TIM_DMA__BTCH_TIMx_CHy NONE
+// N channels are converted to corresponding base channel first
+
+// Create accessor macro and call it with entry from table
+// DMA_VARIANT_MISSING are used to satisfy variable arguments (-Wpedantic) and to get better error message (undefined symbol instead of preprocessor error)
+#define DEF_TIM_DMA_GET(variant, timch) PP_CALL(CONCAT(DEF_TIM_DMA_GET_VARIANT__, variant), CONCAT(DEF_TIM_DMA__, DEF_TIM_TCH2BTCH(timch)), DMA_VARIANT_MISSING, DMA_VARIANT_MISSING, ERROR)
+#define DEF_TIM_DMA_GET_VARIANT__0(_0, ...)         _0
+#define DEF_TIM_DMA_GET_VARIANT__1(_0, _1, ...)     _1
+#define DEF_TIM_DMA_GET_VARIANT__2(_0, _1, _2, ...) _2
+
+// symbolic names for DMA variants
+#define DMA_VAR0     0
+#define DMA_VAR1     1
+#define DMA_VAR2     2
+
+// get record from AF table
+//  Parameters in D(...) are target-specific
+#define DEF_TIM_AF_GET(timch, pin) CONCAT4(DEF_TIM_AF__, pin, __, timch)
+
+// define output type (N-channel)
+#define DEF_TIM_OUTPUT(ch)         CONCAT(DEF_TIM_OUTPUT__, DEF_TIM_CH_GET(ch))
+#define DEF_TIM_OUTPUT__D(chan_n, n_channel) PP_IIF(n_channel, TIMER_OUTPUT_N_CHANNEL, TIMER_OUTPUT_NONE)
+
 #if defined(STM32F1)
 
-#define DEF_TIM(tim, chan, pin, flags, out) {\
-    tim,\
-    IO_TAG(pin),\
-    EXPAND(DEF_CHAN_ ## chan),\
-    flags,\
-    (DEF_CHAN_ ## chan ## _OUTPUT | out),\
-    DEF_TIM_DMA_COND( \
-        CONCAT(EXPAND(DEF_TIM_DMA__ ## tim ## _ ## chan), _CHANNEL),\
-        CONCAT(EXPAND(DEF_TIM_DMA__ ## tim ## _ ## chan), _HANDLER)\
-    )\
-    }
+#define DEF_TIM(tim, chan, pin, flags, out) {                           \
+    tim,                                                                \
+    IO_TAG(pin),                                                        \
+    DEF_TIM_CHANNEL(CH_ ## chan),                                       \
+    flags,                                                              \
+    (DEF_TIM_OUTPUT(CH_ ## chan) | out),                                \
+    DEF_TIM_DMA_COND(                                                   \
+        DEF_TIM_DMA_CHANNEL(TCH_## tim ## _ ## chan),                   \
+        DEF_TIM_DMA_HANDLER(TCH_## tim ## _ ## chan)                    \
+    )                                                                   \
+    }                                                                   \
+/**/
 
-#define DEF_DMA_CHANNEL(tim, chan) CONCAT(EXPAND(DEF_TIM_DMA__ ## tim ## _ ## chan), _CHANNEL)
-#define DEF_DMA_HANDLER(tim, chan) CONCAT(EXPAND(DEF_TIM_DMA__ ## tim ## _ ## chan), _HANDLER)
+#define DEF_TIM_CHANNEL(ch)        CONCAT(DEF_TIM_CHANNEL__, DEF_TIM_CH_GET(ch))
+#define DEF_TIM_CHANNEL__D(chan_n, n_channel) TIM_Channel_ ## chan_n
 
-/* add the DMA mappings here for F1 */
-#define DEF_TIM_DMA__TIM1_CH1    DMA1_CH2
-#define DEF_TIM_DMA__TIM1_CH2    DMA_NONE
-#define DEF_TIM_DMA__TIM1_CH3    DMA1_CH6
-#define DEF_TIM_DMA__TIM1_CH4    DMA1_CH4
+#define DEF_TIM_DMA_CHANNEL(timch) CONCAT(DEF_TIM_DMA_CHANNEL__, DEF_TIM_DMA_GET(0, timch))
+#define DEF_TIM_DMA_CHANNEL__D(dma_n, chan_n) DMA ## dma_n ## _Channel ## chan_n
+#define DEF_TIM_DMA_CHANNEL__NONE NULL
 
-#define DEF_TIM_DMA__TIM2_CH1    DMA1_CH5
-#define DEF_TIM_DMA__TIM2_CH2    DMA1_CH7
-#define DEF_TIM_DMA__TIM2_CH3    DMA1_CH1
-#define DEF_TIM_DMA__TIM2_CH4    DMA1_CH7
+#define DEF_TIM_DMA_HANDLER(timch) CONCAT(DEF_TIM_DMA_HANDLER__, DEF_TIM_DMA_GET(0, timch))
+#define DEF_TIM_DMA_HANDLER__D(dma_n, chan_n) DMA ## dma_n ## _CH ## chan_n ## _HANDLER
+#define DEF_TIM_DMA_HANDLER__NONE 0
 
-#define DEF_TIM_DMA__TIM3_CH1    DMA1_CH6
-#define DEF_TIM_DMA__TIM3_CH2    DMA_NONE
-#define DEF_TIM_DMA__TIM3_CH3    DMA1_CH2
-#define DEF_TIM_DMA__TIM3_CH4    DMA1_CH3
+/* add F1 DMA mappings here */
+// D(dma_n, channel_n)
+#define DEF_TIM_DMA__BTCH_TIM1_CH1    D(1, 2)
+#define DEF_TIM_DMA__BTCH_TIM1_CH2    NONE
+#define DEF_TIM_DMA__BTCH_TIM1_CH3    D(1, 6)
+#define DEF_TIM_DMA__BTCH_TIM1_CH4    D(1, 4)
 
-#define DEF_TIM_DMA__TIM4_CH1    DMA1_CH1
-#define DEF_TIM_DMA__TIM4_CH2    DMA1_CH4
-#define DEF_TIM_DMA__TIM4_CH3    DMA1_CH5
-#define DEF_TIM_DMA__TIM4_CH4    DMA_NONE
+#define DEF_TIM_DMA__BTCH_TIM2_CH1    D(1, 5)
+#define DEF_TIM_DMA__BTCH_TIM2_CH2    D(1, 7)
+#define DEF_TIM_DMA__BTCH_TIM2_CH3    D(1, 1)
+#define DEF_TIM_DMA__BTCH_TIM2_CH4    D(1, 7)
+
+#define DEF_TIM_DMA__BTCH_TIM3_CH1    D(1, 6)
+#define DEF_TIM_DMA__BTCH_TIM3_CH2    NONE
+#define DEF_TIM_DMA__BTCH_TIM3_CH3    D(1, 2)
+#define DEF_TIM_DMA__BTCH_TIM3_CH4    D(1, 3)
+
+#define DEF_TIM_DMA__BTCH_TIM4_CH1    D(1, 1)
+#define DEF_TIM_DMA__BTCH_TIM4_CH2    D(1, 4)
+#define DEF_TIM_DMA__BTCH_TIM4_CH3    D(1, 5)
+#define DEF_TIM_DMA__BTCH_TIM4_CH4    NONE
 
 #elif defined(STM32F3)
 
-#define DEF_TIM(tim, chan, pin, flags, out) {\
-    tim,\
-    IO_TAG(pin),\
-    EXPAND(DEF_CHAN_ ## chan),\
-    flags,\
-    (DEF_CHAN_ ## chan ## _OUTPUT | out),\
-    EXPAND(GPIO_AF__ ## pin ## _ ## tim ## _ ## chan),\
-    DEF_TIM_DMA_COND( \
-        CONCAT(EXPAND(DEF_TIM_DMA__ ## tim ## _ ## chan), _CHANNEL),\
-        CONCAT(EXPAND(DEF_TIM_DMA__ ## tim ## _ ## chan), _HANDLER)\
-    )\
-    }
+#define DEF_TIM(tim, chan, pin, flags, out) {                           \
+    tim,                                                                \
+    IO_TAG(pin),                                                        \
+    DEF_TIM_CHANNEL(CH_ ## chan),                                       \
+    flags,                                                              \
+    (DEF_TIM_OUTPUT(CH_ ## chan) | out),                                \
+    DEF_TIM_AF(TCH_## tim ## _ ## chan, pin),                           \
+    DEF_TIM_DMA_COND(                                                   \
+        DEF_TIM_DMA_CHANNEL(TCH_## tim ## _ ## chan),                   \
+        DEF_TIM_DMA_HANDLER(TCH_## tim ## _ ## chan)                    \
+    )                                                                   \
+    }                                                                   \
+/**/
 
-#define DEF_DMA_CHANNEL(tim, chan) CONCAT(EXPAND(DEF_TIM_DMA__ ## tim ## _ ## chan), _CHANNEL)
-#define DEF_DMA_HANDLER(tim, chan) CONCAT(EXPAND(DEF_TIM_DMA__ ## tim ## _ ## chan), _HANDLER)
+#define DEF_TIM_CHANNEL(ch)        CONCAT(DEF_TIM_CHANNEL__, DEF_TIM_CH_GET(ch))
+#define DEF_TIM_CHANNEL__D(chan_n, n_channel) TIM_Channel_ ## chan_n
+
+#define DEF_TIM_AF(timch, pin)     CONCAT(DEF_TIM_AF__, DEF_TIM_AF_GET(timch, pin))
+#define DEF_TIM_AF__D(af_n) GPIO_AF_ ## af_n
+
+#define DEF_TIM_DMA_CHANNEL(timch) CONCAT(DEF_TIM_DMA_CHANNEL__, DEF_TIM_DMA_GET(0, timch))
+#define DEF_TIM_DMA_CHANNEL__D(dma_n, chan_n) DMA ## dma_n ## _Channel ## chan_n
+#define DEF_TIM_DMA_CHANNEL__NONE NULL
+
+#define DEF_TIM_DMA_HANDLER(timch) CONCAT(DEF_TIM_DMA_HANDLER__, DEF_TIM_DMA_GET(0, timch))
+#define DEF_TIM_DMA_HANDLER__D(dma_n, chan_n) DMA ## dma_n ## _CH ## chan_n ## _HANDLER
+#define DEF_TIM_DMA_HANDLER__NONE 0
+
 
 /* add the DMA mappings here */
-#define DEF_TIM_DMA__TIM1_CH1    DMA1_CH2
-#define DEF_TIM_DMA__TIM1_CH2    DMA1_CH3
-#define DEF_TIM_DMA__TIM1_CH4    DMA1_CH4
-#define DEF_TIM_DMA__TIM1_CH1N   DMA1_CH2
-#define DEF_TIM_DMA__TIM1_CH2N   DMA1_CH3
-#define DEF_TIM_DMA__TIM1_TRIG   DMA1_CH4
-#define DEF_TIM_DMA__TIM1_COM    DMA1_CH4
-#define DEF_TIM_DMA__TIM1_UP     DMA1_CH5
-#define DEF_TIM_DMA__TIM1_CH3    DMA1_CH6
-#define DEF_TIM_DMA__TIM1_CH3N   DMA1_CH6
+// D(dma_n, channel_n)
 
-#define DEF_TIM_DMA__TIM2_CH3    DMA1_CH1
-#define DEF_TIM_DMA__TIM2_UP     DMA1_CH2
-#define DEF_TIM_DMA__TIM2_CH1    DMA1_CH5
-#define DEF_TIM_DMA__TIM2_CH2    DMA1_CH7
-#define DEF_TIM_DMA__TIM2_CH4    DMA1_CH7
+#define DEF_TIM_DMA__BTCH_TIM1_CH1    D(1, 2)
+#define DEF_TIM_DMA__BTCH_TIM1_CH2    D(1, 3)
+#define DEF_TIM_DMA__BTCH_TIM1_CH4    D(1, 4)
+#define DEF_TIM_DMA__BTCH_TIM1_TRIG   D(1, 4)
+#define DEF_TIM_DMA__BTCH_TIM1_COM    D(1, 4)
+#define DEF_TIM_DMA__BTCH_TIM1_UP     D(1, 5)
+#define DEF_TIM_DMA__BTCH_TIM1_CH3    D(1, 6)
 
-#define DEF_TIM_DMA__TIM3_CH2    DMA_NONE
-#define DEF_TIM_DMA__TIM3_CH3    DMA1_CH2
-#define DEF_TIM_DMA__TIM3_CH4    DMA1_CH3
-#define DEF_TIM_DMA__TIM3_UP     DMA1_CH3
-#define DEF_TIM_DMA__TIM3_CH1    DMA1_CH6
-#define DEF_TIM_DMA__TIM3_TRIG   DMA1_CH6
+#define DEF_TIM_DMA__BTCH_TIM2_CH3    D(1, 1)
+#define DEF_TIM_DMA__BTCH_TIM2_UP     D(1, 2)
+#define DEF_TIM_DMA__BTCH_TIM2_CH1    D(1, 5)
+#define DEF_TIM_DMA__BTCH_TIM2_CH2    D(1, 7)
+#define DEF_TIM_DMA__BTCH_TIM2_CH4    D(1, 7)
 
-#define DEF_TIM_DMA__TIM4_CH1    DMA1_CH1
-#define DEF_TIM_DMA__TIM4_CH2    DMA1_CH4
-#define DEF_TIM_DMA__TIM4_CH3    DMA1_CH5
-#define DEF_TIM_DMA__TIM4_UP     DMA1_CH7
-#define DEF_TIM_DMA__TIM4_CH4    DMA_NONE
+#define DEF_TIM_DMA__BTCH_TIM3_CH2    NONE
+#define DEF_TIM_DMA__BTCH_TIM3_CH3    D(1, 2)
+#define DEF_TIM_DMA__BTCH_TIM3_CH4    D(1, 3)
+#define DEF_TIM_DMA__BTCH_TIM3_UP     D(1, 3)
+#define DEF_TIM_DMA__BTCH_TIM3_CH1    D(1, 6)
+#define DEF_TIM_DMA__BTCH_TIM3_TRIG   D(1, 6)
 
-#define DEF_TIM_DMA__TIM15_CH1   DMA1_CH5
-#define DEF_TIM_DMA__TIM15_CH2   DMA_NONE
-#define DEF_TIM_DMA__TIM15_UP    DMA1_CH5
-#define DEF_TIM_DMA__TIM15_TRIG  DMA1_CH5
-#define DEF_TIM_DMA__TIM15_COM   DMA1_CH5
-#define DEF_TIM_DMA__TIM15_CH1N  DMA1_CH5
+#define DEF_TIM_DMA__BTCH_TIM4_CH1    D(1, 1)
+#define DEF_TIM_DMA__BTCH_TIM4_CH2    D(1, 4)
+#define DEF_TIM_DMA__BTCH_TIM4_CH3    D(1, 5)
+#define DEF_TIM_DMA__BTCH_TIM4_UP     D(1, 7)
+#define DEF_TIM_DMA__BTCH_TIM4_CH4    NONE
+
+#define DEF_TIM_DMA__BTCH_TIM15_CH1   D(1, 5)
+#define DEF_TIM_DMA__BTCH_TIM15_CH2   NONE
+#define DEF_TIM_DMA__BTCH_TIM15_UP    D(1, 5)
+#define DEF_TIM_DMA__BTCH_TIM15_TRIG  D(1, 5)
+#define DEF_TIM_DMA__BTCH_TIM15_COM   D(1, 5)
 
 #ifdef REMAP_TIM16_DMA
-#define DEF_TIM_DMA__TIM16_CH1   DMA1_CH6
-#define DEF_TIM_DMA__TIM16_CH1N  DMA1_CH6
-#define DEF_TIM_DMA__TIM16_UP    DMA1_CH6
+#define DEF_TIM_DMA__BTCH_TIM16_CH1   D(1, 6)
+#define DEF_TIM_DMA__BTCH_TIM16_UP    D(1, 6)
 #else
-#define DEF_TIM_DMA__TIM16_CH1   DMA1_CH3
-#define DEF_TIM_DMA__TIM16_CH1N  DMA1_CH3
-#define DEF_TIM_DMA__TIM16_UP    DMA1_CH3
+#define DEF_TIM_DMA__BTCH_TIM16_CH1   D(1, 3)
+#define DEF_TIM_DMA__BTCH_TIM16_UP    D(1, 3)
 #endif
 
 #ifdef REMAP_TIM17_DMA
-#define DEF_TIM_DMA__TIM17_CH1   DMA1_CH7
-#define DEF_TIM_DMA__TIM17_CH1N  DMA1_CH7
-#define DEF_TIM_DMA__TIM17_UP    DMA1_CH7
+#define DEF_TIM_DMA__BTCH_TIM17_CH1   D(1, 7)
+#define DEF_TIM_DMA__BTCH_TIM17_UP    D(1, 7)
 #else
-#define DEF_TIM_DMA__TIM17_CH1   DMA1_CH1
-#define DEF_TIM_DMA__TIM17_CH1N  DMA1_CH1
-#define DEF_TIM_DMA__TIM17_UP    DMA1_CH1
+#define DEF_TIM_DMA__BTCH_TIM17_CH1   D(1, 1)
+#define DEF_TIM_DMA__BTCH_TIM17_UP    D(1, 1)
 #endif
 
-#define DEF_TIM_DMA__TIM8_CH3    DMA2_CH1
-#define DEF_TIM_DMA__TIM8_CH3N   DMA2_CH1
-#define DEF_TIM_DMA__TIM8_UP     DMA2_CH1
-#define DEF_TIM_DMA__TIM8_CH4    DMA2_CH2
-#define DEF_TIM_DMA__TIM8_TRIG   DMA2_CH2
-#define DEF_TIM_DMA__TIM8_COM    DMA2_CH2
-#define DEF_TIM_DMA__TIM8_CH1    DMA2_CH3
-#define DEF_TIM_DMA__TIM8_CH1N   DMA2_CH3
-#define DEF_TIM_DMA__TIM8_CH2    DMA2_CH5
-#define DEF_TIM_DMA__TIM8_CH2N   DMA2_CH5
+#define DEF_TIM_DMA__BTCH_TIM8_CH3    D(2, 1)
+#define DEF_TIM_DMA__BTCH_TIM8_UP     D(2, 1)
+#define DEF_TIM_DMA__BTCH_TIM8_CH4    D(2, 2)
+#define DEF_TIM_DMA__BTCH_TIM8_TRIG   D(2, 2)
+#define DEF_TIM_DMA__BTCH_TIM8_COM    D(2, 2)
+#define DEF_TIM_DMA__BTCH_TIM8_CH1    D(2, 3)
+#define DEF_TIM_DMA__BTCH_TIM8_CH2    D(2, 5)
 
+// AF table
 
-#define GPIO_AF(p, t) CONCAT(GPIO_AF__, p, _, t)
+#define DEF_TIM_AF__PA0__TCH_TIM2_CH1     D(1)
+#define DEF_TIM_AF__PA1__TCH_TIM2_CH2     D(1)
+#define DEF_TIM_AF__PA2__TCH_TIM2_CH3     D(1)
+#define DEF_TIM_AF__PA3__TCH_TIM2_CH4     D(1)
+#define DEF_TIM_AF__PA5__TCH_TIM2_CH1     D(1)
+#define DEF_TIM_AF__PA6__TCH_TIM16_CH1    D(1)
+#define DEF_TIM_AF__PA7__TCH_TIM17_CH1    D(1)
+#define DEF_TIM_AF__PA12__TCH_TIM16_CH1   D(1)
+#define DEF_TIM_AF__PA13__TCH_TIM16_CH1N  D(1)
+#define DEF_TIM_AF__PA15__TCH_TIM2_CH1    D(1)
 
-#define GPIO_AF__PA0_TIM2_CH1     GPIO_AF_1
-#define GPIO_AF__PA1_TIM2_CH2     GPIO_AF_1
-#define GPIO_AF__PA2_TIM2_CH3     GPIO_AF_1
-#define GPIO_AF__PA3_TIM2_CH4     GPIO_AF_1
-#define GPIO_AF__PA5_TIM2_CH1     GPIO_AF_1
-#define GPIO_AF__PA6_TIM16_CH1    GPIO_AF_1
-#define GPIO_AF__PA7_TIM17_CH1    GPIO_AF_1
-#define GPIO_AF__PA12_TIM16_CH1   GPIO_AF_1
-#define GPIO_AF__PA13_TIM16_CH1N  GPIO_AF_1
-#define GPIO_AF__PA15_TIM2_CH1    GPIO_AF_1
+#define DEF_TIM_AF__PA4__TCH_TIM3_CH2     D(2)
+#define DEF_TIM_AF__PA6__TCH_TIM3_CH1     D(2)
+#define DEF_TIM_AF__PA7__TCH_TIM3_CH2     D(2)
+#define DEF_TIM_AF__PA15__TCH_TIM8_CH1    D(2)
 
-#define GPIO_AF__PA4_TIM3_CH2     GPIO_AF_2
-#define GPIO_AF__PA6_TIM3_CH1     GPIO_AF_2
-#define GPIO_AF__PA7_TIM3_CH2     GPIO_AF_2
-#define GPIO_AF__PA15_TIM8_CH1    GPIO_AF_2
+#define DEF_TIM_AF__PA7__TCH_TIM8_CH1N    D(4)
 
-#define GPIO_AF__PA7_TIM8_CH1N    GPIO_AF_4
+#define DEF_TIM_AF__PA14__TCH_TIM4_CH2    D(5)
 
-#define GPIO_AF__PA14_TIM4_CH2    GPIO_AF_5
+#define DEF_TIM_AF__PA7__TCH_TIM1_CH1N    D(6)
+#define DEF_TIM_AF__PA8__TCH_TIM1_CH1     D(6)
+#define DEF_TIM_AF__PA9__TCH_TIM1_CH2     D(6)
+#define DEF_TIM_AF__PA10__TCH_TIM1_CH3    D(6)
+#define DEF_TIM_AF__PA11__TCH_TIM1_CH1N   D(6)
+#define DEF_TIM_AF__PA12__TCH_TIM1_CH2N   D(6)
 
-#define GPIO_AF__PA7_TIM1_CH1N    GPIO_AF_6
-#define GPIO_AF__PA8_TIM1_CH1     GPIO_AF_6
-#define GPIO_AF__PA9_TIM1_CH2     GPIO_AF_6
-#define GPIO_AF__PA10_TIM1_CH3    GPIO_AF_6
-#define GPIO_AF__PA11_TIM1_CH1N   GPIO_AF_6
-#define GPIO_AF__PA12_TIM1_CH2N   GPIO_AF_6
+#define DEF_TIM_AF__PA1__TCH_TIM15_CH1N   D(9)
+#define DEF_TIM_AF__PA2__TCH_TIM15_CH1    D(9)
+#define DEF_TIM_AF__PA3__TCH_TIM15_CH2    D(9)
 
-#define GPIO_AF__PA1_TIM15_CH1N   GPIO_AF_9
-#define GPIO_AF__PA2_TIM15_CH1    GPIO_AF_9
-#define GPIO_AF__PA3_TIM15_CH2    GPIO_AF_9
+#define DEF_TIM_AF__PA9__TCH_TIM2_CH3     D(10)
+#define DEF_TIM_AF__PA10__TCH_TIM2_CH4    D(10)
+#define DEF_TIM_AF__PA11__TCH_TIM4_CH1    D(10)
+#define DEF_TIM_AF__PA12__TCH_TIM4_CH2    D(10)
+#define DEF_TIM_AF__PA13__TCH_TIM4_CH3    D(10)
+#define DEF_TIM_AF__PA11__TCH_TIM1_CH4    D(11)
 
-#define GPIO_AF__PA9_TIM2_CH3     GPIO_AF_10
-#define GPIO_AF__PA10_TIM2_CH4    GPIO_AF_10
-#define GPIO_AF__PA11_TIM4_CH1    GPIO_AF_10
-#define GPIO_AF__PA12_TIM4_CH2    GPIO_AF_10
-#define GPIO_AF__PA13_TIM4_CH3    GPIO_AF_10
-#define GPIO_AF__PA11_TIM1_CH4    GPIO_AF_11
+#define DEF_TIM_AF__PB3__TCH_TIM2_CH2     D(1)
+#define DEF_TIM_AF__PB4__TCH_TIM16_CH1    D(1)
+#define DEF_TIM_AF__PB6__TCH_TIM16_CH1N   D(1)
+#define DEF_TIM_AF__PB7__TCH_TIM17_CH1N   D(1)
+#define DEF_TIM_AF__PB8__TCH_TIM16_CH1    D(1)
+#define DEF_TIM_AF__PB9__TCH_TIM17_CH1    D(1)
+#define DEF_TIM_AF__PB10__TCH_TIM2_CH3    D(1)
+#define DEF_TIM_AF__PB11__TCH_TIM2_CH4    D(1)
+#define DEF_TIM_AF__PB14__TCH_TIM15_CH1   D(1)
+#define DEF_TIM_AF__PB15__TCH_TIM15_CH2   D(1)
 
-#define GPIO_AF__PB3_TIM2_CH2     GPIO_AF_1
-#define GPIO_AF__PB4_TIM16_CH1    GPIO_AF_1
-#define GPIO_AF__PB6_TIM16_CH1N   GPIO_AF_1
-#define GPIO_AF__PB7_TIM17_CH1N   GPIO_AF_1
-#define GPIO_AF__PB8_TIM16_CH1    GPIO_AF_1
-#define GPIO_AF__PB9_TIM17_CH1    GPIO_AF_1
-#define GPIO_AF__PB10_TIM2_CH3    GPIO_AF_1
-#define GPIO_AF__PB11_TIM2_CH4    GPIO_AF_1
-#define GPIO_AF__PB14_TIM15_CH1   GPIO_AF_1
-#define GPIO_AF__PB15_TIM15_CH2   GPIO_AF_1
+#define DEF_TIM_AF__PB0__TCH_TIM3_CH3     D(2)
+#define DEF_TIM_AF__PB1__TCH_TIM3_CH4     D(2)
+#define DEF_TIM_AF__PB4__TCH_TIM3_CH1     D(2)
+#define DEF_TIM_AF__PB5__TCH_TIM3_CH2     D(2)
+#define DEF_TIM_AF__PB6__TCH_TIM4_CH1     D(2)
+#define DEF_TIM_AF__PB7__TCH_TIM4_CH2     D(2)
+#define DEF_TIM_AF__PB8__TCH_TIM4_CH3     D(2)
+#define DEF_TIM_AF__PB9__TCH_TIM4_CH4     D(2)
+#define DEF_TIM_AF__PB15__TCH_TIM15_CH1N  D(2)
 
-#define GPIO_AF__PB0_TIM3_CH3     GPIO_AF_2
-#define GPIO_AF__PB1_TIM3_CH4     GPIO_AF_2
-#define GPIO_AF__PB4_TIM3_CH1     GPIO_AF_2
-#define GPIO_AF__PB5_TIM3_CH2     GPIO_AF_2
-#define GPIO_AF__PB6_TIM4_CH1     GPIO_AF_2
-#define GPIO_AF__PB7_TIM4_CH2     GPIO_AF_2
-#define GPIO_AF__PB8_TIM4_CH3     GPIO_AF_2
-#define GPIO_AF__PB9_TIM4_CH4     GPIO_AF_2
-#define GPIO_AF__PB15_TIM15_CH1N  GPIO_AF_2
+#define DEF_TIM_AF__PB5__TCH_TIM8_CH3N    D(3)
 
-#define GPIO_AF__PB5_TIM8_CH3N    GPIO_AF_3
+#define DEF_TIM_AF__PB0__TCH_TIM8_CH2N    D(4)
+#define DEF_TIM_AF__PB1__TCH_TIM8_CH3N    D(4)
+#define DEF_TIM_AF__PB3__TCH_TIM8_CH1N    D(4)
+#define DEF_TIM_AF__PB4__TCH_TIM8_CH2N    D(4)
+#define DEF_TIM_AF__PB15__TCH_TIM1_CH3N   D(4)
 
-#define GPIO_AF__PB0_TIM8_CH2N    GPIO_AF_4
-#define GPIO_AF__PB1_TIM8_CH3N    GPIO_AF_4
-#define GPIO_AF__PB3_TIM8_CH1N    GPIO_AF_4
-#define GPIO_AF__PB4_TIM8_CH2N    GPIO_AF_4
-#define GPIO_AF__PB15_TIM1_CH3N   GPIO_AF_4
+#define DEF_TIM_AF__PB6__TCH_TIM8_CH1     D(5)
 
-#define GPIO_AF__PB6_TIM8_CH1     GPIO_AF_5
+#define DEF_TIM_AF__PB0__TCH_TIM1_CH2N    D(6)
+#define DEF_TIM_AF__PB1__TCH_TIM1_CH3N    D(6)
+#define DEF_TIM_AF__PB13__TCH_TIM1_CH1N   D(6)
+#define DEF_TIM_AF__PB14__TCH_TIM1_CH2N   D(6)
 
-#define GPIO_AF__PB0_TIM1_CH2N    GPIO_AF_6
-#define GPIO_AF__PB1_TIM1_CH3N    GPIO_AF_6
-#define GPIO_AF__PB13_TIM1_CH1N   GPIO_AF_6
-#define GPIO_AF__PB14_TIM1_CH2N   GPIO_AF_6
+#define DEF_TIM_AF__PB5__TCH_TIM17_CH1    D(10)
+#define DEF_TIM_AF__PB7__TCH_TIM3_CH4     D(10)
+#define DEF_TIM_AF__PB8__TCH_TIM8_CH2     D(10)
+#define DEF_TIM_AF__PB9__TCH_TIM8_CH3     D(10)
 
-#define GPIO_AF__PB5_TIM17_CH1    GPIO_AF_10
-#define GPIO_AF__PB7_TIM3_CH4     GPIO_AF_10
-#define GPIO_AF__PB8_TIM8_CH2     GPIO_AF_10
-#define GPIO_AF__PB9_TIM8_CH3     GPIO_AF_10
+#define DEF_TIM_AF__PC6__TCH_TIM3_CH1     D(2)
+#define DEF_TIM_AF__PC7__TCH_TIM3_CH2     D(2)
+#define DEF_TIM_AF__PC8__TCH_TIM3_CH3     D(2)
+#define DEF_TIM_AF__PC9__TCH_TIM3_CH4     D(2)
 
-#define GPIO_AF__PC6_TIM3_CH1     GPIO_AF_2
-#define GPIO_AF__PC7_TIM3_CH2     GPIO_AF_2
-#define GPIO_AF__PC8_TIM3_CH3     GPIO_AF_2
-#define GPIO_AF__PC9_TIM3_CH4     GPIO_AF_2
+#define DEF_TIM_AF__PC6__TCH_TIM8_CH1     D(4)
+#define DEF_TIM_AF__PC7__TCH_TIM8_CH2     D(4)
+#define DEF_TIM_AF__PC8__TCH_TIM8_CH3     D(4)
+#define DEF_TIM_AF__PC9__TCH_TIM8_CH4     D(4)
 
-#define GPIO_AF__PC6_TIM8_CH1     GPIO_AF_4
-#define GPIO_AF__PC7_TIM8_CH2     GPIO_AF_4
-#define GPIO_AF__PC8_TIM8_CH3     GPIO_AF_4
-#define GPIO_AF__PC9_TIM8_CH4     GPIO_AF_4
+#define DEF_TIM_AF__PC10__TCH_TIM8_CH1N   D(4)
+#define DEF_TIM_AF__PC11__TCH_TIM8_CH2N   D(4)
+#define DEF_TIM_AF__PC12__TCH_TIM8_CH3N   D(4)
+#define DEF_TIM_AF__PC13__TCH_TIM8_CH1N   D(4)
 
-#define GPIO_AF__PC10_TIM8_CH1N   GPIO_AF_4
-#define GPIO_AF__PC11_TIM8_CH2N   GPIO_AF_4
-#define GPIO_AF__PC12_TIM8_CH3N   GPIO_AF_4
-#define GPIO_AF__PC13_TIM8_CH1N   GPIO_AF_4
+#define DEF_TIM_AF__PD3__TCH_TIM2_CH1     D(2)
+#define DEF_TIM_AF__PD4__TCH_TIM2_CH2     D(2)
+#define DEF_TIM_AF__PD6__TCH_TIM2_CH4     D(2)
+#define DEF_TIM_AF__PD7__TCH_TIM2_CH3     D(2)
 
-#define GPIO_AF__PD3_TIM2_CH1     GPIO_AF_2
-#define GPIO_AF__PD4_TIM2_CH2     GPIO_AF_2
-#define GPIO_AF__PD6_TIM2_CH4     GPIO_AF_2
-#define GPIO_AF__PD7_TIM2_CH3     GPIO_AF_2
+#define DEF_TIM_AF__PD12__TCH_TIM4_CH1    D(2)
+#define DEF_TIM_AF__PD13__TCH_TIM4_CH2    D(2)
+#define DEF_TIM_AF__PD14__TCH_TIM4_CH3    D(2)
+#define DEF_TIM_AF__PD15__TCH_TIM4_CH4    D(2)
 
-#define GPIO_AF__PD12_TIM4_CH1    GPIO_AF_2
-#define GPIO_AF__PD13_TIM4_CH2    GPIO_AF_2
-#define GPIO_AF__PD14_TIM4_CH3    GPIO_AF_2
-#define GPIO_AF__PD15_TIM4_CH4    GPIO_AF_2
+#define DEF_TIM_AF__PD1__TCH_TIM8_CH4     D(4)
 
-#define GPIO_AF__PD1_TIM8_CH4     GPIO_AF_4
-
-#define GPIO_AF__PF9_TIM15_CH1    GPIO_AF_3
-#define GPIO_AF__PF10_TIM15_CH2   GPIO_AF_3
+#define DEF_TIM_AF__PF9__TCH_TIM15_CH1    D(3)
+#define DEF_TIM_AF__PF10__TCH_TIM15_CH2   D(3)
 
 #elif defined(STM32F4)
 
-#define DMA_OPT_FIRST     0
-#define DMA_OPT_SECOND    0
-#define DMA_OPT_THIRD     0
+#define DEF_TIM(tim, chan, pin, flags, out, dmaopt) {           \
+    tim,                                                        \
+    IO_TAG(pin),                                                \
+    DEF_TIM_CHANNEL(CH_ ## chan),                               \
+    flags,                                                      \
+    (DEF_TIM_OUTPUT(CH_ ## chan) | out),                        \
+    DEF_TIM_AF(TIM_ ## tim),                                    \
+    DEF_TIM_DMA_COND(                                           \
+        DEF_TIM_DMA_STREAM(dmaopt, TCH_## tim ## _ ## chan),    \
+        DEF_TIM_DMA_CHANNEL(dmaopt, TCH_## tim ## _ ## chan),   \
+        DEF_TIM_DMA_HANDLER(dmaopt, TCH_## tim ## _ ## chan)    \
+    )                                                           \
+}                                                               \
+/**/
 
-#define DEF_TIM(tim, chan, pin, flags, out, dmaopt) {\
-    tim,\
-    IO_TAG(pin),\
-    EXPAND(DEF_CHAN_ ## chan),\
-    flags,\
-    (DEF_CHAN_ ## chan ## _OUTPUT | out),\
-    EXPAND(GPIO_AF_## tim),\
-    DEF_TIM_DMA_COND(\
-        CONCAT(EXPAND(DEF_TIM_DMA_STR_ ## dmaopt ## __ ## tim ## _ ## chan), _STREAM),\
-        EXPAND(DEF_TIM_DMA_CHN_ ## dmaopt ## __ ## tim ## _ ## chan),\
-        CONCAT(EXPAND(DEF_TIM_DMA_STR_ ## dmaopt ## __ ## tim ## _ ## chan), _HANDLER)\
-    )\
-    }
+#define DEF_TIM_CHANNEL(ch)                   CONCAT(DEF_TIM_CHANNEL__, DEF_TIM_CH_GET(ch))
+#define DEF_TIM_CHANNEL__D(chan_n, n_channel) TIM_Channel_ ## chan_n
 
-#define DEF_DMA_CHANNEL(tim, chan, dmaopt) EXPAND(DEF_TIM_DMA_CHN_ ## dmaopt ## __ ## tim ## _ ## chan)
-#define DEF_DMA_STREAM(tim, chan, dmaopt) CONCAT(EXPAND(DEF_TIM_DMA_STR_ ## dmaopt ## __ ## tim ## _ ## chan), _STREAM)
-#define DEF_DMA_HANDLER(tim, chan, dmaopt) CONCAT(EXPAND(DEF_TIM_DMA_STR_ ## dmaopt ## __ ## tim ## _ ## chan), _HANDLER)
+#define DEF_TIM_AF(tim)                       CONCAT(DEF_TIM_AF__, DEF_TIM_TIM_GET(tim))
+#define DEF_TIM_AF__D(tim_n)                  GPIO_AF_TIM ## tim_n
+
+#define DEF_TIM_DMA_CHANNEL(variant, timch) \
+    CONCAT(DEF_TIM_DMA_CHANNEL__, DEF_TIM_DMA_GET(variant, timch))
+#define DEF_TIM_DMA_CHANNEL__D(dma_n, stream_n, chan_n)    DMA_Channel_ ## chan_n
+#define DEF_TIM_DMA_CHANNEL__NONE                          DMA_Channel_0
+
+#define DEF_TIM_DMA_STREAM(variant, timch)                              \
+    CONCAT(DEF_TIM_DMA_STREAM__, DEF_TIM_DMA_GET(variant, timch))
+#define DEF_TIM_DMA_STREAM__D(dma_n, stream_n, chan_n)  DMA ## dma_n ## _Stream ## stream_n
+#define DEF_TIM_DMA_STREAM__NONE                        NULL
+
+#define DEF_TIM_DMA_HANDLER(variant, timch) \
+    CONCAT(DEF_TIM_DMA_HANDLER__, DEF_TIM_DMA_GET(variant, timch))
+#define DEF_TIM_DMA_HANDLER__D(dma_n, stream_n, chan_n) DMA ## dma_n ## _ST ## stream_n ## _HANDLER
+#define DEF_TIM_DMA_HANDLER__NONE                       0
+
 
 /* F4 Stream Mappings */
+// D(DMAx, Stream, Channel)
+#define DEF_TIM_DMA__BTCH_TIM1_CH1    D(2, 6, 0),D(2, 1, 6),D(2, 3, 6)
+#define DEF_TIM_DMA__BTCH_TIM1_CH2    D(2, 6, 0),D(2, 2, 6)
+#define DEF_TIM_DMA__BTCH_TIM1_CH3    D(2, 6, 0),D(2, 6, 6)
+#define DEF_TIM_DMA__BTCH_TIM1_CH4    D(2, 4, 6)
 
-#define DEF_TIM_DMA_STR_0__TIM1_CH1    DMA2_ST6
-#define DEF_TIM_DMA_STR_1__TIM1_CH1    DMA2_ST1
-#define DEF_TIM_DMA_STR_2__TIM1_CH1    DMA2_ST3
-#define DEF_TIM_DMA_STR_0__TIM1_CH1N   DMA2_ST6
-#define DEF_TIM_DMA_STR_1__TIM1_CH1N   DMA2_ST1
-#define DEF_TIM_DMA_STR_2__TIM1_CH1N   DMA2_ST3
-#define DEF_TIM_DMA_STR_0__TIM1_CH2    DMA2_ST6
-#define DEF_TIM_DMA_STR_1__TIM1_CH2    DMA2_ST2
-#define DEF_TIM_DMA_STR_0__TIM1_CH2N   DMA2_ST6
-#define DEF_TIM_DMA_STR_1__TIM1_CH2N   DMA2_ST2
-#define DEF_TIM_DMA_STR_0__TIM1_CH3    DMA2_ST6
-#define DEF_TIM_DMA_STR_1__TIM1_CH3    DMA2_ST6
-#define DEF_TIM_DMA_STR_0__TIM1_CH3N   DMA2_ST6
-#define DEF_TIM_DMA_STR_1__TIM1_CH3N   DMA2_ST6
-#define DEF_TIM_DMA_STR_0__TIM1_CH4    DMA2_ST4
+#define DEF_TIM_DMA__BTCH_TIM2_CH1    D(1, 5, 3)
+#define DEF_TIM_DMA__BTCH_TIM2_CH2    D(1, 6, 3)
+#define DEF_TIM_DMA__BTCH_TIM2_CH3    D(1, 1, 3)
+#define DEF_TIM_DMA__BTCH_TIM2_CH4    D(1, 7, 3),D(1, 6, 3)
 
-#define DEF_TIM_DMA_STR_0__TIM2_CH1    DMA1_ST5
-#define DEF_TIM_DMA_STR_0__TIM2_CH2    DMA1_ST6
-#define DEF_TIM_DMA_STR_0__TIM2_CH3    DMA1_ST1
-#define DEF_TIM_DMA_STR_0__TIM2_CH4    DMA1_ST7
-#define DEF_TIM_DMA_STR_1__TIM2_CH4    DMA1_ST6
+#define DEF_TIM_DMA__BTCH_TIM3_CH1    D(1, 4, 5)
+#define DEF_TIM_DMA__BTCH_TIM3_CH2    D(1, 5, 5)
+#define DEF_TIM_DMA__BTCH_TIM3_CH3    D(1, 7, 5)
+#define DEF_TIM_DMA__BTCH_TIM3_CH4    D(1, 2, 5)
 
-#define DEF_TIM_DMA_STR_0__TIM3_CH1    DMA1_ST4
-#define DEF_TIM_DMA_STR_0__TIM3_CH2    DMA1_ST5
-#define DEF_TIM_DMA_STR_0__TIM3_CH3    DMA1_ST7
-#define DEF_TIM_DMA_STR_0__TIM3_CH4    DMA1_ST2
+#define DEF_TIM_DMA__BTCH_TIM4_CH1    D(1, 0, 2)
+#define DEF_TIM_DMA__BTCH_TIM4_CH2    D(1, 3, 2)
+#define DEF_TIM_DMA__BTCH_TIM4_CH3    D(1, 7, 2)
 
-#define DEF_TIM_DMA_STR_0__TIM4_CH1    DMA1_ST0
-#define DEF_TIM_DMA_STR_0__TIM4_CH2    DMA1_ST3
-#define DEF_TIM_DMA_STR_0__TIM4_CH3    DMA1_ST7
+#define DEF_TIM_DMA__BTCH_TIM5_CH1    D(1, 2, 6)
+#define DEF_TIM_DMA__BTCH_TIM5_CH2    D(1, 4, 6)
+#define DEF_TIM_DMA__BTCH_TIM5_CH3    D(1, 0, 6)
+#define DEF_TIM_DMA__BTCH_TIM5_CH4    D(1, 1, 6),D(1, 3, 6)
 
-#define DEF_TIM_DMA_STR_0__TIM5_CH1    DMA1_ST2
-#define DEF_TIM_DMA_STR_0__TIM5_CH2    DMA1_ST4
-#define DEF_TIM_DMA_STR_0__TIM5_CH3    DMA1_ST0
-#define DEF_TIM_DMA_STR_0__TIM5_CH4    DMA1_ST1
-#define DEF_TIM_DMA_STR_1__TIM5_CH4    DMA1_ST3
+#define DEF_TIM_DMA__BTCH_TIM8_CH1    D(2, 2, 0),D(2, 2, 7)
+#define DEF_TIM_DMA__BTCH_TIM8_CH2    D(2, 2, 0),D(2, 3, 7)
+#define DEF_TIM_DMA__BTCH_TIM8_CH3    D(2, 2, 0),D(2, 4, 7)
+#define DEF_TIM_DMA__BTCH_TIM8_CH4    D(2, 7, 7)
 
-#define DEF_TIM_DMA_STR_0__TIM8_CH1    DMA2_ST2
-#define DEF_TIM_DMA_STR_1__TIM8_CH1    DMA2_ST2
-#define DEF_TIM_DMA_STR_0__TIM8_CH1N   DMA2_ST2
-#define DEF_TIM_DMA_STR_1__TIM8_CH1N   DMA2_ST2
-#define DEF_TIM_DMA_STR_0__TIM8_CH2    DMA2_ST2
-#define DEF_TIM_DMA_STR_1__TIM8_CH2    DMA2_ST3
-#define DEF_TIM_DMA_STR_0__TIM8_CH2N   DMA2_ST3
-#define DEF_TIM_DMA_STR_1__TIM8_CH2N   DMA2_ST2
-#define DEF_TIM_DMA_STR_0__TIM8_CH3    DMA2_ST2
-#define DEF_TIM_DMA_STR_1__TIM8_CH3    DMA2_ST4
-#define DEF_TIM_DMA_STR_0__TIM8_CH3N   DMA2_ST2
-#define DEF_TIM_DMA_STR_1__TIM8_CH3N   DMA2_ST4
-#define DEF_TIM_DMA_STR_0__TIM8_CH4    DMA2_ST7
+#define DEF_TIM_DMA__BTCH_TIM4_CH4    NONE
 
-#define DEF_TIM_DMA_STR_0__TIM4_CH4    DMA_NONE
+#define DEF_TIM_DMA__BTCH_TIM9_CH1    NONE
+#define DEF_TIM_DMA__BTCH_TIM9_CH2    NONE
 
-#define DEF_TIM_DMA_STR_0__TIM9_CH1    DMA_NONE
-#define DEF_TIM_DMA_STR_0__TIM9_CH2    DMA_NONE
+#define DEF_TIM_DMA__BTCH_TIM10_CH1   NONE
 
-#define DEF_TIM_DMA_STR_0__TIM10_CH1   DMA_NONE
+#define DEF_TIM_DMA__BTCH_TIM11_CH1   NONE
 
-#define DEF_TIM_DMA_STR_0__TIM11_CH1   DMA_NONE
+#define DEF_TIM_DMA__BTCH_TIM12_CH1   NONE
+#define DEF_TIM_DMA__BTCH_TIM12_CH2   NONE
 
-#define DEF_TIM_DMA_STR_0__TIM12_CH1   DMA_NONE
-#define DEF_TIM_DMA_STR_0__TIM12_CH2   DMA_NONE
+#define DEF_TIM_DMA__BTCH_TIM13_CH1   NONE
 
-#define DEF_TIM_DMA_STR_0__TIM13_CH1   DMA_NONE
-
-#define DEF_TIM_DMA_STR_0__TIM14_CH1   DMA_NONE
-
-/* F4 Channel Mappings */
-
-#define DEF_TIM_DMA_CHN_0__TIM1_CH1    DMA_Channel_0
-#define DEF_TIM_DMA_CHN_1__TIM1_CH1    DMA_Channel_6
-#define DEF_TIM_DMA_CHN_2__TIM1_CH1    DMA_Channel_6
-#define DEF_TIM_DMA_CHN_0__TIM1_CH1N   DMA_Channel_0
-#define DEF_TIM_DMA_CHN_1__TIM1_CH1N   DMA_Channel_6
-#define DEF_TIM_DMA_CHN_2__TIM1_CH1N   DMA_Channel_6
-#define DEF_TIM_DMA_CHN_0__TIM1_CH2    DMA_Channel_0
-#define DEF_TIM_DMA_CHN_1__TIM1_CH2    DMA_Channel_6
-#define DEF_TIM_DMA_CHN_0__TIM1_CH2N   DMA_Channel_0
-#define DEF_TIM_DMA_CHN_1__TIM1_CH2N   DMA_Channel_6
-#define DEF_TIM_DMA_CHN_0__TIM1_CH3    DMA_Channel_0
-#define DEF_TIM_DMA_CHN_1__TIM1_CH3    DMA_Channel_6
-#define DEF_TIM_DMA_CHN_0__TIM1_CH3N   DMA_Channel_0
-#define DEF_TIM_DMA_CHN_1__TIM1_CH3N   DMA_Channel_6
-#define DEF_TIM_DMA_CHN_0__TIM1_CH4    DMA_Channel_6
-
-#define DEF_TIM_DMA_CHN_0__TIM2_CH1    DMA_Channel_3
-#define DEF_TIM_DMA_CHN_0__TIM2_CH2    DMA_Channel_3
-#define DEF_TIM_DMA_CHN_0__TIM2_CH3    DMA_Channel_3
-#define DEF_TIM_DMA_CHN_0__TIM2_CH4    DMA_Channel_3
-#define DEF_TIM_DMA_CHN_1__TIM2_CH4    DMA_Channel_3
-
-#define DEF_TIM_DMA_CHN_0__TIM3_CH1    DMA_Channel_5
-#define DEF_TIM_DMA_CHN_0__TIM3_CH2    DMA_Channel_5
-#define DEF_TIM_DMA_CHN_0__TIM3_CH3    DMA_Channel_5
-#define DEF_TIM_DMA_CHN_0__TIM3_CH4    DMA_Channel_5
-
-#define DEF_TIM_DMA_CHN_0__TIM4_CH1    DMA_Channel_2
-#define DEF_TIM_DMA_CHN_0__TIM4_CH2    DMA_Channel_2
-#define DEF_TIM_DMA_CHN_0__TIM4_CH3    DMA_Channel_2
-
-#define DEF_TIM_DMA_CHN_0__TIM5_CH1    DMA_Channel_6
-#define DEF_TIM_DMA_CHN_0__TIM5_CH2    DMA_Channel_6
-#define DEF_TIM_DMA_CHN_0__TIM5_CH3    DMA_Channel_6
-#define DEF_TIM_DMA_CHN_0__TIM5_CH4    DMA_Channel_6
-#define DEF_TIM_DMA_CHN_1__TIM5_CH4    DMA_Channel_6
-
-#define DEF_TIM_DMA_CHN_0__TIM8_CH1    DMA_Channel_0
-#define DEF_TIM_DMA_CHN_1__TIM8_CH1    DMA_Channel_7
-#define DEF_TIM_DMA_CHN_0__TIM8_CH1N   DMA_Channel_0
-#define DEF_TIM_DMA_CHN_1__TIM8_CH1N   DMA_Channel_7
-#define DEF_TIM_DMA_CHN_0__TIM8_CH2    DMA_Channel_0
-#define DEF_TIM_DMA_CHN_1__TIM8_CH2    DMA_Channel_7
-#define DEF_TIM_DMA_CHN_0__TIM8_CH2N   DMA_Channel_0
-#define DEF_TIM_DMA_CHN_1__TIM8_CH2N   DMA_Channel_7
-#define DEF_TIM_DMA_CHN_0__TIM8_CH3    DMA_Channel_0
-#define DEF_TIM_DMA_CHN_1__TIM8_CH3    DMA_Channel_7
-#define DEF_TIM_DMA_CHN_0__TIM8_CH3N   DMA_Channel_0
-#define DEF_TIM_DMA_CHN_1__TIM8_CH3N   DMA_Channel_7
-#define DEF_TIM_DMA_CHN_0__TIM8_CH4    DMA_Channel_7
-
-#define DEF_TIM_DMA_CHN_0__TIM4_CH4    0
-
-#define DEF_TIM_DMA_CHN_0__TIM9_CH1    0
-#define DEF_TIM_DMA_CHN_0__TIM9_CH2    0
-
-#define DEF_TIM_DMA_CHN_0__TIM10_CH1   0
-
-#define DEF_TIM_DMA_CHN_0__TIM11_CH1   0
-
-#define DEF_TIM_DMA_CHN_0__TIM12_CH1   0
-#define DEF_TIM_DMA_CHN_0__TIM12_CH2   0
-
-#define DEF_TIM_DMA_CHN_0__TIM13_CH1   0
-
-#define DEF_TIM_DMA_CHN_0__TIM14_CH1   0
-
-#define DMA1_ST0_STREAM                DMA1_Stream0
-#define DMA1_ST1_STREAM                DMA1_Stream1
-#define DMA1_ST2_STREAM                DMA1_Stream2
-#define DMA1_ST3_STREAM                DMA1_Stream3
-#define DMA1_ST4_STREAM                DMA1_Stream4
-#define DMA1_ST5_STREAM                DMA1_Stream5
-#define DMA1_ST6_STREAM                DMA1_Stream6
-#define DMA1_ST7_STREAM                DMA1_Stream7
-#define DMA2_ST0_STREAM                DMA2_Stream0
-#define DMA2_ST1_STREAM                DMA2_Stream1
-#define DMA2_ST2_STREAM                DMA2_Stream2
-#define DMA2_ST3_STREAM                DMA2_Stream3
-#define DMA2_ST4_STREAM                DMA2_Stream4
-#define DMA2_ST5_STREAM                DMA2_Stream5
-#define DMA2_ST6_STREAM                DMA2_Stream6
-#define DMA2_ST7_STREAM                DMA2_Stream7
+#define DEF_TIM_DMA__BTCH_TIM14_CH1   NONE
 
 #elif defined(STM32F7)
-#define DEF_TIM(tim, chan, pin, flags, out, dmaopt) {\
-    tim,\
-    IO_TAG(pin),\
-    EXPAND(DEF_CHAN_ ## chan),\
-    flags,\
-    (DEF_CHAN_ ## chan ## _OUTPUT | out),\
-    EXPAND(GPIO_AF__ ## pin ## _ ## tim ## _ ## chan),\
-    DEF_TIM_DMA_COND(\
-        CONCAT(EXPAND(DEF_TIM_DMA_STR_ ## dmaopt ## __ ## tim ## _ ## chan), _STREAM),\
-        EXPAND(DEF_TIM_DMA_CHN_ ## dmaopt ## __ ## tim ## _ ## chan),\
-        CONCAT(EXPAND(DEF_TIM_DMA_STR_ ## dmaopt ## __ ## tim ## _ ## chan), _HANDLER)\
-    )\
-    }
+#define DEF_TIM(tim, chan, pin, flags, out, dmaopt) {                   \
+    tim,                                                                \
+    IO_TAG(pin),                                                        \
+    DEF_TIM_CHANNEL(CH_ ## chan),                                       \
+    flags,                                                              \
+    (DEF_TIM_OUTPUT(CH_ ## chan) | out),                                \
+    DEF_TIM_AF(TCH_## tim ## _ ## chan, pin),                           \
+    DEF_TIM_DMA_COND(                                                   \
+        DEF_TIM_DMA_STREAM(dmaopt, TCH_## tim ## _ ## chan),            \
+        DEF_TIM_DMA_CHANNEL(dmaopt, TCH_## tim ## _ ## chan),           \
+        DEF_TIM_DMA_HANDLER(dmaopt, TCH_## tim ## _ ## chan)            \
+    )                                                                   \
+}                                                                       \
+/**/
 
-#define DEF_DMA_CHANNEL(tim, chan, dmaopt) EXPAND(DEF_TIM_DMA_CHN_ ## dmaopt ## __ ## tim ## _ ## chan)
-#define DEF_DMA_STREAM(tim, chan, dmaopt) CONCAT(EXPAND(DEF_TIM_DMA_STR_ ## dmaopt ## __ ## tim ## _ ## chan), _STREAM)
-#define DEF_DMA_HANDLER(tim, chan, dmaopt) CONCAT(EXPAND(DEF_TIM_DMA_STR_ ## dmaopt ## __ ## tim ## _ ## chan), _HANDLER)
+#define DEF_TIM_CHANNEL(ch)                   CONCAT(DEF_TIM_CHANNEL__, DEF_TIM_CH_GET(ch))
+#define DEF_TIM_CHANNEL__D(chan_n, n_channel) TIM_CHANNEL_ ## chan_n
+
+#define DEF_TIM_AF(timch, pin)                CONCAT(DEF_TIM_AF__, DEF_TIM_AF_GET(timch, pin))
+#define DEF_TIM_AF__D(af_n, tim_n)            GPIO_AF ## af_n ## _TIM ## tim_n
+
+#define DEF_TIM_DMA_CHANNEL(variant, timch) \
+    CONCAT(DEF_TIM_DMA_CHANNEL__, DEF_TIM_DMA_GET(variant, timch))
+#define DEF_TIM_DMA_CHANNEL__D(dma_n, stream_n, chan_n)    DMA_CHANNEL_ ## chan_n
+#define DEF_TIM_DMA_CHANNEL__NONE                          DMA_CHANNEL_0
+
+#define DEF_TIM_DMA_STREAM(variant, timch)                              \
+    CONCAT(DEF_TIM_DMA_STREAM__, DEF_TIM_DMA_GET(variant, timch))
+#define DEF_TIM_DMA_STREAM__D(dma_n, stream_n, chan_n)  DMA ## dma_n ## _Stream ## stream_n
+#define DEF_TIM_DMA_STREAM__NONE                        NULL
+
+#define DEF_TIM_DMA_HANDLER(variant, timch) \
+    CONCAT(DEF_TIM_DMA_HANDLER__, DEF_TIM_DMA_GET(variant, timch))
+#define DEF_TIM_DMA_HANDLER__D(dma_n, stream_n, chan_n) DMA ## dma_n ## _ST ## stream_n ## _HANDLER
+#define DEF_TIM_DMA_HANDLER__NONE                       0
 
 /* F7 Stream Mappings */
+// D(DMAx, Stream, Channel)
+#define DEF_TIM_DMA__BTCH_TIM1_CH1    D(2, 6, 0),D(2, 1, 6),D(2, 3, 6)
+#define DEF_TIM_DMA__BTCH_TIM1_CH2    D(2, 6, 0),D(2, 2, 6)
+#define DEF_TIM_DMA__BTCH_TIM1_CH3    D(2, 6, 0),D(2, 6, 6)
+#define DEF_TIM_DMA__BTCH_TIM1_CH4    D(2, 4, 6)
 
-#define DEF_TIM_DMA_STR_0__TIM1_CH1    DMA2_ST6
-#define DEF_TIM_DMA_STR_1__TIM1_CH1    DMA2_ST1
-#define DEF_TIM_DMA_STR_2__TIM1_CH1    DMA2_ST3
-#define DEF_TIM_DMA_STR_0__TIM1_CH1N   DMA2_ST6
-#define DEF_TIM_DMA_STR_1__TIM1_CH1N   DMA2_ST1
-#define DEF_TIM_DMA_STR_2__TIM1_CH1N   DMA2_ST3
-#define DEF_TIM_DMA_STR_0__TIM1_CH2    DMA2_ST6
-#define DEF_TIM_DMA_STR_1__TIM1_CH2    DMA2_ST2
-#define DEF_TIM_DMA_STR_0__TIM1_CH2N   DMA2_ST6
-#define DEF_TIM_DMA_STR_1__TIM1_CH2N   DMA2_ST2
-#define DEF_TIM_DMA_STR_0__TIM1_CH3    DMA2_ST6
-#define DEF_TIM_DMA_STR_1__TIM1_CH3    DMA2_ST6
-#define DEF_TIM_DMA_STR_0__TIM1_CH3N   DMA2_ST6
-#define DEF_TIM_DMA_STR_1__TIM1_CH3N   DMA2_ST6
-#define DEF_TIM_DMA_STR_0__TIM1_CH4    DMA2_ST4
+#define DEF_TIM_DMA__BTCH_TIM2_CH1    D(1, 5, 3)
+#define DEF_TIM_DMA__BTCH_TIM2_CH2    D(1, 6, 3)
+#define DEF_TIM_DMA__BTCH_TIM2_CH3    D(1, 1, 3)
+#define DEF_TIM_DMA__BTCH_TIM2_CH4    D(1, 7, 3),D(1, 6, 3)
 
-#define DEF_TIM_DMA_STR_0__TIM2_CH1    DMA1_ST5
-#define DEF_TIM_DMA_STR_0__TIM2_CH2    DMA1_ST6
-#define DEF_TIM_DMA_STR_0__TIM2_CH3    DMA1_ST1
-#define DEF_TIM_DMA_STR_0__TIM2_CH4    DMA1_ST7
-#define DEF_TIM_DMA_STR_1__TIM2_CH4    DMA1_ST6
+#define DEF_TIM_DMA__BTCH_TIM3_CH1    D(1, 4, 5)
+#define DEF_TIM_DMA__BTCH_TIM3_CH2    D(1, 5, 5)
+#define DEF_TIM_DMA__BTCH_TIM3_CH3    D(1, 7, 5)
+#define DEF_TIM_DMA__BTCH_TIM3_CH4    D(1, 2, 5)
 
-#define DEF_TIM_DMA_STR_0__TIM3_CH1    DMA1_ST4
-#define DEF_TIM_DMA_STR_0__TIM3_CH2    DMA1_ST5
-#define DEF_TIM_DMA_STR_0__TIM3_CH3    DMA1_ST7
-#define DEF_TIM_DMA_STR_0__TIM3_CH4    DMA1_ST2
+#define DEF_TIM_DMA__BTCH_TIM4_CH1    D(1, 0, 2)
+#define DEF_TIM_DMA__BTCH_TIM4_CH2    D(1, 3, 2)
+#define DEF_TIM_DMA__BTCH_TIM4_CH3    D(1, 7, 2)
 
-#define DEF_TIM_DMA_STR_0__TIM4_CH1    DMA1_ST0
-#define DEF_TIM_DMA_STR_0__TIM4_CH2    DMA1_ST3
-#define DEF_TIM_DMA_STR_0__TIM4_CH3    DMA1_ST7
+#define DEF_TIM_DMA__BTCH_TIM5_CH1    D(1, 2, 6)
+#define DEF_TIM_DMA__BTCH_TIM5_CH2    D(1, 4, 6)
+#define DEF_TIM_DMA__BTCH_TIM5_CH3    D(1, 0, 6)
+#define DEF_TIM_DMA__BTCH_TIM5_CH4    D(1, 1, 6),D(1, 3, 6)
 
-#define DEF_TIM_DMA_STR_0__TIM5_CH1    DMA1_ST2
-#define DEF_TIM_DMA_STR_0__TIM5_CH2    DMA1_ST4
-#define DEF_TIM_DMA_STR_0__TIM5_CH3    DMA1_ST0
-#define DEF_TIM_DMA_STR_0__TIM5_CH4    DMA1_ST1
-#define DEF_TIM_DMA_STR_1__TIM5_CH4    DMA1_ST3
+#define DEF_TIM_DMA__BTCH_TIM8_CH1    D(2, 2, 7),D(2, 2, 0)
+#define DEF_TIM_DMA__BTCH_TIM8_CH2    D(2, 3, 7),D(2, 2, 0)
+#define DEF_TIM_DMA__BTCH_TIM8_CH3    D(2, 4, 7),D(2, 2, 0)
+#define DEF_TIM_DMA__BTCH_TIM8_CH4    D(2, 7, 7)
 
-#define DEF_TIM_DMA_STR_0__TIM8_CH1    DMA2_ST2
-#define DEF_TIM_DMA_STR_1__TIM8_CH1    DMA2_ST2
-#define DEF_TIM_DMA_STR_0__TIM8_CH1N   DMA2_ST2
-#define DEF_TIM_DMA_STR_1__TIM8_CH1N   DMA2_ST2
-#define DEF_TIM_DMA_STR_0__TIM8_CH2    DMA2_ST3
-#define DEF_TIM_DMA_STR_1__TIM8_CH2    DMA2_ST2
-#define DEF_TIM_DMA_STR_0__TIM8_CH2N   DMA2_ST3
-#define DEF_TIM_DMA_STR_1__TIM8_CH2N   DMA2_ST2
-#define DEF_TIM_DMA_STR_0__TIM8_CH3    DMA2_ST4
-#define DEF_TIM_DMA_STR_1__TIM8_CH3    DMA2_ST2
-#define DEF_TIM_DMA_STR_0__TIM8_CH3N   DMA2_ST4
-#define DEF_TIM_DMA_STR_1__TIM8_CH3N   DMA2_ST2
-#define DEF_TIM_DMA_STR_0__TIM8_CH4    DMA2_ST7
+#define DEF_TIM_DMA__BTCH_TIM4_CH4    NONE
 
-#define DEF_TIM_DMA_STR_0__TIM4_CH4    DMA_NONE
+#define DEF_TIM_DMA__BTCH_TIM9_CH1    NONE
+#define DEF_TIM_DMA__BTCH_TIM9_CH2    NONE
 
-#define DEF_TIM_DMA_STR_0__TIM9_CH1    DMA_NONE
-#define DEF_TIM_DMA_STR_0__TIM9_CH2    DMA_NONE
+#define DEF_TIM_DMA__BTCH_TIM10_CH1   NONE
 
-#define DEF_TIM_DMA_STR_0__TIM10_CH1   DMA_NONE
+#define DEF_TIM_DMA__BTCH_TIM11_CH1   NONE
 
-#define DEF_TIM_DMA_STR_0__TIM11_CH1   DMA_NONE
+#define DEF_TIM_DMA__BTCH_TIM12_CH1   NONE
+#define DEF_TIM_DMA__BTCH_TIM12_CH2   NONE
 
-#define DEF_TIM_DMA_STR_0__TIM12_CH1   DMA_NONE
-#define DEF_TIM_DMA_STR_0__TIM12_CH2   DMA_NONE
+#define DEF_TIM_DMA__BTCH_TIM13_CH1   NONE
 
-#define DEF_TIM_DMA_STR_0__TIM13_CH1   DMA_NONE
+#define DEF_TIM_DMA__BTCH_TIM14_CH1   NONE
 
-#define DEF_TIM_DMA_STR_0__TIM14_CH1   DMA_NONE
-
-/* F7 Channel Mappings */
-
-#define DEF_TIM_DMA_CHN_0__TIM1_CH1    DMA_CHANNEL_0
-#define DEF_TIM_DMA_CHN_1__TIM1_CH1    DMA_CHANNEL_6
-#define DEF_TIM_DMA_CHN_2__TIM1_CH1    DMA_CHANNEL_6
-#define DEF_TIM_DMA_CHN_0__TIM1_CH1N   DMA_CHANNEL_0
-#define DEF_TIM_DMA_CHN_1__TIM1_CH1N   DMA_CHANNEL_6
-#define DEF_TIM_DMA_CHN_2__TIM1_CH1N   DMA_CHANNEL_6
-#define DEF_TIM_DMA_CHN_0__TIM1_CH2    DMA_CHANNEL_0
-#define DEF_TIM_DMA_CHN_1__TIM1_CH2    DMA_CHANNEL_6
-#define DEF_TIM_DMA_CHN_0__TIM1_CH2N   DMA_CHANNEL_0
-#define DEF_TIM_DMA_CHN_1__TIM1_CH2N   DMA_CHANNEL_6
-#define DEF_TIM_DMA_CHN_0__TIM1_CH3    DMA_CHANNEL_0
-#define DEF_TIM_DMA_CHN_1__TIM1_CH3    DMA_CHANNEL_6
-#define DEF_TIM_DMA_CHN_0__TIM1_CH3N   DMA_CHANNEL_0
-#define DEF_TIM_DMA_CHN_1__TIM1_CH3N   DMA_CHANNEL_6
-#define DEF_TIM_DMA_CHN_0__TIM1_CH4    DMA_CHANNEL_6
-
-#define DEF_TIM_DMA_CHN_0__TIM2_CH1    DMA_CHANNEL_3
-#define DEF_TIM_DMA_CHN_0__TIM2_CH2    DMA_CHANNEL_3
-#define DEF_TIM_DMA_CHN_0__TIM2_CH3    DMA_CHANNEL_3
-#define DEF_TIM_DMA_CHN_0__TIM2_CH4    DMA_CHANNEL_3
-#define DEF_TIM_DMA_CHN_1__TIM2_CH4    DMA_CHANNEL_3
-
-#define DEF_TIM_DMA_CHN_0__TIM3_CH1    DMA_CHANNEL_5
-#define DEF_TIM_DMA_CHN_0__TIM3_CH2    DMA_CHANNEL_5
-#define DEF_TIM_DMA_CHN_0__TIM3_CH3    DMA_CHANNEL_5
-#define DEF_TIM_DMA_CHN_0__TIM3_CH4    DMA_CHANNEL_5
-
-#define DEF_TIM_DMA_CHN_0__TIM4_CH1    DMA_CHANNEL_2
-#define DEF_TIM_DMA_CHN_0__TIM4_CH2    DMA_CHANNEL_2
-#define DEF_TIM_DMA_CHN_0__TIM4_CH3    DMA_CHANNEL_2
-
-#define DEF_TIM_DMA_CHN_0__TIM5_CH1    DMA_CHANNEL_6
-#define DEF_TIM_DMA_CHN_0__TIM5_CH2    DMA_CHANNEL_6
-#define DEF_TIM_DMA_CHN_0__TIM5_CH3    DMA_CHANNEL_6
-#define DEF_TIM_DMA_CHN_0__TIM5_CH4    DMA_CHANNEL_6
-#define DEF_TIM_DMA_CHN_1__TIM5_CH4    DMA_CHANNEL_6
-
-#define DEF_TIM_DMA_CHN_0__TIM8_CH1    DMA_CHANNEL_7
-#define DEF_TIM_DMA_CHN_1__TIM8_CH1    DMA_CHANNEL_0
-#define DEF_TIM_DMA_CHN_0__TIM8_CH1N   DMA_CHANNEL_7
-#define DEF_TIM_DMA_CHN_1__TIM8_CH1N   DMA_CHANNEL_0
-#define DEF_TIM_DMA_CHN_0__TIM8_CH2    DMA_CHANNEL_7
-#define DEF_TIM_DMA_CHN_1__TIM8_CH2    DMA_CHANNEL_0
-#define DEF_TIM_DMA_CHN_0__TIM8_CH2N   DMA_CHANNEL_7
-#define DEF_TIM_DMA_CHN_1__TIM8_CH2N   DMA_CHANNEL_0
-#define DEF_TIM_DMA_CHN_0__TIM8_CH3    DMA_CHANNEL_7
-#define DEF_TIM_DMA_CHN_1__TIM8_CH3    DMA_CHANNEL_0
-#define DEF_TIM_DMA_CHN_0__TIM8_CH3N   DMA_CHANNEL_7
-#define DEF_TIM_DMA_CHN_1__TIM8_CH3N   DMA_CHANNEL_0
-#define DEF_TIM_DMA_CHN_0__TIM8_CH4    DMA_CHANNEL_7
-
-#define DEF_TIM_DMA_CHN_0__TIM4_CH4    0
-
-#define DEF_TIM_DMA_CHN_0__TIM9_CH1    0
-#define DEF_TIM_DMA_CHN_0__TIM9_CH2    0
-
-#define DEF_TIM_DMA_CHN_0__TIM10_CH1   0
-
-#define DEF_TIM_DMA_CHN_0__TIM11_CH1   0
-
-#define DEF_TIM_DMA_CHN_0__TIM12_CH1   0
-#define DEF_TIM_DMA_CHN_0__TIM12_CH2   0
-
-#define DEF_TIM_DMA_CHN_0__TIM13_CH1   0
-
-#define DEF_TIM_DMA_CHN_0__TIM14_CH1   0
-
-#define DMA1_ST0_STREAM                DMA1_Stream0
-#define DMA1_ST1_STREAM                DMA1_Stream1
-#define DMA1_ST2_STREAM                DMA1_Stream2
-#define DMA1_ST3_STREAM                DMA1_Stream3
-#define DMA1_ST4_STREAM                DMA1_Stream4
-#define DMA1_ST5_STREAM                DMA1_Stream5
-#define DMA1_ST6_STREAM                DMA1_Stream6
-#define DMA1_ST7_STREAM                DMA1_Stream7
-#define DMA2_ST0_STREAM                DMA2_Stream0
-#define DMA2_ST1_STREAM                DMA2_Stream1
-#define DMA2_ST2_STREAM                DMA2_Stream2
-#define DMA2_ST3_STREAM                DMA2_Stream3
-#define DMA2_ST4_STREAM                DMA2_Stream4
-#define DMA2_ST5_STREAM                DMA2_Stream5
-#define DMA2_ST6_STREAM                DMA2_Stream6
-#define DMA2_ST7_STREAM                DMA2_Stream7
-
-#define GPIO_AF(p, t) CONCAT(GPIO_AF__, p, _, t)
+// AF table
 
 //PORTA
-#define GPIO_AF__PA0_TIM2_CH1     GPIO_AF1_TIM2
-#define GPIO_AF__PA1_TIM2_CH2     GPIO_AF1_TIM2
-#define GPIO_AF__PA2_TIM2_CH3     GPIO_AF1_TIM2
-#define GPIO_AF__PA3_TIM2_CH4     GPIO_AF1_TIM2
-#define GPIO_AF__PA5_TIM2_CH1     GPIO_AF1_TIM2
-#define GPIO_AF__PA7_TIM1_CH1N    GPIO_AF1_TIM1
-#define GPIO_AF__PA8_TIM1_CH1     GPIO_AF1_TIM1
-#define GPIO_AF__PA9_TIM1_CH2     GPIO_AF1_TIM1
-#define GPIO_AF__PA10_TIM1_CH3    GPIO_AF1_TIM1
-#define GPIO_AF__PA11_TIM1_CH1N   GPIO_AF1_TIM1
-#define GPIO_AF__PA15_TIM2_CH1    GPIO_AF1_TIM2
+#define DEF_TIM_AF__PA0__TCH_TIM2_CH1     D(1, 2)
+#define DEF_TIM_AF__PA1__TCH_TIM2_CH2     D(1, 2)
+#define DEF_TIM_AF__PA2__TCH_TIM2_CH3     D(1, 2)
+#define DEF_TIM_AF__PA3__TCH_TIM2_CH4     D(1, 2)
+#define DEF_TIM_AF__PA5__TCH_TIM2_CH1     D(1, 2)
+#define DEF_TIM_AF__PA7__TCH_TIM1_CH1N    D(1, 1)
+#define DEF_TIM_AF__PA8__TCH_TIM1_CH1     D(1, 1)
+#define DEF_TIM_AF__PA9__TCH_TIM1_CH2     D(1, 1)
+#define DEF_TIM_AF__PA10__TCH_TIM1_CH3    D(1, 1)
+#define DEF_TIM_AF__PA11__TCH_TIM1_CH1N   D(1, 1)
+#define DEF_TIM_AF__PA15__TCH_TIM2_CH1    D(1, 2)
 
-#define GPIO_AF__PA0_TIM5_CH1     GPIO_AF2_TIM5
-#define GPIO_AF__PA1_TIM5_CH2     GPIO_AF2_TIM5
-#define GPIO_AF__PA3_TIM5_CH3     GPIO_AF2_TIM5
-#define GPIO_AF__PA4_TIM5_CH4     GPIO_AF2_TIM5
-#define GPIO_AF__PA6_TIM3_CH1     GPIO_AF2_TIM3
-#define GPIO_AF__PA7_TIM3_CH2     GPIO_AF2_TIM3
+#define DEF_TIM_AF__PA0__TCH_TIM5_CH1     D(2, 5)
+#define DEF_TIM_AF__PA1__TCH_TIM5_CH2     D(2, 5)
+#define DEF_TIM_AF__PA3__TCH_TIM5_CH3     D(2, 5)
+#define DEF_TIM_AF__PA4__TCH_TIM5_CH4     D(2, 5)
+#define DEF_TIM_AF__PA6__TCH_TIM3_CH1     D(2, 3)
+#define DEF_TIM_AF__PA7__TCH_TIM3_CH2     D(2, 3)
 
-#define GPIO_AF__PA2_TIM9_CH1     GPIO_AF3_TIM9
-#define GPIO_AF__PA3_TIM9_CH2     GPIO_AF3_TIM9
-#define GPIO_AF__PA5_TIM8_CH1N    GPIO_AF3_TIM8
-#define GPIO_AF__PA7_TIM8_CH1N    GPIO_AF3_TIM8
+#define DEF_TIM_AF__PA2__TCH_TIM9_CH1     D(3, 9)
+#define DEF_TIM_AF__PA3__TCH_TIM9_CH2     D(3, 9)
+#define DEF_TIM_AF__PA5__TCH_TIM8_CH1N    D(3, 8)
+#define DEF_TIM_AF__PA7__TCH_TIM8_CH1N    D(3, 8)
 
-#define GPIO_AF__PA6_TIM13_CH1    GPIO_AF9_TIM13
-#define GPIO_AF__PA7_TIM14_CH1    GPIO_AF9_TIM14
+#define DEF_TIM_AF__PA6__TCH_TIM13_CH1    D(9, 13)
+#define DEF_TIM_AF__PA7__TCH_TIM14_CH1    D(9, 14)
 
 //PORTB
-#define GPIO_AF__PB0_TIM1_CH2N    GPIO_AF1_TIM1
-#define GPIO_AF__PB1_TIM1_CH3N    GPIO_AF1_TIM1
-#define GPIO_AF__PB3_TIM2_CH2     GPIO_AF1_TIM2
-#define GPIO_AF__PB10_TIM2_CH3    GPIO_AF1_TIM2
-#define GPIO_AF__PB11_TIM2_CH4    GPIO_AF1_TIM2
-#define GPIO_AF__PB13_TIM1_CH1N   GPIO_AF1_TIM1
-#define GPIO_AF__PB14_TIM1_CH2N   GPIO_AF1_TIM1
-#define GPIO_AF__PB15_TIM1_CH3N   GPIO_AF1_TIM1
+#define DEF_TIM_AF__PB0__TCH_TIM1_CH2N    D(1, 1)
+#define DEF_TIM_AF__PB1__TCH_TIM1_CH2N    D(1, 1)
+#define DEF_TIM_AF__PB3__TCH_TIM2_CH2     D(1, 2)
+#define DEF_TIM_AF__PB10__TCH_TIM2_CH3    D(1, 2)
+#define DEF_TIM_AF__PB11__TCH_TIM2_CH4    D(1, 2)
+#define DEF_TIM_AF__PB13__TCH_TIM1_CH1N   D(1, 1)
+#define DEF_TIM_AF__PB14__TCH_TIM1_CH2N   D(1, 1)
+#define DEF_TIM_AF__PB15__TCH_TIM1_CH3N   D(1, 1)
 
-#define GPIO_AF__PB0_TIM3_CH3     GPIO_AF2_TIM3
-#define GPIO_AF__PB1_TIM3_CH4     GPIO_AF2_TIM3
-#define GPIO_AF__PB4_TIM3_CH1     GPIO_AF2_TIM3
-#define GPIO_AF__PB5_TIM3_CH2     GPIO_AF2_TIM3
-#define GPIO_AF__PB6_TIM4_CH1     GPIO_AF2_TIM4
-#define GPIO_AF__PB7_TIM4_CH2     GPIO_AF2_TIM4
-#define GPIO_AF__PB8_TIM4_CH3     GPIO_AF2_TIM4
-#define GPIO_AF__PB9_TIM4_CH4     GPIO_AF2_TIM4
+#define DEF_TIM_AF__PB0__TCH_TIM3_CH3     D(2, 3)
+#define DEF_TIM_AF__PB1__TCH_TIM3_CH4     D(2, 3)
+#define DEF_TIM_AF__PB4__TCH_TIM3_CH1     D(2, 3)
+#define DEF_TIM_AF__PB5__TCH_TIM3_CH2     D(2, 3)
+#define DEF_TIM_AF__PB6__TCH_TIM4_CH1     D(2, 4)
+#define DEF_TIM_AF__PB7__TCH_TIM4_CH2     D(2, 4)
+#define DEF_TIM_AF__PB8__TCH_TIM4_CH3     D(2, 4)
+#define DEF_TIM_AF__PB9__TCH_TIM4_CH4     D(2, 4)
 
-#define GPIO_AF__PB0_TIM8_CH2N    GPIO_AF3_TIM8
-#define GPIO_AF__PB1_TIM8_CH3N    GPIO_AF3_TIM8
-#define GPIO_AF__PB8_TIM10_CH1    GPIO_AF3_TIM10
-#define GPIO_AF__PB9_TIM11_CH1    GPIO_AF3_TIM11
-#define GPIO_AF__PB14_TIM8_CH2N   GPIO_AF3_TIM8
-#define GPIO_AF__PB15_TIM8_CH3N   GPIO_AF3_TIM8
+#define DEF_TIM_AF__PB0__TCH_TIM8_CH2N    D(3, 8)
+#define DEF_TIM_AF__PB1__TCH_TIM8_CH3N    D(3, 8)
+#define DEF_TIM_AF__PB8__TCH_TIM10_CH1    D(3, 10)
+#define DEF_TIM_AF__PB9__TCH_TIM11_CH1    D(3, 11)
+#define DEF_TIM_AF__PB14__TCH_TIM8_CH2N   D(3, 8)
+#define DEF_TIM_AF__PB15__TCH_TIM8_CH3N   D(3, 8)
 
-#define GPIO_AF__PB14_TIM12_CH1   GPIO_AF9_TIM12
-#define GPIO_AF__PB15_TIM12_CH2   GPIO_AF9_TIM12
+#define DEF_TIM_AF__PB14__TCH_TIM12_CH1   D(9, 12)
+#define DEF_TIM_AF__PB15__TCH_TIM12_CH2   D(9, 12)
 
 //PORTC
-#define GPIO_AF__PC6_TIM3_CH1     GPIO_AF2_TIM3
-#define GPIO_AF__PC7_TIM3_CH2     GPIO_AF2_TIM3
-#define GPIO_AF__PC8_TIM3_CH3     GPIO_AF2_TIM3
-#define GPIO_AF__PC9_TIM3_CH4     GPIO_AF2_TIM3
+#define DEF_TIM_AF__PC6__TCH_TIM3_CH1     D(2, 3)
+#define DEF_TIM_AF__PC7__TCH_TIM3_CH2     D(2, 3)
+#define DEF_TIM_AF__PC8__TCH_TIM3_CH3     D(2, 3)
+#define DEF_TIM_AF__PC9__TCH_TIM3_CH4     D(2, 3)
 
-#define GPIO_AF__PC6_TIM8_CH1     GPIO_AF3_TIM8
-#define GPIO_AF__PC7_TIM8_CH2     GPIO_AF3_TIM8
-#define GPIO_AF__PC8_TIM8_CH3     GPIO_AF3_TIM8
-#define GPIO_AF__PC9_TIM8_CH4     GPIO_AF3_TIM8
+#define DEF_TIM_AF__PC6__TCH_TIM8_CH1     D(3, 8)
+#define DEF_TIM_AF__PC7__TCH_TIM8_CH2     D(3, 8)
+#define DEF_TIM_AF__PC8__TCH_TIM8_CH3     D(3, 8)
+#define DEF_TIM_AF__PC9__TCH_TIM8_CH4     D(3, 8)
 
 //PORTD
-#define GPIO_AF__PD12_TIM4_CH1    GPIO_AF2_TIM4
-#define GPIO_AF__PD13_TIM4_CH2    GPIO_AF2_TIM4
-#define GPIO_AF__PD14_TIM4_CH3    GPIO_AF2_TIM4
-#define GPIO_AF__PD15_TIM4_CH4    GPIO_AF2_TIM4
+#define DEF_TIM_AF__PD12__TCH_TIM4_CH1    D(2, 4)
+#define DEF_TIM_AF__PD13__TCH_TIM4_CH2    D(2, 4)
+#define DEF_TIM_AF__PD14__TCH_TIM4_CH3    D(2, 4)
+#define DEF_TIM_AF__PD15__TCH_TIM4_CH4    D(2, 4)
 
 //PORTE
-#define GPIO_AF__PE8_TIM1_CH1N    GPIO_AF1_TIM1
-#define GPIO_AF__PE9_TIM1_CH1     GPIO_AF1_TIM1
-#define GPIO_AF__PE10_TIM1_CH2N   GPIO_AF1_TIM1
-#define GPIO_AF__PE11_TIM1_CH2    GPIO_AF1_TIM1
-#define GPIO_AF__PE12_TIM1_CH3N   GPIO_AF1_TIM1
-#define GPIO_AF__PE13_TIM1_CH3    GPIO_AF1_TIM1
-#define GPIO_AF__PE14_TIM1_CH4    GPIO_AF1_TIM1
+#define DEF_TIM_AF__PE8__TCH_TIM1_CH1N    D(1, 1)
+#define DEF_TIM_AF__PE9__TCH_TIM1_CH1     D(1, 1)
+#define DEF_TIM_AF__PE10__TCH_TIM1_CH2N   D(1, 1)
+#define DEF_TIM_AF__PE11__TCH_TIM1_CH2    D(1, 1)
+#define DEF_TIM_AF__PE12__TCH_TIM1_CH3N   D(1, 1)
+#define DEF_TIM_AF__PE13__TCH_TIM1_CH3    D(1, 1)
+#define DEF_TIM_AF__PE14__TCH_TIM1_CH4    D(1, 1)
 
-#define GPIO_AF__PE5_TIM9_CH1     GPIO_AF3_TIM9
-#define GPIO_AF__PE6_TIM9_CH2     GPIO_AF3_TIM9
+#define DEF_TIM_AF__PE5__TCH_TIM9_CH1     D(3, 9)
+#define DEF_TIM_AF__PE6__TCH_TIM9_CH2     D(3, 9)
 
 //PORTF
-#define GPIO_AF__PF6_TIM10_CH1    GPIO_AF3_TIM10
-#define GPIO_AF__PF7_TIM11_CH1    GPIO_AF3_TIM11
+#define DEF_TIM_AF__PF6__TCH_TIM10_CH1    D(3, 10)
+#define DEF_TIM_AF__PF7__TCH_TIM11_CH1    D(3, 11)
 
 //PORTH
-#define GPIO_AF__PH10_TIM5_CH1    GPIO_AF2_TIM5
-#define GPIO_AF__PH11_TIM5_CH2    GPIO_AF2_TIM5
-#define GPIO_AF__PH12_TIM5_CH3    GPIO_AF2_TIM5
+#define DEF_TIM_AF__PH10__TCH_TIM5_CH1    D(2, 5)
+#define DEF_TIM_AF__PH11__TCH_TIM5_CH2    D(2, 5)
+#define DEF_TIM_AF__PH12__TCH_TIM5_CH3    D(2, 5)
 
-#define GPIO_AF__PH13_TIM8_CH1N   GPIO_AF3_TIM8
-#define GPIO_AF__PH14_TIM8_CH2N   GPIO_AF3_TIM8
-#define GPIO_AF__PH15_TIM8_CH3N   GPIO_AF3_TIM8
+#define DEF_TIM_AF__PH13__TCH_TIM8_CH1N   D(3, 8)
+#define DEF_TIM_AF__PH14__TCH_TIM8_CH2N   D(3, 8)
+#define DEF_TIM_AF__PH15__TCH_TIM8_CH3N   D(3, 8)
 
-#define GPIO_AF__PH6_TIM12_CH1    GPIO_AF9_TIM12
-#define GPIO_AF__PH9_TIM12_CH2    GPIO_AF9_TIM12
+#define DEF_TIM_AF__PH6__TCH_TIM12_CH1    D(9, 12)
+#define DEF_TIM_AF__PH9__TCH_TIM12_CH2    D(9, 12)
 
 //PORTI
-#define GPIO_AF__PI0_TIM5_CH4     GPIO_AF2_TIM5
+#define DEF_TIM_AF__PI0__TCH_TIM5_CH4     D(2, 5)
 
-#define GPIO_AF__PI2_TIM8_CH4     GPIO_AF3_TIM8
-#define GPIO_AF__PI5_TIM8_CH1     GPIO_AF3_TIM8
-#define GPIO_AF__PI6_TIM8_CH2     GPIO_AF3_TIM8
-#define GPIO_AF__PI7_TIM8_CH3     GPIO_AF3_TIM8
+#define DEF_TIM_AF__PI2__TCH_TIM8_CH4     D(3, 8)
+#define DEF_TIM_AF__PI5__TCH_TIM8_CH1     D(3, 8)
+#define DEF_TIM_AF__PI6__TCH_TIM8_CH2     D(3, 8)
+#define DEF_TIM_AF__PI7__TCH_TIM8_CH3     D(3, 8)
 
 #endif
-
-/**** Common Defines across all targets ****/
-#define DMA_NONE_CHANNEL     NULL
-#define DMA_NONE_STREAM      NULL
-
-
-#define DEF_TIM_CHAN(chan) DEF_CHAN_ ## chan
-#define DEF_TIM_OUTPUT(chan, out) ( DEF_CHAN_ ## chan ## _OUTPUT | out )
-
-#define DMA_NONE_HANDLER     0
-
-#if defined(STM32F7)
-#define DEF_CHAN_CH1         TIM_CHANNEL_1
-#define DEF_CHAN_CH2         TIM_CHANNEL_2
-#define DEF_CHAN_CH3         TIM_CHANNEL_3
-#define DEF_CHAN_CH4         TIM_CHANNEL_4
-#define DEF_CHAN_CH1N        TIM_CHANNEL_1
-#define DEF_CHAN_CH2N        TIM_CHANNEL_2
-#define DEF_CHAN_CH3N        TIM_CHANNEL_3
-#define DEF_CHAN_CH4N        TIM_CHANNEL_4
-#else
-#define DEF_CHAN_CH1         TIM_Channel_1
-#define DEF_CHAN_CH2         TIM_Channel_2
-#define DEF_CHAN_CH3         TIM_Channel_3
-#define DEF_CHAN_CH4         TIM_Channel_4
-#define DEF_CHAN_CH1N        TIM_Channel_1
-#define DEF_CHAN_CH2N        TIM_Channel_2
-#define DEF_CHAN_CH3N        TIM_Channel_3
-#define DEF_CHAN_CH4N        TIM_Channel_4
-#endif
-
-#define DEF_CHAN_CH1_OUTPUT  TIMER_OUTPUT_NONE
-#define DEF_CHAN_CH2_OUTPUT  TIMER_OUTPUT_NONE
-#define DEF_CHAN_CH3_OUTPUT  TIMER_OUTPUT_NONE
-#define DEF_CHAN_CH4_OUTPUT  TIMER_OUTPUT_NONE
-#define DEF_CHAN_CH1N_OUTPUT TIMER_OUTPUT_N_CHANNEL
-#define DEF_CHAN_CH2N_OUTPUT TIMER_OUTPUT_N_CHANNEL
-#define DEF_CHAN_CH3N_OUTPUT TIMER_OUTPUT_N_CHANNEL
-#define DEF_CHAN_CH4N_OUTPUT TIMER_OUTPUT_N_CHANNEL
-
-#define DMA1_CH1_CHANNEL     DMA1_Channel1
-#define DMA1_CH2_CHANNEL     DMA1_Channel2
-#define DMA1_CH3_CHANNEL     DMA1_Channel3
-#define DMA1_CH4_CHANNEL     DMA1_Channel4
-#define DMA1_CH5_CHANNEL     DMA1_Channel5
-#define DMA1_CH6_CHANNEL     DMA1_Channel6
-#define DMA1_CH7_CHANNEL     DMA1_Channel7
-#define DMA2_CH1_CHANNEL     DMA2_Channel1
-#define DMA2_CH2_CHANNEL     DMA2_Channel2
-#define DMA2_CH3_CHANNEL     DMA2_Channel3
-#define DMA2_CH4_CHANNEL     DMA2_Channel4
-#define DMA2_CH5_CHANNEL     DMA2_Channel5
-#define DMA2_CH6_CHANNEL     DMA2_Channel6
-#define DMA2_CH7_CHANNEL     DMA2_Channel7


### PR DESCRIPTION
The idea is to use preprocessor magic to simplify actual mapping
definition, so that mapping database is easier to check/upkeep.