### PR TITLE
CF/BF - SPRACINGF4NEO stabilise ADC readings.

### DIFF
--- a/src/main/sensors/voltage.h
+++ b/src/main/sensors/voltage.h
@@ -54,7 +54,9 @@ typedef enum {
 #define VBAT_SCALE_MIN 0
 #define VBAT_SCALE_MAX 255
 
+#ifndef VBATT_LPF_FREQ
 #define VBATT_LPF_FREQ  1.0f
+#endif
 
 #ifndef MAX_VOLTAGE_SENSOR_ADC
 #define MAX_VOLTAGE_SENSOR_ADC 1 // VBAT - some boards have external, 12V, 9V and 5V meters.

--- a/src/main/target/SPRACINGF4NEO/target.h
+++ b/src/main/target/SPRACINGF4NEO/target.h
@@ -178,6 +178,8 @@
 #define MPU6500_CS_PIN                      SPI1_NSS_PIN
 #define MPU6500_SPI_INSTANCE                SPI1
 
+#define VBATT_LPF_FREQ 0.25f                // The ADC in the F4NEO appears to be noisy, this stabilises it but at the cost of latency.
+
 #define USE_ADC
 #define ADC_INSTANCE                        ADC1
 #define ADC1_DMA_STREAM                     DMA2_Stream0


### PR DESCRIPTION
The F4 NEO ADC readings fluctuate quite a lot, this fix helps, but at the cost of latency.

![f4neo-adc](https://user-images.githubusercontent.com/57075/27993744-9953a1fe-64a7-11e7-830c-eb90a7e80803.PNG)

The graph above shows the filtered ADC output, the unfiltered output and the difference between the two, for comparison.  Low-noise bench power supply used for tests.

This fix works for now, but perhaps it's working making the ADC frequency configurable?