### PR TITLE
Read current from ESC fixed.

### DIFF
--- a/src/main/sensors/current.c
+++ b/src/main/sensors/current.c
@@ -211,7 +211,6 @@ void currentMeterESCReadCombined(currentMeter_t *meter)
     meter->amperageLatest = currentMeterESCState.amperage;
     meter->amperage = currentMeterESCState.amperage;
     meter->mAhDrawn = currentMeterESCState.mAhDrawn;
-    currentMeterReset(meter);
 }
 
 void currentMeterESCReadMotor(uint8_t motorNumber, currentMeter_t *meter)


### PR DESCRIPTION
I think there is a problem in currentMeterESCReadCombined function, it fills out meter pointer and then calls currentMeterReset function which clears the pointer.

