### PR TITLE
CF/BF - Fix Naze32 missing second softserial port.

### DIFF
--- a/src/main/target/NAZE/initialisation.c
+++ b/src/main/target/NAZE/initialisation.c
@@ -32,13 +32,14 @@ void targetBusInit(void)
     #endif
     #endif
 
-    if (hardwareRevision != NAZE32_SP) {
-        i2cInit(I2C_DEVICE);
+    if (hardwareRevision == NAZE32_SP) {
         serialRemovePort(SERIAL_PORT_SOFTSERIAL2);
-    } else {
+
         if (!doesConfigurationUsePort(SERIAL_PORT_USART3)) {
             serialRemovePort(SERIAL_PORT_USART3);
             i2cInit(I2C_DEVICE);
         }
+    } else {
+        i2cInit(I2C_DEVICE);
     }
 }


### PR DESCRIPTION
The NAZE32_SP can only have one port because it the pins are not
available for use as soft serial.
The NAZE32_SP should only configure the I2C pins if USART3 is not used.

See https://github.com/cleanflight/cleanflight/issues/2668#issuecomment-290953473