### PR TITLE
Fixed servo cli to process correct arguments.

### DIFF
--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -2469,11 +2469,11 @@ static void cliServo(char *cmdline)
             return;
         }
 
-        servo->min = arguments[1];
-        servo->max = arguments[2];
-        servo->middle = arguments[3];
-        servo->rate = arguments[5];
-        servo->forwardFromChannel = arguments[7];
+        servo->min = arguments[MIN];
+        servo->max = arguments[MAX];
+        servo->middle = arguments[MIDDLE];
+        servo->rate = arguments[RATE];
+        servo->forwardFromChannel = arguments[FORWARD];
     }
 }
 #endif


### PR DESCRIPTION
Noticed the the CLI servo command referenced invalid arguments via magic numbers.  Corrected that.