### PR TITLE
Make the GPS stable again

### DIFF
--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -435,7 +435,7 @@ void gpsUpdate(timeUs_t currentTimeUs)
                 gpsData.baudrateIndex++;
                 gpsData.baudrateIndex %= GPS_INIT_ENTRIES;
             }
-            gpsData.lastMessage = currentTimeUs / 1000;
+            gpsData.lastMessage = millis();
             // TODO - move some / all of these into gpsData
             GPS_numSat = 0;
             DISABLE_STATE(GPS_FIX);
@@ -444,7 +444,7 @@ void gpsUpdate(timeUs_t currentTimeUs)
 
         case GPS_RECEIVING_DATA:
             // check for no data/gps timeout/cable disconnection etc
-            if (currentTimeUs / 1000 - gpsData.lastMessage > GPS_TIMEOUT) {
+            if (millis() - gpsData.lastMessage > GPS_TIMEOUT) {
                 // remove GPS from capability
                 sensorsClear(SENSOR_GPS);
                 gpsSetState(GPS_LOST_COMMUNICATION);


### PR DESCRIPTION
This PR solves https://github.com/cleanflight/cleanflight/issues/2698

The GPS is unstable in NAZE32 (customized compilation, as GPS is disabled for F1 targets), but with this little change, based on CleanFlight 1.x, the GPS is stable as rock again. I don't know anything about GPS system, I've only changed lines between 1.x and 2.x until I found the lines that make it work again.

So if someone can take a look at it to see if this change is clean or can have secondary effects will be great. Maybe can be added with `#if defined` only for NAZE or only fo F1 CPUs. I'm open to test any changes.

Regards!