### PR TITLE
Fix compiles issues when not defined USE_SERVOS

### DIFF
--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -557,9 +557,10 @@ void validateAndFixConfig(void)
     if (!(mixerMode == MIXER_CUSTOM || mixerMode == MIXER_CUSTOM_AIRPLANE || mixerMode == MIXER_CUSTOM_TRI)) {
         if (mixers[mixerMode].motorCount && mixers[mixerMode].motor == NULL)
             mixerConfigMutable()->mixerMode = MIXER_CUSTOM;
-
+#ifdef USE_SERVOS
         if (mixers[mixerMode].useServo && servoMixers[mixerMode].servoRuleCount == 0)
             mixerConfigMutable()->mixerMode = MIXER_CUSTOM_AIRPLANE;
+#endif
     }
 #endif
 


### PR DESCRIPTION
When added:
```
#undef USE_SERVOS
```
to the `target.h` file to free some space to other features, the compiler gives an error because:
```
/tmp/ccq2pmk9.ltrans15.ltrans.o: In function `loadEEPROM':
/mnt/d/git/mcgivergim/cleanflight/./src/main/config/config_eeprom.c:180: undefined reference to `servoMixers'
```
This commit solves the problem.

NOTE: I don't know what the code does exactly, so maybe it's better to put the conditional in other part. Please review the code before merge.