### PR TITLE
Fix PWM rx 100% CPU load (#5598) (#5606)

### DIFF
--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -408,7 +408,6 @@ bool rxUpdateCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTime)
         }
     } else if (feature(FEATURE_RX_PARALLEL_PWM)) {
         if (isPWMDataBeingReceived()) {
-            rxDataProcessingRequired = true;
             rxSignalReceived = true;
             rxIsInFailsafeMode = false;
             needRxSignalBefore = currentTimeUs + needRxSignalMaxDelayUs;


### PR DESCRIPTION
Previous logic changes were causing the RX task to run every loop for PWM rx leading to 100% CPU load. Reverted PWM processing to be based on a time interval rather than whether new data is available. With PWM we can't differentiate when new data is available as it's a continuous stream.
