### PR TITLE
activate 'USE_RX_MSP' on NAZE targets

### DIFF
--- a/src/main/target/NAZE/target.h
+++ b/src/main/target/NAZE/target.h
@@ -49,6 +49,8 @@
 
 #define INVERTER_PIN_UART2        PB2 // PB2 (BOOT1) abused as inverter select GPIO
 
+#define USE_RX_MSP
+
 #define USE_EXTI
 #define MAG_INT_EXTI            PC14
 #define MPU_INT_EXTI            PC13


### PR DESCRIPTION
This PR replaces https://github.com/cleanflight/cleanflight/pull/2812. It activates 'USE_RX_MSP' for NAZE targets. I am not able to test this on hardware for now, since commit 839b5dd408737045bcf7f83df015d1496acaa759 breaks cleanflight on NAZE targets.