### PR TITLE
Fix markdown links to filenames with spaces

### DIFF
--- a/docs/Battery.md
+++ b/docs/Battery.md
@@ -43,7 +43,7 @@ Notes:
 
 ### Sparky
 
-See the [Sparky board chapter](Board - Sparky.md).
+See the [Sparky board chapter](Board%20-%20Sparky.md).
 
 ## Configuration
 

--- a/docs/Board - AlienFlight.md
+++ b/docs/Board - AlienFlight.md
@@ -32,7 +32,7 @@ Here are the general hardware specifications for this boards:
     set serialrx_provider = 1   (0 for 1024bit, 1 for 2048bit) 
     set spektrum_sat_bind = 5
     
-For more detail of the different bind modes please refer the [Spektrum Bind](Spektrum bind.md) document
+For more detail of the different bind modes please refer the [Spektrum Bind](Spektrum%20bind.md) document
 
 Deltang receivers in serial mode will work like any other Spektrum satellite receiver (10bit, 22ms) only the bind process will be different. 
 

--- a/docs/Board - MotoLab.md
+++ b/docs/Board - MotoLab.md
@@ -34,7 +34,7 @@ The MotoF3 also provides built-in power distribution for four ESCs, an on-board 
 
 MotoLab boards all use the built-in USB interface on the STM32F3 microcontroller. New versions of Cleanflight can be installed using Cleanflight Configurator through the USB interface. Installation of new firmware is described here:
 
-[USB Flashing](USB Flashing.md)
+[USB Flashing](USB%20Flashing.md)
 
 Firmware installation using Windows operating system is complicated because the default device driver for the STM32 USB interface in DFU programming mode is not compatible with the Configurator flash tool. The required DFU mode driver must be manually installed. The default driver for the USB port in normal (VCP) mode is also required for connection to Configurator. Additional details on the drivers and their installion is provided here:
 

--- a/docs/Buzzer.md
+++ b/docs/Buzzer.md
@@ -72,4 +72,4 @@ Buzzer support on the CC3D requires that a buzzer circuit be created to which th
 PA15 is unused and not connected according to the CC3D Revision A schematic.
 Connecting to PA15 requires careful soldering.
 
-See the [CC3D - buzzer circuit.pdf](Wiring/CC3D - buzzer circuit.pdf) for details.
+See the [CC3D - buzzer circuit.pdf](Wiring/CC3D%20-%20buzzer%20circuit.pdf) for details.

--- a/docs/Display.md
+++ b/docs/Display.md
@@ -60,8 +60,8 @@ or other display corruption.
 
 More can be read about this procedure here: http://www.multiwii.com/forum/viewtopic.php?f=6&t=2705&start=10
 
-![Crius CO-16 Diagram](Wiring/Crius CO-16 OLED diagram.png)
-![Crius CO-16 Modification](Wiring/Crius CO-16 OLED modifications.jpg)
+![Crius CO-16 Diagram](Wiring/Crius%20CO-16%20OLED%20diagram.png)
+![Crius CO-16 Modification](Wiring/Crius%20CO-16%20OLED%20modifications.jpg)
 
 ## Connections
 

--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -99,12 +99,12 @@ If the aircraft won't arm, count the red Warning LED flashes and find out the re
 Some advanced configurations and features are documented in the following pages, but have not been touched-upon earlier:
 
 * [Profiles](Profiles.md)
-* [PID tuning](PID tuning.md)
-* [In-flight Adjustments](Inflight Adjustments.md)
+* [PID tuning](PID%20tuning.md)
+* [In-flight Adjustments](Inflight%20Adjustments.md)
 * [Blackbox logging](Blackbox.md)
 * [Using a Sonar](Sonar.md)
-* [Spektrum Bind](Spektrum bind.md)
+* [Spektrum Bind](Spektrum%20bind.md)
 * [Telemetry](Telemetry.md)
 * [Using a Display](Display.md)
 * [Using a LED strip](LedStrip.md)
-* [Migrating from baseflight](Migrating from baseflight.md)
+* [Migrating from baseflight](Migrating%20from%20baseflight.md)

--- a/docs/development/Hardware Debugging in Eclipse.md
+++ b/docs/development/Hardware Debugging in Eclipse.md
@@ -4,7 +4,7 @@ Build a binary with debugging information using command line or via Eclipse make
 
 Example Eclipse make target
 
-![](assets/eclipse-gdb-debugging/make 1 - OLIMEXINO GDB.PNG)
+![](assets/eclipse-gdb-debugging/make%201%20-%20OLIMEXINO%20GDB.PNG)
 
 # GDB and OpenOCD
 
@@ -41,7 +41,7 @@ Here are some screenshots showing Hydra's configuration of Eclipse (Kepler)
 
 If you use cygwin to build the binaries then be sure to have configured your common `Source Lookup Path`, `Path Mappings` first, like this:
 
-![](assets/eclipse-gdb-debugging/config 7.PNG)
+![](assets/eclipse-gdb-debugging/config%207.PNG)
 
 
 Create a new `GDB Hardware Debugging` launch configuration from the `Run` menu
@@ -51,11 +51,11 @@ Select the appropriate .elf file (not hex file) - In these examples the target p
 
 DISABLE auto-build
 
-![](assets/eclipse-gdb-debugging/config 1.PNG)
+![](assets/eclipse-gdb-debugging/config%201.PNG)
 
 Choose the appropriate gdb executable - ideally from the same toolchain that you use to build the executable.
 
-![](assets/eclipse-gdb-debugging/config 2.PNG)
+![](assets/eclipse-gdb-debugging/config%202.PNG)
 
 Configure Startup as follows
 
@@ -73,9 +73,9 @@ monitor reset
 ```
 
 
-![](assets/eclipse-gdb-debugging/config 3.PNG)
+![](assets/eclipse-gdb-debugging/config%203.PNG)
 
-![](assets/eclipse-gdb-debugging/config 4.PNG)
+![](assets/eclipse-gdb-debugging/config%204.PNG)
 
 It may be useful to specify run commands too:
 
@@ -85,31 +85,31 @@ monitor reg pc = (0x00000004)
 continue
 ```
 
-![](assets/eclipse-gdb-debugging/config 13.PNG)
+![](assets/eclipse-gdb-debugging/config%2013.PNG)
 
 If you use cygwin an additional entry should be shown on the Source tab (not present in this screenshot)
 
-![](assets/eclipse-gdb-debugging/config 5.PNG)
+![](assets/eclipse-gdb-debugging/config%205.PNG)
 
 Nothing to change from the defaults on the Common tab
 
-![](assets/eclipse-gdb-debugging/config 6.PNG)
+![](assets/eclipse-gdb-debugging/config%206.PNG)
 
 Start up the J-Link server in USB mode
 
-![](assets/eclipse-gdb-debugging/config 9.PNG)
+![](assets/eclipse-gdb-debugging/config%209.PNG)
 
 If it connects to your target device it should look like this
 
-![](assets/eclipse-gdb-debugging/config 10.PNG)
+![](assets/eclipse-gdb-debugging/config%2010.PNG)
 
 From Eclipse launch the application using the Run/Debug Configurations..., Eclipse should upload the compiled file to the target device which looks like this
  
-![](assets/eclipse-gdb-debugging/config 11.PNG)
+![](assets/eclipse-gdb-debugging/config%2011.PNG)
 
 When it's running the J-Link server should look like this.
 
-![](assets/eclipse-gdb-debugging/config 12.PNG)
+![](assets/eclipse-gdb-debugging/config%2012.PNG)
 
 Then finally you can use Eclipse debug features to inspect variables, memory, stacktrace, set breakpoints, step over code, etc.
 
@@ -117,5 +117,5 @@ Then finally you can use Eclipse debug features to inspect variables, memory, st
 
 If Eclipse can't find your breakpoints and they are ignored then check your path mappings (if using cygwin) or use the other debugging launcher as follows.  Note the 'Select other...' at the bottom of the configuration window.
 
-![](assets/eclipse-gdb-debugging/config 8 - If breakpoints do not work.PNG)
+![](assets/eclipse-gdb-debugging/config%208%20-%20If%20breakpoints%20do%20not%20work.PNG)
 

--- a/docs/development/Hardware Debugging.md
+++ b/docs/development/Hardware Debugging.md
@@ -2,7 +2,7 @@
 
 The code can be compiled with debugging information, you can then upload a debug version to a board via a JLink/St-Link debug adapter and step through the code in your IDE.
 
-More information about the necessary hardware and setting up the eclipse IDE can be found [here](Hardware Debugging in Eclipse.md)
+More information about the necessary hardware and setting up the eclipse IDE can be found [here](Hardware%20Debugging%20in%20Eclipse.md)
 
 A guide for visual studio can be found here:
 http://visualgdb.com/tutorials/arm/st-link/


### PR DESCRIPTION
Markdown links cannot have actual spaces in the filename.  Use URL-encoded
spaces (%20) instead.

robo-fixed using:
   sed -i -e 's/\(]([^ )]*\) \([^"]\)/\1%20\2/g' **/*.md

If you don't use zhell, you may need to customize the ** part of that command.