### PR TITLE
CF/BF - Fix servo filter initialisation.

### DIFF
--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -440,6 +440,10 @@ void init(void)
     // gyro.targetLooptime set in sensorsAutodetect(), so we are ready to call pidInit()
     pidInit(currentPidProfile);
 
+#ifdef USE_SERVOS
+    servosFilterInit();
+#endif
+
     imuInit();
 
     mspFcInit();

--- a/src/main/flight/servos.h
+++ b/src/main/flight/servos.h
@@ -132,3 +132,4 @@ void loadCustomServoMixer(void);
 int servoDirection(int servoIndex, int fromChannel);
 void servoConfigureOutput(void);
 void servosInit(void);
+void servosFilterInit(void);


### PR DESCRIPTION
Prior to this only the first filter was initialised.  The bug was clearly visible from the motors tab in the UI - servos 2-8 were always static.

Either one flag per servo is needed or just initialise all of them after the targetPidLooptime is set.  I went with the latter as it's a) simpler , b) makes the main loop faster, and c) follows the same pattern as other filter initialisation code.

Tested and working here.