### PR TITLE
Change the timerHardware_t to use the DEF_TIM macro

### DIFF
--- a/src/main/target/SPRACINGF4EVO/config.c
+++ b/src/main/target/SPRACINGF4EVO/config.c
@@ -1,0 +1,61 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <platform.h>
+
+#include "common/axis.h"
+
+#include "drivers/sensor.h"
+#include "drivers/compass.h"
+#include "drivers/serial.h"
+
+#include "fc/rc_controls.h"
+
+#include "flight/failsafe.h"
+#include "flight/mixer.h"
+#include "flight/pid.h"
+
+#include "rx/rx.h"
+
+#include "io/serial.h"
+
+#include "telemetry/telemetry.h"
+
+#include "sensors/sensors.h"
+#include "sensors/compass.h"
+#include "sensors/barometer.h"
+
+#include "config/feature.h"
+
+#include "fc/config.h"
+
+#ifdef TARGET_CONFIG
+void targetConfiguration(void)
+{
+    barometerConfigMutable()->baro_hardware = BARO_DEFAULT;
+    rxConfigMutable()->sbus_inversion = 1;
+    serialConfigMutable()->portConfigs[1].functionMask = FUNCTION_MSP; // So SPRacingF3OSD users don't have to change anything.
+    serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(SERIALRX_UART)].functionMask = FUNCTION_RX_SERIAL;
+    serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(TELEMETRY_UART)].functionMask = FUNCTION_TELEMETRY_SMARTPORT;
+    telemetryConfigMutable()->telemetry_inversion = 0;
+    telemetryConfigMutable()->sportHalfDuplex = 0;
+
+}
+#endif

--- a/src/main/target/SPRACINGF4EVO/target.c
+++ b/src/main/target/SPRACINGF4EVO/target.c
@@ -26,39 +26,40 @@
 
 
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
-    { TIM9,  IO_TAG(PA3),   TIM_Channel_2, TIM_USE_PPM | TIM_USE_PWM,   0, GPIO_AF_TIM9, NULL, 0, 0 }, // PPM / PWM1 / UART2 RX
-    { TIM9,  IO_TAG(PA2),   TIM_Channel_1, TIM_USE_PWM,                 0, GPIO_AF_TIM9, NULL, 0, 0 }, // PPM / PWM2 / UART2 TX
 
-    { TIM8,  IO_TAG(PC6),  TIM_Channel_1, TIM_USE_MOTOR,                1, GPIO_AF_TIM8,  DMA2_Stream2, DMA_Channel_7, DMA2_ST2_HANDLER }, // ESC 1
-    { TIM8,  IO_TAG(PC7),  TIM_Channel_2, TIM_USE_MOTOR,                1, GPIO_AF_TIM8,  DMA2_Stream3, DMA_Channel_7, DMA2_ST3_HANDLER }, // ESC 2
-    { TIM8,  IO_TAG(PC9),  TIM_Channel_4, TIM_USE_MOTOR,                1, GPIO_AF_TIM8,  DMA2_Stream7, DMA_Channel_7, DMA2_ST7_HANDLER }, // ESC 3
-    { TIM8,  IO_TAG(PC8),  TIM_Channel_3, TIM_USE_MOTOR,                1, GPIO_AF_TIM8,  DMA2_Stream4, DMA_Channel_7, DMA2_ST4_HANDLER }, // ESC 4
+    DEF_TIM(TIM9,  CH2, PA3,  TIM_USE_PPM | TIM_USE_PWM,   0, 0), // PPM / PWM1 / UART2 RX
+    DEF_TIM(TIM9,  CH1, PA2,  TIM_USE_PWM,                 0, 0), // PPM / PWM2 / UART2 TX
+
+    DEF_TIM(TIM8,  CH1, PC6,  TIM_USE_MOTOR,               1, 1), // ESC 1
+    DEF_TIM(TIM8,  CH2, PC7,  TIM_USE_MOTOR,               1, 1), // ESC 2
+    DEF_TIM(TIM8,  CH4, PC9,  TIM_USE_MOTOR,               1, 0), // ESC 3
+    DEF_TIM(TIM8,  CH3, PC8,  TIM_USE_MOTOR,               1, 1), // ESC 4
 
 #if (SPRACINGF4EVO_REV >= 2)
-    { TIM4,  IO_TAG(PB6),  TIM_Channel_1, TIM_USE_MOTOR,                1, GPIO_AF_TIM4, DMA1_Stream0, DMA_Channel_2, DMA1_ST0_HANDLER }, // ESC 5 / Conflicts with USART5_RX / SPI3_RX - SPI3_RX can be mapped to DMA1_ST3_CH0
-    { TIM4,  IO_TAG(PB7),  TIM_Channel_2, TIM_USE_MOTOR,                1, GPIO_AF_TIM4, DMA1_Stream3, DMA_Channel_2, DMA1_ST3_HANDLER }, // ESC 6 / Conflicts with USART3_RX
+    DEF_TIM(TIM4,  CH1, PB6,  TIM_USE_MOTOR,               1, 0), // ESC 5 / Conflicts with USART5_RX / SPI3_RX - SPI3_RX can be mapped to DMA1_ST3_CH0
+    DEF_TIM(TIM4,  CH2, PB7,  TIM_USE_MOTOR,               1, 0), // ESC 6 / Conflicts with USART3_RX
 #else
 #ifdef USE_TIM10_TIM11_FOR_MOTORS
-    { TIM10,  IO_TAG(PB8),  TIM_Channel_1, TIM_USE_MOTOR,                1, GPIO_AF_TIM10, NULL,         0,             0                }, // ESC 5
-    { TIM11,  IO_TAG(PB9),  TIM_Channel_1, TIM_USE_MOTOR,                1, GPIO_AF_TIM11, NULL,         0,             0                }, // ESC 6
+    DEF_TIM(TIM10, CH1, PB8,  TIM_USE_MOTOR,               1, 0), // ESC 5
+    DEF_TIM(TIM11, CH1, PB9,  TIM_USE_MOTOR,               1, 0), // ESC 6
 #else
-    { TIM4,  IO_TAG(PB8),  TIM_Channel_3, TIM_USE_MOTOR,                1, GPIO_AF_TIM4, DMA1_Stream7, DMA_Channel_2, DMA1_ST7_HANDLER }, // ESC 5
-    { TIM4,  IO_TAG(PB9),  TIM_Channel_4, TIM_USE_MOTOR,                1, GPIO_AF_TIM4, NULL,         0,             0                }, // ESC 6
+    DEF_TIM(TIM4,  CH3, PB8,  TIM_USE_MOTOR,               1, 0), // ESC 5
+    DEF_TIM(TIM4,  CH4, PB9,  TIM_USE_MOTOR,               1, 0), // ESC 6
 #endif
 #endif
-    { TIM3,  IO_TAG(PB1),  TIM_Channel_4, TIM_USE_MOTOR,                1, GPIO_AF_TIM3, DMA1_Stream2, DMA_Channel_5, DMA1_ST2_HANDLER }, // ESC 7
-    { TIM3,  IO_TAG(PB0),  TIM_Channel_3, TIM_USE_MOTOR,                1, GPIO_AF_TIM3, DMA1_Stream7, DMA_Channel_5, DMA1_ST7_HANDLER }, // ESC 8
+    DEF_TIM(TIM3,  CH4, PB1,  TIM_USE_MOTOR,               1, 0), // ESC 7
+    DEF_TIM(TIM3,  CH3, PB0,  TIM_USE_MOTOR,               1, 0), // ESC 8
 
-
-    { TIM2,  IO_TAG(PA1),  TIM_Channel_2, TIM_USE_LED,                  1, GPIO_AF_TIM2, DMA1_Stream6, DMA_Channel_3, DMA1_ST6_HANDLER }, // LED Strip
+    DEF_TIM(TIM2,  CH2, PA1,  TIM_USE_LED,                 1, 0), // LED Strip
     // Additional 2 PWM channels available on UART3 RX/TX pins
     // However, when using led strip the timer cannot be used, but no code appears to prevent that right now
-    { TIM2,  IO_TAG(PB10), TIM_Channel_3, TIM_USE_MOTOR,                1, GPIO_AF_TIM2, DMA1_Stream1, DMA_Channel_3, DMA1_ST1_HANDLER }, // Shared with UART3 TX PIN and SPI3 TX (OSD)
-    { TIM2,  IO_TAG(PB11), TIM_Channel_4, TIM_USE_MOTOR,                1, GPIO_AF_TIM2, DMA1_Stream6, DMA_Channel_3, DMA1_ST6_HANDLER }, // Shared with UART3 RX PIN
+    DEF_TIM(TIM2,  CH3, PB10, TIM_USE_MOTOR,               1, 0), // Shared with UART3 TX PIN and SPI3 TX (OSD)
+    DEF_TIM(TIM2,  CH4, PB11, TIM_USE_MOTOR,               1, 1), // Shared with UART3 RX PIN
 
-    { TIM1,  IO_TAG(PA8),  TIM_Channel_1, TIM_USE_TRANSPONDER,          1, GPIO_AF_TIM1, DMA2_Stream6, DMA_Channel_0, DMA2_ST6_HANDLER }, // Transponder
+    DEF_TIM(TIM1,  CH1, PA8,  TIM_USE_TRANSPONDER,         1, 0), // Transponder
     // Additional 2 PWM channels available on UART1 RX/TX pins
     // However, when using transponder the timer cannot be used, but no code appears to prevent that right now
-    { TIM1,  IO_TAG(PA9),  TIM_Channel_2, TIM_USE_SERVO | TIM_USE_PWM,  1, GPIO_AF_TIM1, DMA2_Stream2, DMA_Channel_6, DMA2_ST2_HANDLER }, // PWM 3
-    { TIM1,  IO_TAG(PA10), TIM_Channel_3, TIM_USE_SERVO | TIM_USE_PWM,  1, GPIO_AF_TIM1, DMA2_Stream6, DMA_Channel_6, DMA2_ST6_HANDLER }, // PWM 4
+    DEF_TIM(TIM1,  CH2, PA9,  TIM_USE_SERVO | TIM_USE_PWM, 1, 1), // PWM 3
+    DEF_TIM(TIM1,  CH3, PA10, TIM_USE_SERVO | TIM_USE_PWM, 1, 1), // PWM 4
+
 };

--- a/src/main/target/SPRACINGF4EVO/target.c
+++ b/src/main/target/SPRACINGF4EVO/target.c
@@ -1,0 +1,64 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+
+#include <platform.h>
+#include "drivers/io.h"
+
+#include "drivers/timer.h"
+#include "drivers/timer_def.h"
+#include "drivers/dma.h"
+
+
+const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
+    { TIM9,  IO_TAG(PA3),   TIM_Channel_2, TIM_USE_PPM | TIM_USE_PWM,   0, GPIO_AF_TIM9, NULL, 0, 0 }, // PPM / PWM1 / UART2 RX
+    { TIM9,  IO_TAG(PA2),   TIM_Channel_1, TIM_USE_PWM,                 0, GPIO_AF_TIM9, NULL, 0, 0 }, // PPM / PWM2 / UART2 TX
+
+    { TIM8,  IO_TAG(PC6),  TIM_Channel_1, TIM_USE_MOTOR,                1, GPIO_AF_TIM8,  DMA2_Stream2, DMA_Channel_7, DMA2_ST2_HANDLER }, // ESC 1
+    { TIM8,  IO_TAG(PC7),  TIM_Channel_2, TIM_USE_MOTOR,                1, GPIO_AF_TIM8,  DMA2_Stream3, DMA_Channel_7, DMA2_ST3_HANDLER }, // ESC 2
+    { TIM8,  IO_TAG(PC9),  TIM_Channel_4, TIM_USE_MOTOR,                1, GPIO_AF_TIM8,  DMA2_Stream7, DMA_Channel_7, DMA2_ST7_HANDLER }, // ESC 3
+    { TIM8,  IO_TAG(PC8),  TIM_Channel_3, TIM_USE_MOTOR,                1, GPIO_AF_TIM8,  DMA2_Stream4, DMA_Channel_7, DMA2_ST4_HANDLER }, // ESC 4
+
+#if (SPRACINGF4EVO_REV >= 2)
+    { TIM4,  IO_TAG(PB6),  TIM_Channel_1, TIM_USE_MOTOR,                1, GPIO_AF_TIM4, DMA1_Stream0, DMA_Channel_2, DMA1_ST0_HANDLER }, // ESC 5 / Conflicts with USART5_RX / SPI3_RX - SPI3_RX can be mapped to DMA1_ST3_CH0
+    { TIM4,  IO_TAG(PB7),  TIM_Channel_2, TIM_USE_MOTOR,                1, GPIO_AF_TIM4, DMA1_Stream3, DMA_Channel_2, DMA1_ST3_HANDLER }, // ESC 6 / Conflicts with USART3_RX
+#else
+#ifdef USE_TIM10_TIM11_FOR_MOTORS
+    { TIM10,  IO_TAG(PB8),  TIM_Channel_1, TIM_USE_MOTOR,                1, GPIO_AF_TIM10, NULL,         0,             0                }, // ESC 5
+    { TIM11,  IO_TAG(PB9),  TIM_Channel_1, TIM_USE_MOTOR,                1, GPIO_AF_TIM11, NULL,         0,             0                }, // ESC 6
+#else
+    { TIM4,  IO_TAG(PB8),  TIM_Channel_3, TIM_USE_MOTOR,                1, GPIO_AF_TIM4, DMA1_Stream7, DMA_Channel_2, DMA1_ST7_HANDLER }, // ESC 5
+    { TIM4,  IO_TAG(PB9),  TIM_Channel_4, TIM_USE_MOTOR,                1, GPIO_AF_TIM4, NULL,         0,             0                }, // ESC 6
+#endif
+#endif
+    { TIM3,  IO_TAG(PB1),  TIM_Channel_4, TIM_USE_MOTOR,                1, GPIO_AF_TIM3, DMA1_Stream2, DMA_Channel_5, DMA1_ST2_HANDLER }, // ESC 7
+    { TIM3,  IO_TAG(PB0),  TIM_Channel_3, TIM_USE_MOTOR,                1, GPIO_AF_TIM3, DMA1_Stream7, DMA_Channel_5, DMA1_ST7_HANDLER }, // ESC 8
+
+
+    { TIM2,  IO_TAG(PA1),  TIM_Channel_2, TIM_USE_LED,                  1, GPIO_AF_TIM2, DMA1_Stream6, DMA_Channel_3, DMA1_ST6_HANDLER }, // LED Strip
+    // Additional 2 PWM channels available on UART3 RX/TX pins
+    // However, when using led strip the timer cannot be used, but no code appears to prevent that right now
+    { TIM2,  IO_TAG(PB10), TIM_Channel_3, TIM_USE_MOTOR,                1, GPIO_AF_TIM2, DMA1_Stream1, DMA_Channel_3, DMA1_ST1_HANDLER }, // Shared with UART3 TX PIN and SPI3 TX (OSD)
+    { TIM2,  IO_TAG(PB11), TIM_Channel_4, TIM_USE_MOTOR,                1, GPIO_AF_TIM2, DMA1_Stream6, DMA_Channel_3, DMA1_ST6_HANDLER }, // Shared with UART3 RX PIN
+
+    { TIM1,  IO_TAG(PA8),  TIM_Channel_1, TIM_USE_TRANSPONDER,          1, GPIO_AF_TIM1, DMA2_Stream6, DMA_Channel_0, DMA2_ST6_HANDLER }, // Transponder
+    // Additional 2 PWM channels available on UART1 RX/TX pins
+    // However, when using transponder the timer cannot be used, but no code appears to prevent that right now
+    { TIM1,  IO_TAG(PA9),  TIM_Channel_2, TIM_USE_SERVO | TIM_USE_PWM,  1, GPIO_AF_TIM1, DMA2_Stream2, DMA_Channel_6, DMA2_ST2_HANDLER }, // PWM 3
+    { TIM1,  IO_TAG(PA10), TIM_Channel_3, TIM_USE_SERVO | TIM_USE_PWM,  1, GPIO_AF_TIM1, DMA2_Stream6, DMA_Channel_6, DMA2_ST6_HANDLER }, // PWM 4
+};

--- a/src/main/target/SPRACINGF4EVO/target.h
+++ b/src/main/target/SPRACINGF4EVO/target.h
@@ -1,0 +1,189 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define TARGET_BOARD_IDENTIFIER "SP4E"
+#define TARGET_CONFIG
+
+#ifndef SPRACINGF4EVO_REV
+#define SPRACINGF4EVO_REV 2
+#endif
+
+#define USBD_PRODUCT_STRING     "SP Racing F4 NEO"
+
+#define LED0                    PA0
+
+#define BEEPER                  PC15
+#define BEEPER_INVERTED
+
+#define INVERTER_PIN_UART2     PB2
+
+#define USE_EXTI
+#define MPU_INT_EXTI            PC13
+
+#define USE_MPU_DATA_READY_SIGNAL
+#define ENSURE_MPU_DATA_READY_IS_LOW
+
+#define USE_MAG_DATA_READY_SIGNAL
+#define ENSURE_MAG_DATA_READY_IS_HIGH
+
+#define GYRO
+#define USE_GYRO_SPI_MPU6500
+
+#define ACC
+#define USE_ACC_SPI_MPU6500
+
+#define ACC_MPU6500_ALIGN       CW0_DEG
+#define GYRO_MPU6500_ALIGN      CW0_DEG
+
+#define BARO
+#define USE_BARO_BMP280
+#define USE_BARO_MS5611
+
+#define MAG
+#define USE_MAG_AK8975
+#define USE_MAG_HMC5883
+
+#define USB_IO
+
+#define USE_VCP
+#define USE_UART1
+#define USE_UART2
+#define USE_UART3
+#define USE_UART4
+#define USE_UART5
+#define SERIAL_PORT_COUNT       6
+
+#define UART1_TX_PIN            PA9
+#define UART1_RX_PIN            PA10
+
+#define UART2_TX_PIN            PA2
+#define UART2_RX_PIN            PA3
+
+#define UART3_TX_PIN            PB10
+#define UART3_RX_PIN            PB11
+
+#define UART4_TX_PIN            PC10
+#define UART4_RX_PIN            PC11
+
+#define UART5_TX_PIN            PC12
+#define UART5_RX_PIN            PD2
+
+// TODO
+// #define USE_ESCSERIAL
+// #define ESCSERIAL_TIMER_TX_HARDWARE 0 // PWM 1
+
+#define USE_I2C
+#define I2C_DEVICE              (I2CDEV_1)
+#if (SPRACINGF4EVO_REV >= 2)
+    #define I2C1_SCL                PB8
+    #define I2C1_SDA                PB9
+#else
+    #define I2C1_SCL                PB6
+    #define I2C1_SDA                PB7
+#endif
+
+#define USE_SPI
+#define USE_SPI_DEVICE_1 // MPU
+#define USE_SPI_DEVICE_2 // SDCard
+#define USE_SPI_DEVICE_3 // External
+
+#define SPI1_NSS_PIN            PA4
+#define SPI1_SCK_PIN            PA5
+#define SPI1_MISO_PIN           PA6
+#define SPI1_MOSI_PIN           PA7
+
+#define SPI2_NSS_PIN            PB12
+#define SPI2_SCK_PIN            PB13
+#define SPI2_MISO_PIN           PB14
+#define SPI2_MOSI_PIN           PB15
+
+#define SPI3_NSS_PIN            PA15 // NC
+#define SPI3_SCK_PIN            PB3  // NC
+#define SPI3_MISO_PIN           PB4  // NC
+#define SPI3_MOSI_PIN           PB5  // NC
+
+#define USE_SDCARD
+#define USE_SDCARD_SPI2
+
+#define SDCARD_DETECT_INVERTED
+
+#define SDCARD_DETECT_PIN                   PC14
+#define SDCARD_SPI_INSTANCE                 SPI2
+#define SDCARD_SPI_CS_PIN                   SPI2_NSS_PIN
+
+// SPI3 is on the APB1 bus whose clock runs at 84MHz. Divide to under 400kHz for init:
+#define SDCARD_SPI_INITIALIZATION_CLOCK_DIVIDER 256 // 328kHz
+// Divide to under 25MHz for normal operation:
+#define SDCARD_SPI_FULL_SPEED_CLOCK_DIVIDER     4 // 21MHz
+
+#define SDCARD_DMA_CHANNEL_TX               DMA1_Stream4
+#define SDCARD_DMA_CHANNEL_TX_COMPLETE_FLAG DMA_FLAG_TCIF4
+#define SDCARD_DMA_CLK                      RCC_AHB1Periph_DMA1
+#define SDCARD_DMA_CHANNEL                  DMA_Channel_0
+
+
+#define MPU6500_CS_PIN                      SPI1_NSS_PIN
+#define MPU6500_SPI_INSTANCE                SPI1
+
+#define USE_ADC
+#define ADC_INSTANCE            ADC1
+#define ADC1_DMA_STREAM DMA2_Stream0
+
+#define VBAT_ADC_PIN            PC1
+#define CURRENT_METER_ADC_PIN   PC2
+#define RSSI_ADC_PIN            PC0
+
+// PC4 - NC - Free for ADC12_IN14 / VTX CS
+// PC5 - NC - Free for ADC12_IN15 / VTX Enable / OSD VSYNC
+
+#define BOARD_HAS_VOLTAGE_DIVIDER
+
+
+#define LED_STRIP
+#define TRANSPONDER
+
+#define ENABLE_BLACKBOX_LOGGING_ON_SDCARD_BY_DEFAULT
+
+#define DEFAULT_RX_FEATURE      FEATURE_RX_SERIAL
+#define DEFAULT_FEATURES        (FEATURE_TRANSPONDER | FEATURE_BLACKBOX | FEATURE_RSSI_ADC | FEATURE_TELEMETRY | FEATURE_OSD | FEATURE_LED_STRIP)
+#define SERIALRX_UART           SERIAL_PORT_USART2
+#define TELEMETRY_UART          SERIAL_PORT_UART5
+#define SERIALRX_PROVIDER       SERIALRX_SBUS
+
+#define SPEKTRUM_BIND_PIN       UART2_RX_PIN
+
+#define USE_SERIAL_4WAY_BLHELI_INTERFACE
+
+#define TARGET_IO_PORTA         0xffff
+#define TARGET_IO_PORTB         0xffff
+#define TARGET_IO_PORTC         0xffff
+#define TARGET_IO_PORTD         (BIT(2))
+
+#define USABLE_TIMER_CHANNEL_COUNT 16 // 4xPWM, 8xESC, 2xESC via UART3 RX/TX, 1xLED Strip, 1xIR.
+#if (SPRACINGF4NEO_REV >= 2)
+#define USED_TIMERS  (TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(4) | TIM_N(8) | TIM_N(9))
+#else
+#define USE_TIM10_TIM11_FOR_MOTORS
+#ifdef USE_TIM10_TIM11_FOR_MOTORS
+#define USED_TIMERS  (TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(4) | TIM_N(8) | TIM_N(9) | TIM_N(10) | TIM_N(11))
+#else
+#define USED_TIMERS  (TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(4) | TIM_N(8) | TIM_N(9))
+#endif
+#endif
+

--- a/src/main/target/SPRACINGF4EVO/target.mk
+++ b/src/main/target/SPRACINGF4EVO/target.mk
@@ -1,0 +1,18 @@
+F405_TARGETS  += $(TARGET)
+FEATURES    = VCP SDCARD
+
+TARGET_SRC = \
+            drivers/accgyro_mpu6500.c \
+            drivers/accgyro_spi_mpu6500.c \
+            drivers/barometer_bmp280.c \
+            drivers/barometer_ms5611.c \
+            drivers/compass_ak8975.c \
+            drivers/compass_hmc5883l.c \
+            drivers/max7456.c \
+            drivers/transponder_ir.c \
+            drivers/vtx_rtc6705.c \
+            io/osd.c \
+            io/transponder_ir.c \
+            io/vtx.c
+
+


### PR DESCRIPTION
It's better to use de DEF_TIM macro to create each element of the structure. In this way an user can deactivate the LED_STRIP or DSHOT to get some free space (not needed in the F4 fc, but for coherence with the rest of the boards). All the others config.c of each target use it.

It needs the https://github.com/cleanflight/cleanflight/commit/27e4fe812d7c363172c32cb6a016e0e32e34d012 to work.