### PR TITLE
For NAZE32 REV5 and REV6 use the dataflash for blackbox as default

### DIFF
--- a/src/main/target/NAZE/config.c
+++ b/src/main/target/NAZE/config.c
@@ -22,6 +22,8 @@
 
 #ifdef TARGET_CONFIG
 
+#include "blackbox/blackbox.h"
+
 #include "common/axis.h"
 #include "common/utils.h"
 
@@ -103,6 +105,11 @@ void targetConfiguration(void)
     if (hardwareRevision < NAZE32_REV5) {
         compassConfigMutable()->interruptTag = IO_TAG(PB12);
     }
+#endif
+
+#ifdef BLACKBOX
+    if (hardwareRevision >= NAZE32_REV5)
+        blackboxConfigMutable()->device = BLACKBOX_DEVICE_FLASH;
 #endif
 }
 


### PR DESCRIPTION
This solves https://github.com/cleanflight/cleanflight/issues/2666

@hydra I know you closed it, but I haven't do it before because it was assigned ;-).

The problem are the default values for the NAZE32. It uses serial device by default, but some hardware revisions have an on-board dataflash. This PR detects this revisions and uses by default the on-board dataflash.
