### PR TITLE
Documentation for combine ibus serial rx and telemetry on same UART

### DIFF
--- a/docs/Rx.md
+++ b/docs/Rx.md
@@ -150,6 +150,30 @@ These receivers are reported working (all gives 10 channels serial):
 - FlySky/Turnigy FS-iA10 10-Channel Receiver (http://www.flysky-cn.com/products_detail/productId=53.html)
 - FlySky/Turnigy FS-iA10B 10-Channel Receiver (http://www.flysky-cn.com/products_detail/productId=52.html)
 
+#### Combine flysky ibus telemetry and serial rx on the same FC serial port
+  
+  Connect Flysky FS-iA6B receiver like this:
+```   
+    +---------+
+    | FS-iA6B |
+    |         |
+    | Ser RX  |---|<---\       +------------+
+    |         |        |       | FC         |
+    | Sensor  |--#==#--*-------| SerialTX   |
+    +---------+                +------------+
+```
+
+Use a diode with cathode to receiver serial rx output (for example 1N4148),
+the anode is connected to the FC serial _TX_ pin, and also via a 
+resistor (10KOhm) to the receiver ibus sensor port.
+
+Enable with cli:
+```  
+    serial 1 1088 115200 57600 115200 115200
+    feature RX_SERIAL
+    set serialrx_provider = IBUS
+    save
+```
 ## MultiWii serial protocol (MSP)
 
 Allows you to use MSP commands as the RC input.  Only 8 channel support to maintain compatibility with MSP.

--- a/docs/Telemetry.md
+++ b/docs/Telemetry.md
@@ -269,6 +269,8 @@ It runs at a fixed baud rate of 115200.
 
 It should be possible to daisy chain multiple sensors with ibus. This is implemented but not tested because i don't have one of the sensors to test with, the FC shall always be the last sensor in the chain.
 
+It is possible to combine serial rx and ibus telemetry on the same uart pin on the flight controller, see [Rx](Rx.md).
+
 ### Configuration
 
 Ibus telemetry can be enabled in the firmware at build time using defines in target.h. It is enabled by default in those targets that have space left.


### PR DESCRIPTION
This PR https://github.com/cleanflight/cleanflight/pull/2554 was not merged in CF1.x, and was merged into BF. But in BF the doc was not updated.

This PR only recovers the docs updated in this PR, explaining how to use the same UART for SerialRX and Telemetry in IBus.