### PR TITLE
SmartAudio-CMS fixes and improvements

### DIFF
--- a/make/source.mk
+++ b/make/source.mk
@@ -164,6 +164,7 @@ FC_SRC = \
             telemetry/ibus_shared.c \
             sensors/esc_sensor.c \
             io/vtx_string.c \
+            io/vtx_settings_config.c \
             io/vtx_rtc6705.c \
             io/vtx_smartaudio.c \
             io/vtx_tramp.c \
@@ -262,6 +263,7 @@ SIZE_OPTIMISED_SRC := $(SIZE_OPTIMISED_SRC) \
             cms/cms_menu_misc.c \
             cms/cms_menu_osd.c \
             io/vtx_string.c \
+            io/vtx_settings_config.c \
             io/vtx_rtc6705.c \
             io/vtx_smartaudio.c \
             io/vtx_tramp.c \

--- a/src/main/cms/cms_menu_vtx_rtc6705.c
+++ b/src/main/cms/cms_menu_vtx_rtc6705.c
@@ -31,6 +31,7 @@
 
 #include "io/vtx_string.h"
 #include "io/vtx_rtc6705.h"
+#include "io/vtx_settings_config.h"
 
 
 static uint8_t cmsx_vtxBand;
@@ -46,21 +47,19 @@ static const char * const rtc6705BandNames[] = {
 };
 
 static OSD_TAB_t entryVtxBand =         {&cmsx_vtxBand, ARRAYLEN(rtc6705BandNames) - 1, &rtc6705BandNames[0]};
-static OSD_UINT8_t entryVtxChannel =    {&cmsx_vtxChannel, 1, 8, 1};
-static OSD_TAB_t entryVtxPower =        {&cmsx_vtxPower, RTC6705_POWER_COUNT - 1, &rtc6705PowerNames[0]};
+static OSD_UINT8_t entryVtxChannel =    {&cmsx_vtxChannel, 1, VTX_RTC6705_CHAN_COUNT, 1};
+static OSD_TAB_t entryVtxPower =        {&cmsx_vtxPower, VTX_RTC6705_POWER_COUNT - 1, &rtc6705PowerNames[0]};
 
 static void cmsx_Vtx_ConfigRead(void)
 {
-    cmsx_vtxBand = vtxRTC6705Config()->band - 1;
-    cmsx_vtxChannel = vtxRTC6705Config()->channel;
-    cmsx_vtxPower = vtxRTC6705Config()->power;
+    cmsx_vtxBand = vtxSettingsConfig()->band - 1;
+    cmsx_vtxChannel = vtxSettingsConfig()->channel;
+    cmsx_vtxPower = vtxSettingsConfig()->power;
 }
 
 static void cmsx_Vtx_ConfigWriteback(void)
 {
-    vtxRTC6705ConfigMutable()->band = cmsx_vtxBand + 1;
-    vtxRTC6705ConfigMutable()->channel = cmsx_vtxChannel;
-    vtxRTC6705ConfigMutable()->power = cmsx_vtxPower;
+    vtxSettingsSaveBandChanAndPower(cmsx_vtxBand+1, cmsx_vtxChannel, cmsx_vtxPower);
 }
 
 static long cmsx_Vtx_onEnter(void)

--- a/src/main/cms/cms_menu_vtx_smartaudio.c
+++ b/src/main/cms/cms_menu_vtx_smartaudio.c
@@ -32,6 +32,7 @@
 
 #include "io/vtx_string.h"
 #include "io/vtx_smartaudio.h"
+#include "io/vtx_settings_config.h"
 
 // Interface to CMS
 
@@ -340,9 +341,9 @@ static CMS_Menu saCmsMenuStats = {
     .entries = saCmsMenuStatsEntries
 };
 
-static OSD_TAB_t saCmsEntBand = { &saCmsBand, 5, vtx58BandNames };
+static OSD_TAB_t saCmsEntBand = { &saCmsBand, VTX_SMARTAUDIO_BAND_COUNT, vtx58BandNames };
 
-static OSD_TAB_t saCmsEntChan = { &saCmsChan, 8, vtx58ChannelNames };
+static OSD_TAB_t saCmsEntChan = { &saCmsChan, VTX_SMARTAUDIO_CHAN_COUNT, vtx58ChannelNames };
 
 static const char * const saCmsPowerNames[] = {
     "---",
@@ -352,7 +353,7 @@ static const char * const saCmsPowerNames[] = {
     "800",
 };
 
-static OSD_TAB_t saCmsEntPower = { &saCmsPower, 4, saCmsPowerNames};
+static OSD_TAB_t saCmsEntPower = { &saCmsPower, VTX_SMARTAUDIO_POWER_COUNT, saCmsPowerNames};
 
 static OSD_UINT16_t saCmsEntFreqRef = { &saCmsFreqRef, 5600, 5900, 0 };
 

--- a/src/main/cms/cms_menu_vtx_smartaudio.h
+++ b/src/main/cms/cms_menu_vtx_smartaudio.h
@@ -22,4 +22,6 @@
 
 extern CMS_Menu cmsx_menuVtxSmartAudio;
 
+void saCmsUpdate(void);
 void saUpdateStatusString(void);
+void saCmsResetOpmodel();

--- a/src/main/cms/cms_menu_vtx_tramp.c
+++ b/src/main/cms/cms_menu_vtx_tramp.c
@@ -31,6 +31,7 @@
 
 #include "io/vtx_string.h"
 #include "io/vtx_tramp.h"
+#include "io/vtx_settings_config.h"
 
 
 char trampCmsStatusString[31] = "- -- ---- ----";
@@ -62,15 +63,15 @@ uint8_t trampCmsBand = 1;
 uint8_t trampCmsChan = 1;
 uint16_t trampCmsFreqRef;
 
-static OSD_TAB_t trampCmsEntBand = { &trampCmsBand, 5, vtx58BandNames };
+static OSD_TAB_t trampCmsEntBand = { &trampCmsBand, VTX_TRAMP_BAND_COUNT, vtx58BandNames };
 
-static OSD_TAB_t trampCmsEntChan = { &trampCmsChan, 8, vtx58ChannelNames };
+static OSD_TAB_t trampCmsEntChan = { &trampCmsChan, VTX_TRAMP_CHAN_COUNT, vtx58ChannelNames };
 
 static OSD_UINT16_t trampCmsEntFreqRef = { &trampCmsFreqRef, 5600, 5900, 0 };
 
 static uint8_t trampCmsPower = 1;
 
-static OSD_TAB_t trampCmsEntPower = { &trampCmsPower, 5, trampPowerNames };
+static OSD_TAB_t trampCmsEntPower = { &trampCmsPower, sizeof(trampPowerTable), trampPowerNames };
 
 static void trampCmsUpdateFreqRef(void)
 {

--- a/src/main/config/parameter_group_ids.h
+++ b/src/main/config/parameter_group_ids.h
@@ -85,7 +85,7 @@
 #define PG_CURRENT_SENSOR_ADC_CONFIG 256
 #define PG_CURRENT_SENSOR_VIRTUAL_CONFIG 257
 #define PG_VOLTAGE_SENSOR_ADC_CONFIG 258
-#define PG_VTX_RTC6705_CONFIG 259
+#define PG_VTX_SETTINGS_CONFIG 259
 
 
 // betaflight specific parameter group ids start at 500

--- a/src/main/fc/cli.c
+++ b/src/main/fc/cli.c
@@ -111,8 +111,8 @@ extern uint8_t __config_end;
 #include "io/osd.h"
 #include "io/serial.h"
 #include "io/transponder_ir.h"
-#include "io/vtx_rtc6705.h"
 #include "io/vtx_control.h"
+#include "io/vtx_settings_config.h"
 
 #include "msp/msp_protocol.h"
 
@@ -1866,12 +1866,6 @@ static void printVtx(uint8_t dumpMask, const vtxConfig_t *vtxConfig, const vtxCo
     }
 }
 
-// FIXME remove these and use the VTX API
-#define VTX_BAND_MIN                            1
-#define VTX_BAND_MAX                            5
-#define VTX_CHANNEL_MIN                         1
-#define VTX_CHANNEL_MAX                         8
-
 static void cliVtx(char *cmdline)
 {
     int i, val = 0;
@@ -1897,7 +1891,7 @@ static void cliVtx(char *cmdline)
             if (ptr) {
                 val = atoi(ptr);
                 // FIXME Use VTX API to get min/max
-                if (val >= VTX_BAND_MIN && val <= VTX_BAND_MAX) {
+                if (val >= VTX_SETTINGS_MIN_BAND && val <= VTX_SETTINGS_MAX_BAND) {
                     cac->band = val;
                     validArgumentCount++;
                 }
@@ -1906,7 +1900,7 @@ static void cliVtx(char *cmdline)
             if (ptr) {
                 val = atoi(ptr);
                 // FIXME Use VTX API to get min/max
-                if (val >= VTX_CHANNEL_MIN && val <= VTX_CHANNEL_MAX) {
+                if (val >= VTX_SETTINGS_MIN_CHAN && val <= VTX_SETTINGS_MAX_CHAN) {
                     cac->channel = val;
                     validArgumentCount++;
                 }

--- a/src/main/fc/settings.c
+++ b/src/main/fc/settings.c
@@ -737,6 +737,9 @@ const clivalue_t valueTable[] = {
     { "vtx_band",                   VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, VTX_SETTINGS_MAX_BAND }, PG_VTX_SETTINGS_CONFIG, offsetof(vtxSettingsConfig_t, band) },
     { "vtx_channel",                VAR_UINT8  | MASTER_VALUE, .config.minmax = { VTX_SETTINGS_MIN_CHAN, VTX_SETTINGS_MAX_CHAN }, PG_VTX_SETTINGS_CONFIG, offsetof(vtxSettingsConfig_t, channel) },
     { "vtx_power",                  VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, VTX_SETTINGS_POWER_COUNT }, PG_VTX_SETTINGS_CONFIG, offsetof(vtxSettingsConfig_t, power) },
+#ifdef VTX_SETTINGS_FREQCMD
+    { "vtx_freq",                   VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, VTX_SETTINGS_MAX_FREQ }, PG_VTX_SETTINGS_CONFIG, offsetof(vtxSettingsConfig_t, freq) },
+#endif
 #endif
 
 // PG_VTX_CONFIG

--- a/src/main/fc/settings.c
+++ b/src/main/fc/settings.c
@@ -62,7 +62,7 @@
 #include "io/ledstrip.h"
 #include "io/osd.h"
 #include "io/vtx_control.h"
-#include "io/vtx_rtc6705.h"
+#include "io/vtx_settings_config.h"
 
 #include "rx/rx.h"
 #include "rx/spektrum.h"
@@ -732,11 +732,11 @@ const clivalue_t valueTable[] = {
 #endif
     { "pwr_on_arm_grace",           VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 30 }, PG_SYSTEM_CONFIG, offsetof(systemConfig_t, powerOnArmingGraceTime) },
 
-// PG_VTX_RTC6705_CONFIG
-#ifdef VTX_RTC6705
-    { "vtx_band",                   VAR_UINT8  | MASTER_VALUE, .config.minmax = { 1, 5 }, PG_VTX_RTC6705_CONFIG, offsetof(vtxRTC6705Config_t, band) },
-    { "vtx_channel",                VAR_UINT8  | MASTER_VALUE, .config.minmax = { 1, 8 }, PG_VTX_RTC6705_CONFIG, offsetof(vtxRTC6705Config_t, channel) },
-    { "vtx_power",                  VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, RTC6705_POWER_COUNT - 1 }, PG_VTX_RTC6705_CONFIG, offsetof(vtxRTC6705Config_t, power) },
+// PG_VTX_CONFIG
+#ifdef VTX_SETTINGS_CONFIG
+    { "vtx_band",                   VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, VTX_SETTINGS_MAX_BAND }, PG_VTX_SETTINGS_CONFIG, offsetof(vtxSettingsConfig_t, band) },
+    { "vtx_channel",                VAR_UINT8  | MASTER_VALUE, .config.minmax = { VTX_SETTINGS_MIN_CHAN, VTX_SETTINGS_MAX_CHAN }, PG_VTX_SETTINGS_CONFIG, offsetof(vtxSettingsConfig_t, channel) },
+    { "vtx_power",                  VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, VTX_SETTINGS_POWER_COUNT }, PG_VTX_SETTINGS_CONFIG, offsetof(vtxSettingsConfig_t, power) },
 #endif
 
 // PG_VTX_CONFIG

--- a/src/main/io/vtx_rtc6705.h
+++ b/src/main/io/vtx_rtc6705.h
@@ -20,25 +20,23 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include "config/parameter_group.h"
+#define VTX_RTC6705_MIN_BAND 1
+#define VTX_RTC6705_MAX_BAND 5
+#define VTX_RTC6705_MIN_CHAN 1
+#define VTX_RTC6705_MAX_CHAN 8
 
-typedef struct vtxRTC6705Config_s {
-    uint8_t band;       // 1=A, 2=B, 3=E, 4=F(Airwaves/Fatshark), 5=Raceband
-    uint8_t channel;    // 1-8
-    uint8_t power;      // 0 = lowest
-} vtxRTC6705Config_t;
-
-PG_DECLARE(vtxRTC6705Config_t, vtxRTC6705Config);
+#define VTX_RTC6705_BAND_COUNT (VTX_RTC6705_MAX_BAND - VTX_RTC6705_MIN_BAND + 1)
+#define VTX_RTC6705_CHAN_COUNT (VTX_RTC6705_MAX_CHAN - VTX_RTC6705_MIN_CHAN + 1)
 
 #ifdef RTC6705_POWER_PIN
-#define RTC6705_POWER_COUNT 3
+#define VTX_RTC6705_POWER_COUNT 3
 #define VTX_RTC6705_DEFAULT_POWER 1
 #else
-#define RTC6705_POWER_COUNT 2
+#define VTX_RTC6705_POWER_COUNT 2
 #define VTX_RTC6705_DEFAULT_POWER 0
 #endif
 
-extern const char * const rtc6705PowerNames[RTC6705_POWER_COUNT];
+extern const char * const rtc6705PowerNames[VTX_RTC6705_POWER_COUNT];
 
 void vtxRTC6705Configure(void);
 bool vtxRTC6705Init();

--- a/src/main/io/vtx_settings_config.c
+++ b/src/main/io/vtx_settings_config.c
@@ -1,0 +1,95 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config/parameter_group.h"
+#include "config/parameter_group_ids.h"
+#include "fc/config.h"
+
+#include "io/vtx_settings_config.h"
+
+#ifdef VTX_SETTINGS_CONFIG
+
+PG_REGISTER_WITH_RESET_TEMPLATE(vtxSettingsConfig_t, vtxSettingsConfig, PG_VTX_SETTINGS_CONFIG, 0);
+
+PG_RESET_TEMPLATE(vtxSettingsConfig_t, vtxSettingsConfig,
+    .band = VTX_SETTINGS_DEFAULT_BAND,
+    .channel = VTX_SETTINGS_DEFAULT_CHANNEL,
+    .power = VTX_SETTINGS_DEFAULT_POWER
+);
+
+
+void vtxSettingsSaveBandAndChannel(uint8_t band, uint8_t channel)
+{
+    bool modFlag = false;
+    if (band != vtxSettingsConfigMutable()->band) {
+        vtxSettingsConfigMutable()->band = band;
+        modFlag = true;
+    }
+    if (channel != vtxSettingsConfigMutable()->channel) {
+        vtxSettingsConfigMutable()->channel = channel;
+        modFlag = true;
+    }
+    if (modFlag) {
+        // need to save config so vtx settings in place after reboot
+        saveConfigAndNotify();
+    }
+}
+
+void vtxSettingsSavePowerByIndex(uint8_t index)
+{
+    if (index != vtxSettingsConfigMutable()->power) {
+        vtxSettingsConfigMutable()->power = index;
+        // need to save config so vtx settings in place after reboot
+        saveConfigAndNotify();
+    }
+}
+
+void vtxSettingsSaveBandChanAndPower(uint8_t band, uint8_t channel, uint8_t index)
+{
+    bool modFlag = false;
+    if (band != vtxSettingsConfigMutable()->band) {
+        vtxSettingsConfigMutable()->band = band;
+        modFlag = true;
+    }
+    if (channel != vtxSettingsConfigMutable()->channel) {
+        vtxSettingsConfigMutable()->channel = channel;
+        modFlag = true;
+    }
+    if (index != vtxSettingsConfigMutable()->power) {
+        vtxSettingsConfigMutable()->power = index;
+        modFlag = true;
+    }
+    if (modFlag) {
+        // need to save config so vtx settings in place after reboot
+        saveConfigAndNotify();
+    }
+}
+
+void vtxSettingsSaveFrequency(uint16_t freq)
+{
+    //future impl will be to save to a 'vtx_freq' setting, but for now just set
+    // 'vtx_band' to 0 to prevent user freq from being overridden at startup
+    UNUSED(freq);
+
+    if (vtxSettingsConfigMutable()->band != 0) {
+        vtxSettingsConfigMutable()->band = 0;
+        // need to save config so vtx settings in place after reboot
+        saveConfigAndNotify();
+    }
+}
+
+#endif  //VTX_SETTINGS_CONFIG

--- a/src/main/io/vtx_settings_config.h
+++ b/src/main/io/vtx_settings_config.h
@@ -28,11 +28,14 @@
 #define VTX_SETTINGS_DEFAULT_BAND 4         //Fatshark/Airwaves
 #define VTX_SETTINGS_DEFAULT_CHANNEL 1      //CH1
 
+#define VTX_SETTINGS_MAX_FREQ 5999          //max freq (in MHz) for 'vtx_freq' setting
+
 #if defined(VTX_SMARTAUDIO) || defined(VTX_TRAMP)
 
 #define VTX_SETTINGS_POWER_COUNT 5
 #define VTX_SETTINGS_DEFAULT_POWER 1
 #define VTX_SETTINGS_CONFIG
+#define VTX_SETTINGS_FREQCMD
 
 #elif defined(VTX_RTC6705)
 
@@ -54,6 +57,7 @@ typedef struct vtxSettingsConfig_s {
     uint8_t band;       // 1=A, 2=B, 3=E, 4=F(Airwaves/Fatshark), 5=Raceband
     uint8_t channel;    // 1-8
     uint8_t power;      // 0 = lowest
+    uint16_t freq;      // sets freq in MHz if band=0
 } vtxSettingsConfig_t;
 
 PG_DECLARE(vtxSettingsConfig_t, vtxSettingsConfig);
@@ -62,5 +66,6 @@ void vtxSettingsSaveBandAndChannel(uint8_t band, uint8_t channel);
 void vtxSettingsSavePowerByIndex(uint8_t index);
 void vtxSettingsSaveBandChanAndPower(uint8_t band, uint8_t channel, uint8_t index);
 void vtxSettingsSaveFrequency(uint16_t freq);
+void vtxSettingsSaveFreqAndPower(uint16_t freq, uint8_t index);
 
 #endif  //VTX_SETTINGS_CONFIG

--- a/src/main/io/vtx_settings_config.h
+++ b/src/main/io/vtx_settings_config.h
@@ -1,0 +1,66 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define VTX_SETTINGS_MIN_BAND 1
+#define VTX_SETTINGS_MAX_BAND 5
+#define VTX_SETTINGS_MIN_CHAN 1
+#define VTX_SETTINGS_MAX_CHAN 8
+
+#define VTX_SETTINGS_BAND_COUNT (VTX_SETTINGS_MAX_BAND - VTX_SETTINGS_MIN_BAND + 1)
+#define VTX_SETTINGS_CHAN_COUNT (VTX_SETTINGS_MAX_CHAN - VTX_SETTINGS_MIN_CHAN + 1)
+
+#define VTX_SETTINGS_DEFAULT_BAND 4         //Fatshark/Airwaves
+#define VTX_SETTINGS_DEFAULT_CHANNEL 1      //CH1
+
+#if defined(VTX_SMARTAUDIO) || defined(VTX_TRAMP)
+
+#define VTX_SETTINGS_POWER_COUNT 5
+#define VTX_SETTINGS_DEFAULT_POWER 1
+#define VTX_SETTINGS_CONFIG
+
+#elif defined(VTX_RTC6705)
+
+#include "io/vtx_rtc6705.h"
+
+#define VTX_SETTINGS_POWER_COUNT VTX_RTC6705_POWER_COUNT
+#define VTX_SETTINGS_DEFAULT_POWER VTX_RTC6705_DEFAULT_POWER
+#define VTX_SETTINGS_CONFIG
+
+#endif
+
+
+#ifdef VTX_SETTINGS_CONFIG
+
+#include "config/parameter_group.h"
+#include "config/parameter_group_ids.h"
+
+typedef struct vtxSettingsConfig_s {
+    uint8_t band;       // 1=A, 2=B, 3=E, 4=F(Airwaves/Fatshark), 5=Raceband
+    uint8_t channel;    // 1-8
+    uint8_t power;      // 0 = lowest
+} vtxSettingsConfig_t;
+
+PG_DECLARE(vtxSettingsConfig_t, vtxSettingsConfig);
+
+void vtxSettingsSaveBandAndChannel(uint8_t band, uint8_t channel);
+void vtxSettingsSavePowerByIndex(uint8_t index);
+void vtxSettingsSaveBandChanAndPower(uint8_t band, uint8_t channel, uint8_t index);
+void vtxSettingsSaveFrequency(uint16_t freq);
+
+#endif  //VTX_SETTINGS_CONFIG

--- a/src/main/io/vtx_smartaudio.c
+++ b/src/main/io/vtx_smartaudio.c
@@ -33,6 +33,7 @@
 #include "cms/cms_types.h"
 #include "cms/cms_menu_vtx_smartaudio.h"
 
+#include "common/maths.h"
 #include "common/printf.h"
 #include "common/utils.h"
 
@@ -51,6 +52,7 @@
 #include "io/serial.h"
 #include "io/vtx_control.h"
 #include "io/vtx_smartaudio.h"
+#include "io/vtx_settings_config.h"
 #include "io/vtx_string.h"
 
 //#define SMARTAUDIO_DPRINTF
@@ -63,7 +65,7 @@ serialPort_t *debugSerialPort = NULL;
 static serialPort_t *smartAudioSerialPort = NULL;
 
 #if defined(CMS) || defined(VTX_COMMON)
-static const char * const saPowerNames[] = {
+static const char * const saPowerNames[VTX_SMARTAUDIO_POWER_COUNT+1] = {
     "---", "25 ", "200", "500", "800",
 };
 #endif
@@ -72,9 +74,9 @@ static const char * const saPowerNames[] = {
 static const vtxVTable_t saVTable;    // Forward
 static vtxDevice_t vtxSmartAudio = {
     .vTable = &saVTable,
-    .capability.bandCount = 5,
-    .capability.channelCount = 8,
-    .capability.powerCount = 4,
+    .capability.bandCount = VTX_SMARTAUDIO_BAND_COUNT,
+    .capability.channelCount = VTX_SMARTAUDIO_CHAN_COUNT,
+    .capability.powerCount = VTX_SMARTAUDIO_POWER_COUNT,
     .bandNames = (char **)vtx58BandNames,
     .channelNames = (char **)vtx58ChannelNames,
     .powerNames = (char **)saPowerNames,
@@ -113,7 +115,7 @@ smartAudioStat_t saStat = {
     .badcode = 0,
 };
 
-saPowerTable_t saPowerTable[] = {
+saPowerTable_t saPowerTable[VTX_SMARTAUDIO_POWER_COUNT] = {
     {  25,   7,   0 },
     { 200,  16,   1 },
     { 500,  25,   2 },
@@ -539,7 +541,7 @@ static void saGetSettings(void)
     saQueueCmd(bufGetSettings, 5);
 }
 
-void saSetFreq(uint16_t freq)
+static void saDevSetFreq(uint16_t freq)
 {
     static uint8_t buf[7] = { 0xAA, 0x55, SACMD(SA_CMD_SET_FREQ), 2 };
 
@@ -558,6 +560,12 @@ void saSetFreq(uint16_t freq)
     saQueueCmd(buf, 7);
 }
 
+void saSetFreq(uint16_t freq)
+{
+    saDevSetFreq(freq);
+    vtxSettingsSaveFrequency(freq);
+}
+
 #if 0
 static void saSetPitFreq(uint16_t freq)
 {
@@ -570,7 +578,13 @@ static void saGetPitFreq(void)
 }
 #endif
 
-void saSetBandAndChannel(uint8_t band, uint8_t channel)
+bool saValidateBandAndChannel(uint8_t band, uint8_t channel)
+{
+    return (band >= VTX_SMARTAUDIO_MIN_BAND && band <= VTX_SMARTAUDIO_MAX_BAND &&
+             channel >= VTX_SMARTAUDIO_MIN_CHAN && channel <= VTX_SMARTAUDIO_MAX_CHAN);
+}
+
+static void saDevSetBandAndChannel(uint8_t band, uint8_t channel)
 {
     static uint8_t buf[6] = { 0xAA, 0x55, SACMD(SA_CMD_SET_CHAN), 1 };
 
@@ -578,6 +592,12 @@ void saSetBandAndChannel(uint8_t band, uint8_t channel)
     buf[5] = CRC8(buf, 5);
 
     saQueueCmd(buf, 6);
+}
+
+void saSetBandAndChannel(uint8_t band, uint8_t channel)
+{
+    saDevSetBandAndChannel(band, channel);
+    vtxSettingsSaveBandAndChannel(band+1, channel+1);
 }
 
 void saSetMode(int mode)
@@ -590,7 +610,7 @@ void saSetMode(int mode)
     saQueueCmd(buf, 6);
 }
 
-void saSetPowerByIndex(uint8_t index)
+static void saDevSetPowerByIndex(uint8_t index)
 {
     static uint8_t buf[6] = { 0xAA, 0x55, SACMD(SA_CMD_SET_POWER), 1 };
 
@@ -601,12 +621,34 @@ void saSetPowerByIndex(uint8_t index)
         return;
     }
 
-    if (index > 3)
+    if (index >= VTX_SMARTAUDIO_POWER_COUNT)
         return;
 
     buf[4] = (saDevice.version == 1) ? saPowerTable[index].valueV1 : saPowerTable[index].valueV2;
     buf[5] = CRC8(buf, 5);
     saQueueCmd(buf, 6);
+}
+
+void saSetPowerByIndex(uint8_t index)
+{
+    saDevSetPowerByIndex(index);
+    vtxSettingsSavePowerByIndex(index + 1);
+}
+
+static bool saEnterInitBandChanAndPower(uint8_t band, uint8_t channel, uint8_t power)
+{
+    if (!saValidateBandAndChannel(band, channel))
+        return false;
+    saDevSetBandAndChannel(band-1, channel-1);
+
+    uint8_t pwrIdx = constrain(power-1, 0, VTX_SMARTAUDIO_POWER_COUNT-1);
+    saDevSetPowerByIndex(pwrIdx);
+
+    // if 'vtx_power' value out of range then update it
+    if (pwrIdx+1 != power)
+        vtxSettingsSavePowerByIndex(pwrIdx+1);
+
+    return true;
 }
 
 bool vtxSmartAudioInit()
@@ -645,6 +687,7 @@ bool vtxSmartAudioInit()
 void vtxSAProcess(uint32_t now)
 {
     static char initPhase = 0;
+    static bool initSettingsDoneFlag = false;
 
     if (smartAudioSerialPort == NULL)
         return;
@@ -683,11 +726,26 @@ void vtxSAProcess(uint32_t now)
         // Command pending. Send it.
         // dprintf(("process: sending queue\r\n"));
         saSendQueue();
-    } else if (now - sa_lastTransmission >= 1000) {
+    } else if (saDevice.version != 0 && now - sa_lastTransmission >= 1000) {
         // Heart beat for autobauding
         //dprintf(("process: sending heartbeat\r\n"));
         saGetSettings();
         saSendQueue();
+    }
+
+    // once device is ready enter vtx settings
+    if (!initSettingsDoneFlag) {
+        if (saDevice.version != 0) {
+            initSettingsDoneFlag = true;
+            // if vtx_band!=0 then enter 'vtx_band/chan' values (and power)
+            saEnterInitBandChanAndPower(vtxSettingsConfig()->band,
+                             vtxSettingsConfig()->channel, vtxSettingsConfig()->power);
+        }
+        else if (now - sa_lastTransmission >= 100)
+        {  //device is not ready; repeat query
+            saGetSettings();
+            saSendQueue();
+        }
     }
 
 #ifdef SMARTAUDIO_TEST_VTX_COMMON
@@ -725,7 +783,7 @@ bool vtxSAIsReady(void)
 
 void vtxSASetBandAndChannel(uint8_t band, uint8_t channel)
 {
-    if (band && channel)
+    if (saValidateBandAndChannel(band, channel))
         saSetBandAndChannel(band - 1, channel - 1);
 }
 

--- a/src/main/io/vtx_smartaudio.h
+++ b/src/main/io/vtx_smartaudio.h
@@ -91,6 +91,7 @@ void saSetBandAndChannel(uint8_t band, uint8_t channel);
 void saSetMode(int mode);
 void saSetPowerByIndex(uint8_t index);
 void saSetFreq(uint16_t freq);
+void saSetPitFreq(uint16_t freq);
 bool vtxSmartAudioInit();
 
 #ifdef SMARTAUDIO_DPRINTF

--- a/src/main/io/vtx_smartaudio.h
+++ b/src/main/io/vtx_smartaudio.h
@@ -1,4 +1,32 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
+
+#define VTX_SMARTAUDIO_MIN_BAND 1
+#define VTX_SMARTAUDIO_MAX_BAND 5
+#define VTX_SMARTAUDIO_MIN_CHAN 1
+#define VTX_SMARTAUDIO_MAX_CHAN 8
+
+#define VTX_SMARTAUDIO_BAND_COUNT (VTX_SMARTAUDIO_MAX_BAND - VTX_SMARTAUDIO_MIN_BAND + 1)
+#define VTX_SMARTAUDIO_CHAN_COUNT (VTX_SMARTAUDIO_MAX_CHAN - VTX_SMARTAUDIO_MIN_CHAN + 1)
+
+#define VTX_SMARTAUDIO_POWER_COUNT 4
+#define VTX_SMARTAUDIO_DEFAULT_POWER 1
 
 // opmode flags, GET side
 #define SA_MODE_GET_FREQ_BY_FREQ            1

--- a/src/main/io/vtx_smartaudio.h
+++ b/src/main/io/vtx_smartaudio.h
@@ -28,6 +28,9 @@
 #define VTX_SMARTAUDIO_POWER_COUNT 4
 #define VTX_SMARTAUDIO_DEFAULT_POWER 1
 
+#define VTX_SMARTAUDIO_MIN_FREQ 5000        //min freq in MHz
+#define VTX_SMARTAUDIO_MAX_FREQ 5999        //max freq in MHz
+
 // opmode flags, GET side
 #define SA_MODE_GET_FREQ_BY_FREQ            1
 #define SA_MODE_GET_PITMODE                 2

--- a/src/main/io/vtx_string.c
+++ b/src/main/io/vtx_string.c
@@ -27,7 +27,10 @@
 
 #if defined(VTX_COMMON)
 
-const uint16_t vtx58frequencyTable[5][8] =
+#define VTX_STRING_BAND_COUNT 5
+#define VTX_STRING_CHAN_COUNT 8
+
+const uint16_t vtx58frequencyTable[VTX_STRING_BAND_COUNT][VTX_STRING_CHAN_COUNT] =
 {
     { 5865, 5845, 5825, 5805, 5785, 5765, 5745, 5725 }, // Boscam A
     { 5733, 5752, 5771, 5790, 5809, 5828, 5847, 5866 }, // Boscam B
@@ -51,6 +54,7 @@ const char * const vtx58ChannelNames[] = {
     "-", "1", "2", "3", "4", "5", "6", "7", "8",
 };
 
+//Converts frequency (in MHz) to band and channel values.
 bool vtx58_Freq2Bandchan(uint16_t freq, uint8_t *pBand, uint8_t *pChannel)
 {
     int8_t band;
@@ -58,8 +62,8 @@ bool vtx58_Freq2Bandchan(uint16_t freq, uint8_t *pBand, uint8_t *pChannel)
 
     // Use reverse lookup order so that 5880Mhz
     // get Raceband 7 instead of Fatshark 8.
-    for (band = 4 ; band >= 0 ; band--) {
-        for (channel = 0 ; channel < 8 ; channel++) {
+    for (band = VTX_STRING_BAND_COUNT-1 ; band >= 0 ; band--) {
+        for (channel = 0 ; channel < VTX_STRING_CHAN_COUNT ; channel++) {
             if (vtx58frequencyTable[band][channel] == freq) {
                 *pBand = band + 1;
                 *pChannel = channel + 1;
@@ -72,6 +76,19 @@ bool vtx58_Freq2Bandchan(uint16_t freq, uint8_t *pBand, uint8_t *pChannel)
     *pChannel = 0;
 
     return false;
+}
+
+//Converts band and channel values to a frequency (in MHz) value.
+// band:  Band value (1 to 5).
+// channel:  Channel value (1 to 8).
+// Returns frequency value (in MHz), or 0 if band/channel out of range.
+uint16_t vtx58_Bandchan2Freq(uint8_t band, uint8_t channel)
+{
+    if (band > 0 && band <= VTX_STRING_BAND_COUNT &&
+                          channel > 0 && channel <= VTX_STRING_CHAN_COUNT) {
+        return vtx58frequencyTable[band - 1][channel - 1];
+    }
+    return 0;
 }
 
 #endif

--- a/src/main/io/vtx_string.h
+++ b/src/main/io/vtx_string.h
@@ -10,5 +10,6 @@ extern const char * const vtx58ChannelNames[];
 extern const char vtx58BandLetter[];
 
 bool vtx58_Freq2Bandchan(uint16_t freq, uint8_t *pBand, uint8_t *pChannel);
+uint16_t vtx58_Bandchan2Freq(uint8_t band, uint8_t channel);
 
 #endif

--- a/src/main/io/vtx_tramp.c
+++ b/src/main/io/vtx_tramp.c
@@ -129,11 +129,21 @@ void trampCmdU16(uint8_t cmd, uint16_t param)
     trampWriteBuf(trampReqBuffer);
 }
 
-void trampSetFreq(uint16_t freq)
+static bool trampValidateFreq(uint16_t freq)
+{
+    return (freq >= VTX_TRAMP_MIN_FREQ && freq <= VTX_TRAMP_MAX_FREQ);
+}
+
+static void trampDevSetFreq(uint16_t freq)
 {
     trampConfFreq = freq;
     if (trampConfFreq != trampCurFreq)
         trampFreqRetries = TRAMP_MAX_RETRIES;
+}
+void trampSetFreq(uint16_t freq)
+{
+    trampDevSetFreq(freq);
+    vtxSettingsSaveFrequency(freq);
 }
 
 void trampSendFreq(uint16_t freq)
@@ -141,7 +151,7 @@ void trampSendFreq(uint16_t freq)
     trampCmdU16('F', freq);
 }
 
-bool trampValidateBandAndChannel(uint8_t band, uint8_t channel)
+static bool trampValidateBandAndChannel(uint8_t band, uint8_t channel)
 {
     return (band >= VTX_TRAMP_MIN_BAND && band <= VTX_TRAMP_MAX_BAND &&
             channel >= VTX_TRAMP_MIN_CHAN && channel <= VTX_TRAMP_MAX_CHAN);
@@ -149,7 +159,7 @@ bool trampValidateBandAndChannel(uint8_t band, uint8_t channel)
 
 static void trampDevSetBandAndChannel(uint8_t band, uint8_t channel)
 {
-    trampSetFreq(vtx58frequencyTable[band - 1][channel - 1]);
+    trampDevSetFreq(vtx58_Bandchan2Freq(band, channel));
 }
 
 void trampSetBandAndChannel(uint8_t band, uint8_t channel)
@@ -351,11 +361,23 @@ static bool trampEnterInitBandChanAndPower(uint8_t band, uint8_t channel, uint8_
     uint8_t pwrIdx = constrain(power, 1, sizeof(trampPowerTable));
     trampDevSetPowerByIndex(pwrIdx);
 
-    // if 'vtx_power' value out of range then update it
-    if (pwrIdx != power)
-        vtxSettingsSavePowerByIndex(pwrIdx);
+    // update 'vtx_freq' via band/channel table and enter
+    //  power-index value (in case current value is out of range)
+    vtxSettingsSaveFreqAndPower(vtx58_Bandchan2Freq(band,channel), pwrIdx);
 
     return true;
+}
+
+static void trampEnterInitFreqAndPower(uint16_t freq, uint8_t power)
+{
+    if (trampValidateFreq(freq))
+        trampDevSetFreq(freq);
+
+    uint8_t pwrIdx = constrain(power, 1, sizeof(trampPowerTable));
+    trampDevSetPowerByIndex(pwrIdx);
+
+    // enter power-index value (in case current value is out of range)
+    vtxSettingsSavePowerByIndex(pwrIdx);
 }
 
 void vtxTrampProcess(uint32_t currentTimeUs)
@@ -386,8 +408,12 @@ void vtxTrampProcess(uint32_t currentTimeUs)
             if (!initSettingsDoneFlag) {
                 initSettingsDoneFlag = true;
                 // if vtx_band!=0 then enter 'vtx_band/chan' values (and power)
-                trampEnterInitBandChanAndPower(vtxSettingsConfig()->band,
-                             vtxSettingsConfig()->channel, vtxSettingsConfig()->power);
+                if (!trampEnterInitBandChanAndPower(vtxSettingsConfig()->band, vtxSettingsConfig()->channel, vtxSettingsConfig()->power)) {
+                    // if vtx_band=0 then enter 'vtx_freq' value (and power)
+                    if (vtxSettingsConfig()->band == 0) {
+                        trampEnterInitFreqAndPower(vtxSettingsConfig()->freq, vtxSettingsConfig()->power);
+                    }
+                }
             }
         }
         break;

--- a/src/main/io/vtx_tramp.c
+++ b/src/main/io/vtx_tramp.c
@@ -28,6 +28,7 @@
 
 #include "build/debug.h"
 
+#include "common/maths.h"
 #include "common/utils.h"
 
 #include "cms/cms_menu_vtx_tramp.h"
@@ -35,9 +36,10 @@
 #include "drivers/vtx_common.h"
 
 #include "io/serial.h"
+#include "io/vtx_tramp.h"
+#include "io/vtx_settings_config.h"
 #include "io/vtx_control.h"
 #include "io/vtx_string.h"
-#include "io/vtx_tramp.h"
 
 #if defined(CMS) || defined(VTX_COMMON)
 const uint16_t trampPowerTable[VTX_TRAMP_POWER_COUNT] = {
@@ -53,8 +55,8 @@ const char * const trampPowerNames[VTX_TRAMP_POWER_COUNT+1] = {
 static const vtxVTable_t trampVTable; // forward
 static vtxDevice_t vtxTramp = {
     .vTable = &trampVTable,
-    .capability.bandCount = 5,
-    .capability.channelCount = 8,
+    .capability.bandCount = VTX_TRAMP_BAND_COUNT,
+    .capability.channelCount = VTX_TRAMP_CHAN_COUNT,
     .capability.powerCount = sizeof(trampPowerTable),
     .bandNames = (char **)vtx58BandNames,
     .channelNames = (char **)vtx58ChannelNames,
@@ -139,9 +141,21 @@ void trampSendFreq(uint16_t freq)
     trampCmdU16('F', freq);
 }
 
-void trampSetBandAndChannel(uint8_t band, uint8_t channel)
+bool trampValidateBandAndChannel(uint8_t band, uint8_t channel)
+{
+    return (band >= VTX_TRAMP_MIN_BAND && band <= VTX_TRAMP_MAX_BAND &&
+            channel >= VTX_TRAMP_MIN_CHAN && channel <= VTX_TRAMP_MAX_CHAN);
+}
+
+static void trampDevSetBandAndChannel(uint8_t band, uint8_t channel)
 {
     trampSetFreq(vtx58frequencyTable[band - 1][channel - 1]);
+}
+
+void trampSetBandAndChannel(uint8_t band, uint8_t channel)
+{
+    trampDevSetBandAndChannel(band, channel);
+    vtxSettingsSaveBandAndChannel(band, channel);
 }
 
 void trampSetRFPower(uint16_t level)
@@ -164,6 +178,17 @@ bool trampCommitChanges()
 
     trampStatus = TRAMP_STATUS_SET_FREQ_PW;
     return true;
+}
+
+// return false if index out of range
+static bool trampDevSetPowerByIndex(uint8_t index)
+{
+    if (index > 0 && index <= sizeof(trampPowerTable)) {
+        trampSetRFPower(trampPowerTable[index - 1]);
+        trampCommitChanges();
+        return true;
+    }
+    return false;
 }
 
 void trampSetPitMode(uint8_t onoff)
@@ -317,9 +342,26 @@ void trampQueryS(void)
     trampQuery('s');
 }
 
+static bool trampEnterInitBandChanAndPower(uint8_t band, uint8_t channel, uint8_t power)
+{
+    if (!trampValidateBandAndChannel(band, channel))
+        return false;
+    trampDevSetBandAndChannel(band, channel);
+
+    uint8_t pwrIdx = constrain(power, 1, sizeof(trampPowerTable));
+    trampDevSetPowerByIndex(pwrIdx);
+
+    // if 'vtx_power' value out of range then update it
+    if (pwrIdx != power)
+        vtxSettingsSavePowerByIndex(pwrIdx);
+
+    return true;
+}
+
 void vtxTrampProcess(uint32_t currentTimeUs)
 {
     static uint32_t lastQueryTimeUs = 0;
+    static bool initSettingsDoneFlag = false;
 
 #ifdef TRAMP_DEBUG
     static uint16_t debugFreqReqCounter = 0;
@@ -337,8 +379,17 @@ void vtxTrampProcess(uint32_t currentTimeUs)
 
     switch (replyCode) {
     case 'r':
-        if (trampStatus <= TRAMP_STATUS_OFFLINE)
+        if (trampStatus <= TRAMP_STATUS_OFFLINE) {
             trampStatus = TRAMP_STATUS_ONLINE;
+
+            // once device is ready enter vtx settings
+            if (!initSettingsDoneFlag) {
+                initSettingsDoneFlag = true;
+                // if vtx_band!=0 then enter 'vtx_band/chan' values (and power)
+                trampEnterInitBandChanAndPower(vtxSettingsConfig()->band,
+                             vtxSettingsConfig()->channel, vtxSettingsConfig()->power);
+            }
+        }
         break;
 
     case 'v':
@@ -443,7 +494,7 @@ bool vtxTrampIsReady(void)
 
 void vtxTrampSetBandAndChannel(uint8_t band, uint8_t channel)
 {
-    if (band && channel) {
+    if (trampValidateBandAndChannel(band, channel)) {
         trampSetBandAndChannel(band, channel);
         trampCommitChanges();
     }
@@ -451,10 +502,8 @@ void vtxTrampSetBandAndChannel(uint8_t band, uint8_t channel)
 
 void vtxTrampSetPowerByIndex(uint8_t index)
 {
-    if (index) {
-        trampSetRFPower(trampPowerTable[index - 1]);
-        trampCommitChanges();
-    }
+    if (trampDevSetPowerByIndex(index))
+        vtxSettingsSavePowerByIndex(index);
 }
 
 void vtxTrampSetPitMode(uint8_t onoff)

--- a/src/main/io/vtx_tramp.h
+++ b/src/main/io/vtx_tramp.h
@@ -1,6 +1,33 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
+#define VTX_TRAMP_MIN_BAND 1
+#define VTX_TRAMP_MAX_BAND 5
+#define VTX_TRAMP_MIN_CHAN 1
+#define VTX_TRAMP_MAX_CHAN 8
+
+#define VTX_TRAMP_BAND_COUNT (VTX_TRAMP_MAX_BAND - VTX_TRAMP_MIN_BAND + 1)
+#define VTX_TRAMP_CHAN_COUNT (VTX_TRAMP_MAX_CHAN - VTX_TRAMP_MIN_CHAN + 1)
+
 #define VTX_TRAMP_POWER_COUNT 5
+#define VTX_TRAMP_DEFAULT_POWER 1
+
 extern const uint16_t trampPowerTable[VTX_TRAMP_POWER_COUNT];
 extern const char * const trampPowerNames[VTX_TRAMP_POWER_COUNT+1];
 

--- a/src/main/io/vtx_tramp.h
+++ b/src/main/io/vtx_tramp.h
@@ -28,6 +28,9 @@
 #define VTX_TRAMP_POWER_COUNT 5
 #define VTX_TRAMP_DEFAULT_POWER 1
 
+#define VTX_TRAMP_MIN_FREQ 5000             //min freq in MHz
+#define VTX_TRAMP_MAX_FREQ 5999             //max freq in MHz
+
 extern const uint16_t trampPowerTable[VTX_TRAMP_POWER_COUNT];
 extern const char * const trampPowerNames[VTX_TRAMP_POWER_COUNT+1];
 


### PR DESCRIPTION
This builds on PR #2930 and #2936, implementing some fixes and improvements to the SmartAudio part of the CMS OSD menus:

CMS set of USER frequency would fail if frequency was same as previous USER frequency

CMS would set vtx freq immediately when going from USER to CHAN freq mode
  (should wait until SET performed)

After changing CHAN/USER freq mode but before SET, the CMS status line
  would show wrong band-channel / U-F display
  (needed new 'saCmsFselModeNew' variable)

CMS will now update when saDevice settings change
  (if race opmodel via CMS and then user freq set via CLI "set vtx_freq",
     freq is set but CMS would report race opmodel and old band/channel)

Modified SA CMS to use 'saSetPitFreq()' function

Moved 'saCmsUpdate()' declaration to 'cms_menu_vtx_smartaudio.h'

--ET