### PR TITLE
CF/BF - SPRACINGF3NEO - Change the default telemetry settings

### DIFF
--- a/src/main/target/SPRACINGF3NEO/config.c
+++ b/src/main/target/SPRACINGF3NEO/config.c
@@ -55,7 +55,7 @@ void targetConfiguration(void)
     serialConfigMutable()->portConfigs[1].functionMask = FUNCTION_MSP; // So Bluetooth users don't have to change anything.
     serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(TELEMETRY_UART)].functionMask = FUNCTION_TELEMETRY_SMARTPORT;
     serialConfigMutable()->portConfigs[findSerialPortIndexByIdentifier(GPS_UART)].functionMask = FUNCTION_GPS;
-    telemetryConfigMutable()->telemetry_inversion = 0;
-    telemetryConfigMutable()->sportHalfDuplex = 0;
+    telemetryConfigMutable()->telemetry_inversion = 1;
+    telemetryConfigMutable()->sportHalfDuplex = 1;
 }
 #endif


### PR DESCRIPTION
to be appropriate for the XSR receiver.