### PR TITLE
Rename rc_rate_yaw to rc_yaw_rate for coherence in blackbox

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1235,7 +1235,7 @@ static bool blackboxWriteSysinfo()
         BLACKBOX_PRINT_HEADER_LINE("pid_process_denom", "%d",                pidConfig()->pid_process_denom);
         BLACKBOX_PRINT_HEADER_LINE("rc_rate", "%d",                          currentControlRateProfile->rcRate8);
         BLACKBOX_PRINT_HEADER_LINE("rc_expo", "%d",                          currentControlRateProfile->rcExpo8);
-        BLACKBOX_PRINT_HEADER_LINE("rc_rate_yaw", "%d",                      currentControlRateProfile->rcYawRate8);
+        BLACKBOX_PRINT_HEADER_LINE("rc_yaw_rate", "%d",                      currentControlRateProfile->rcYawRate8);
         BLACKBOX_PRINT_HEADER_LINE("rc_yaw_expo", "%d",                      currentControlRateProfile->rcYawExpo8);
         BLACKBOX_PRINT_HEADER_LINE("thr_mid", "%d",                          currentControlRateProfile->thrMid8);
         BLACKBOX_PRINT_HEADER_LINE("thr_expo", "%d",                         currentControlRateProfile->thrExpo8);


### PR DESCRIPTION
This solves part of the issue detected here with BlackBox:
https://github.com/betaflight/blackbox-log-viewer/issues/57

For coherence with the others vars, the `rc_rate_yaw` value must be `rc_yaw_rate`.

It's a good moment to do this change, the BlackBox explorer has not been updated to read it, so we don't break anything.