### PR TITLE
CF/BF - Enable MAG on NAZE32.

### DIFF
--- a/src/main/target/NAZE/target.h
+++ b/src/main/target/NAZE/target.h
@@ -101,11 +101,9 @@
 #define USE_BARO_MS5611 // needed for Flip32 board
 #define USE_BARO_BMP280
 
-/*
 #define MAG
 #define USE_MAG_HMC5883
 #define MAG_HMC5883_ALIGN       CW180_DEG
-*/
 
 //#define SONAR
 //#define SONAR_TRIGGER_PIN       PB0

--- a/src/main/target/common.h
+++ b/src/main/target/common.h
@@ -87,7 +87,6 @@
 #define TELEMETRY
 #define TELEMETRY_FRSKY
 #define TELEMETRY_HOTT
-#define TELEMETRY_LTM
 #define TELEMETRY_SMARTPORT
 #define USE_RESOURCE_MGMT
 #define USE_SERVOS
@@ -96,6 +95,7 @@
 #if (FLASH_SIZE > 128)
 #define GPS
 #define CMS
+#define TELEMETRY_LTM
 #define TELEMETRY_CRSF
 #define TELEMETRY_IBUS
 #define TELEMETRY_JETIEXBUS


### PR DESCRIPTION
Disabling LTM allows MAG to be enabled.

Likely more users want MAG support than LTM support on a NAZE32 so this makes sense - seems like a shame to waste the MAG sensors on the NAZE32.