### PR TITLE
Doc update for current sensor 

### DIFF
--- a/docs/Battery.md
+++ b/docs/Battery.md
@@ -168,8 +168,8 @@ For example, assuming:
 Then the updated `amperage_meter_scale` is:
 ```
 amperage_meter_scale = old_amperage_meter_scale * (reported_draw_mAh / charging_data_mAh)
-                    = 400 * (1158 / 1260)
-                    = 368
+                    = 400 * (1260 / 1158)
+                    = 435
 ```
 
 

--- a/docs/Battery.md
+++ b/docs/Battery.md
@@ -167,7 +167,7 @@ For example, assuming:
 
 Then the updated `amperage_meter_scale` is:
 ```
-amperage_meter_scale = old_amperage_meter_scale * (charging_data_mAh / reported_draw_mAh)
+amperage_meter_scale = old_amperage_meter_scale * (reported_draw_mAh / charging_data_mAh)
                     = 400 * (1158 / 1260)
                     = 368
 ```


### PR DESCRIPTION
The formula for changing the current sensor scale based on consumed and replaced battery power is incorrect. It increases the scale value when it should decrease it and vice versa.
This pull request corrects that.