### PR TITLE
CF/BF - Add BMP085/BMP280 baro support to REVO targets.

### DIFF
--- a/src/main/target/REVO/target.h
+++ b/src/main/target/REVO/target.h
@@ -143,6 +143,8 @@
 
 #define BARO
 #define USE_BARO_MS5611
+#define USE_BARO_BMP085
+#define USE_BARO_BMP280
 
 #if defined(AIRBOTF4SD)
 // SDCARD support for AIRBOTF4SD

--- a/src/main/target/REVO/target.mk
+++ b/src/main/target/REVO/target.mk
@@ -10,4 +10,6 @@ TARGET_SRC = \
             drivers/accgyro/accgyro_mpu6500.c \
             drivers/accgyro/accgyro_spi_mpu6500.c \
             drivers/barometer/barometer_ms5611.c \
+            drivers/barometer/barometer_bmp085.c \
+            drivers/barometer/barometer_bmp280.c \
             drivers/compass/compass_hmc5883l.c


### PR DESCRIPTION
From #2871 