### PR TITLE
Improve OSD slave timeout/disconnect/reconnect handling.

### DIFF
--- a/src/main/drivers/display.c
+++ b/src/main/drivers/display.c
@@ -92,6 +92,11 @@ bool displayIsTransferInProgress(const displayPort_t *instance)
     return instance->vTable->isTransferInProgress(instance);
 }
 
+bool displayIsSynced(const displayPort_t *instance)
+{
+    return instance->vTable->isSynced(instance);
+}
+
 void displayHeartbeat(displayPort_t *instance)
 {
     instance->vTable->heartbeat(instance);

--- a/src/main/drivers/display.h
+++ b/src/main/drivers/display.h
@@ -46,6 +46,7 @@ typedef struct displayPortVTable_s {
     bool (*isTransferInProgress)(const displayPort_t *displayPort);
     int (*heartbeat)(displayPort_t *displayPort);
     void (*resync)(displayPort_t *displayPort);
+    bool (*isSynced)(const displayPort_t *displayPort);
     uint32_t (*txBytesFree)(const displayPort_t *displayPort);
 } displayPortVTable_t;
 
@@ -70,5 +71,6 @@ int displayWriteChar(displayPort_t *instance, uint8_t x, uint8_t y, uint8_t c);
 bool displayIsTransferInProgress(const displayPort_t *instance);
 void displayHeartbeat(displayPort_t *instance);
 void displayResync(displayPort_t *instance);
+bool displayIsSynced(const displayPort_t *instance);
 uint16_t displayTxBytesFree(const displayPort_t *instance);
 void displayInit(displayPort_t *instance, const displayPortVTable_t *vTable);

--- a/src/main/drivers/max7456.h
+++ b/src/main/drivers/max7456.h
@@ -40,3 +40,4 @@ void    max7456ClearScreen(void);
 void    max7456RefreshAll(void);
 uint8_t* max7456GetScreenBuffer(void);
 bool    max7456DmaInProgress(void);
+bool    max7456BuffersSynced(void);

--- a/src/main/io/displayport_max7456.c
+++ b/src/main/io/displayport_max7456.c
@@ -120,6 +120,12 @@ static bool isTransferInProgress(const displayPort_t *displayPort)
     return max7456DmaInProgress();
 }
 
+static bool isSynced(const displayPort_t *displayPort)
+{
+    UNUSED(displayPort);
+    return max7456BuffersSynced();
+}
+
 static void resync(displayPort_t *displayPort)
 {
     UNUSED(displayPort);
@@ -151,6 +157,7 @@ static const displayPortVTable_t max7456VTable = {
     .isTransferInProgress = isTransferInProgress,
     .heartbeat = heartbeat,
     .resync = resync,
+    .isSynced = isSynced,
     .txBytesFree = txBytesFree,
 };
 

--- a/src/main/io/displayport_msp.c
+++ b/src/main/io/displayport_msp.c
@@ -134,10 +134,17 @@ static bool isTransferInProgress(const displayPort_t *displayPort)
     return false;
 }
 
+static bool isSynced(const displayPort_t *displayPort)
+{
+    UNUSED(displayPort);
+    return true;
+}
+
 static void resync(displayPort_t *displayPort)
 {
     displayPort->rows = 13 + displayPortProfileMsp()->rowAdjust; // XXX Will reflect NTSC/PAL in the future
     displayPort->cols = 30 + displayPortProfileMsp()->colAdjust;
+    drawScreen(displayPort);
 }
 
 static uint32_t txBytesFree(const displayPort_t *displayPort)
@@ -157,6 +164,7 @@ static const displayPortVTable_t mspDisplayPortVTable = {
     .isTransferInProgress = isTransferInProgress,
     .heartbeat = heartbeat,
     .resync = resync,
+    .isSynced = isSynced,
     .txBytesFree = txBytesFree
 };
 

--- a/src/main/io/displayport_oled.c
+++ b/src/main/io/displayport_oled.c
@@ -76,6 +76,12 @@ static bool oledIsTransferInProgress(const displayPort_t *displayPort)
     return false;
 }
 
+static bool oledIsSynced(const displayPort_t *displayPort)
+{
+    UNUSED(displayPort);
+    return true;
+}
+
 static int oledHeartbeat(displayPort_t *displayPort)
 {
     UNUSED(displayPort);
@@ -104,6 +110,7 @@ static const displayPortVTable_t oledVTable = {
     .isTransferInProgress = oledIsTransferInProgress,
     .heartbeat = oledHeartbeat,
     .resync = oledResync,
+    .isSynced = oledIsSynced,
     .txBytesFree = oledTxBytesFree
 };
 

--- a/src/main/io/displayport_rcdevice.c
+++ b/src/main/io/displayport_rcdevice.c
@@ -43,6 +43,7 @@ static const displayPortVTable_t rcdeviceOSDVTable = {
     .isTransferInProgress = rcdeviceOSDIsTransferInProgress,
     .heartbeat = rcdeviceOSDHeartbeat,
     .resync = rcdeviceOSDResync,
+    .isSynced = rcdeviceOSDIsSynced,
     .txBytesFree = rcdeviceOSDTxBytesFree,
     .screenSize = rcdeviceScreenSize,
 };

--- a/src/main/io/displayport_srxl.c
+++ b/src/main/io/displayport_srxl.c
@@ -80,6 +80,12 @@ static bool srxlIsTransferInProgress(const displayPort_t *displayPort)
     return false;
 }
 
+static bool srxlIsSynced(const displayPort_t *displayPort)
+{
+    UNUSED(displayPort);
+    return true;
+}
+
 static int srxlHeartbeat(displayPort_t *displayPort)
 {
     UNUSED(displayPort);
@@ -120,6 +126,7 @@ static const displayPortVTable_t srxlVTable = {
     .isTransferInProgress = srxlIsTransferInProgress,
     .heartbeat = srxlHeartbeat,
     .resync = srxlResync,
+    .isSynced = srxlIsSynced,
     .txBytesFree = srxlTxBytesFree
 };
 

--- a/src/main/io/rcdevice_osd.c
+++ b/src/main/io/rcdevice_osd.c
@@ -204,6 +204,12 @@ bool rcdeviceOSDIsTransferInProgress(const displayPort_t *displayPort)
     return false;
 }
 
+bool rcdeviceOSDIsSynced(const displayPort_t *displayPort)
+{
+    UNUSED(displayPort);
+    return true;
+}
+
 int rcdeviceOSDHeartbeat(displayPort_t *displayPort)
 {
     UNUSED(displayPort);

--- a/src/main/io/rcdevice_osd.h
+++ b/src/main/io/rcdevice_osd.h
@@ -35,5 +35,6 @@ int rcdeviceOSDClearScreen(displayPort_t *);
 bool rcdeviceOSDIsTransferInProgress(const displayPort_t *);
 int rcdeviceOSDHeartbeat(displayPort_t *displayPort);
 void rcdeviceOSDResync(displayPort_t *displayPort);
+bool rcdeviceOSDIsSynced(const displayPort_t *displayPort);
 uint32_t rcdeviceOSDTxBytesFree(const displayPort_t *displayPort);
 int rcdeviceScreenSize(const displayPort_t *displayPort);


### PR DESCRIPTION
fixes continual screen flickering issue that can sometimes be experienced after powering off/on either the FC or the OSD while the other board is still on.

key points:
1) max7456ReInitIfRequired extracted from max7456DrawScreen
2) max7456ReInitIfRequired now also called by max7456RefreshAll
3) max7456BuffersSynced added
4) displayPort api updated with isSynced
5) OSD slave can now use isSynced to ensured the display is synced because `displayDrawScreen()` may return WITHOUT having fully updated the screen.
6) When OSD slave boots, the logo and text is now displayed after the first call to displayResync(), rather than it being eventually called by a random amount of calls to `displayDrawScreen` via the OSD_SLAVE_TASK.
7) displayPort MSP displayResync now sends the MSP_DISPLAYPORT command, it was missing.  The current OSD init code did not correctly send the MSP_DISPLAYPORT which meant the OSD slave could not detect when to display the logo - previously the logo was drawn due to timeout handling which was sub-optimal and part of the reason why the screen flashed...

