### PR TITLE
CF/BF - SPRACINGF3 - Re-instate SONAR.

### DIFF
--- a/src/main/target/SPRACINGF3/target.h
+++ b/src/main/target/SPRACINGF3/target.h
@@ -105,8 +105,11 @@
 #elif defined(ZCOREF3)
 #define USE_MAG_DATA_READY_SIGNAL
 #define ENSURE_MAG_DATA_READY_IS_HIGH
+#else
+#define SONAR
+#define SONAR_TRIGGER_PIN       PB0
+#define SONAR_ECHO_PIN          PB1
 
-#else //SPRACINGF3
 #define USE_BARO_MS5611
 #define USE_BARO_BMP085
 


### PR DESCRIPTION
It appears @borisbstyle broke it with this commit. 907a184

After it was commented out @mikeller later deleted it in ce6d020

See https://github.com/cleanflight/cleanflight/issues/2755