### PR TITLE
IOGetByTag did not handle empty Tag correctly

### DIFF
--- a/src/main/drivers/io.c
+++ b/src/main/drivers/io.c
@@ -378,7 +378,7 @@ IO_t IOGetByTag(ioTag_t tag)
     int portIdx = DEFIO_TAG_GPIOID(tag);
     int pinIdx = DEFIO_TAG_PIN(tag);
 
-    if (portIdx >= DEFIO_PORT_USED_COUNT)
+    if (portIdx < 0 || portIdx >= DEFIO_PORT_USED_COUNT)
         return NULL;
     // check if pin exists
     if (!(ioDefUsedMask[portIdx] & (1 << pinIdx)))


### PR DESCRIPTION
Fix critical bug.
IOGetByTag could return invalid IO_t when passed NONE. This error was triggered by non-zero bit in flash location not directly related to IO code and was dependent on another memory then.

Triggered by https://github.com/cleanflight/cleanflight/commit/839b5dd408737045bcf7f83df015d1496acaa759#commitcomment-22309747, fixes it

I am very sorry ... 