### PR TITLE
CF/BF - Always size optimize some non-speed critical files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -887,13 +887,14 @@ SPEED_OPTIMISED_SRC := $(SPEED_OPTIMISED_SRC) \
             drivers/display_ug2864hsweg01.c \
             drivers/light_ws2811strip.c \
             drivers/serial_softserial.c \
-            io/dashboard.c \
             io/displayport_max7456.c \
             io/osd.c \
             io/osd_slave.c
 
 SIZE_OPTIMISED_SRC := $(SIZE_OPTIMISED_SRC) \
             drivers/serial_escserial.c \
+            drivers/vtx_rtc6705_soft_spi.c \
+            drivers/vtx_rtc6705.c \
             drivers/vtx_common.c \
             fc/fc_init.c \
             fc/cli.c \
@@ -905,6 +906,7 @@ SIZE_OPTIMISED_SRC := $(SIZE_OPTIMISED_SRC) \
             io/serial_4way.c \
             io/serial_4way_avrootloader.c \
             io/serial_4way_stk500v2.c \
+            io/dashboard.c \
             msp/msp_serial.c \
             cms/cms.c \
             cms/cms_menu_blackbox.c \
@@ -913,9 +915,11 @@ SIZE_OPTIMISED_SRC := $(SIZE_OPTIMISED_SRC) \
             cms/cms_menu_ledstrip.c \
             cms/cms_menu_misc.c \
             cms/cms_menu_osd.c \
+            io/vtx_string.c \
             io/vtx_rtc6705.c \
             io/vtx_smartaudio.c \
-            io/vtx_tramp.c
+            io/vtx_tramp.c \
+            io/vtx_control.c
 endif #!F1
 
 ifeq ($(TARGET),$(filter $(TARGET),$(F4_TARGETS)))

--- a/Makefile
+++ b/Makefile
@@ -1122,8 +1122,8 @@ SIZE        := $(ARM_SDK_PREFIX)size
 
 ifneq ($(DEBUG),GDB)
 OPTIMISATION_BASE   := -flto -fuse-linker-plugin -ffast-math
-OPTIMISE_SPEED      := ""
-OPTIMISE_SIZE       := ""
+OPTIMISE_SPEED      := 
+OPTIMISE_SIZE       := 
 
 ifeq ($(TARGET),$(filter $(TARGET),$(F1_TARGETS)))
 OPTIMISE_DEFAULT    := -Os


### PR DESCRIPTION
This goes some way to addressing #2808 and certainly allows the new SPRACINGF4NEO target to have all the features enabled now.  See https://github.com/cleanflight/cleanflight/pull/2835