### PR TITLE
add way to manually override battery cell count

### DIFF
--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -650,7 +650,8 @@ const clivalue_t valueTable[] = {
     { "use_cbat_alerts",            VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, useConsumptionAlerts) },
     { "cbat_alert_percent",         VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 100 }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, consumptionWarningPercentage) },
     { "vbat_cutoff_percent",           VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 100 }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, lvcPercentage) },
-
+    { "force_battery_cell_count",   VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 24 }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, forceBatteryCellCount) },
+    
 //  PG_VOLTAGE_SENSOR_ADC_CONFIG
     { "vbat_scale",                 VAR_UINT8  | MASTER_VALUE, .config.minmax = { VBAT_SCALE_MIN, VBAT_SCALE_MAX }, PG_VOLTAGE_SENSOR_ADC_CONFIG, offsetof(voltageSensorADCConfig_t, vbatscale) },
     { "vbat_divider",               VAR_UINT8  | MASTER_VALUE, .config.minmax = { VBAT_DIVIDER_MIN, VBAT_DIVIDER_MAX }, PG_VOLTAGE_SENSOR_ADC_CONFIG, offsetof(voltageSensorADCConfig_t, vbatresdivval) },

--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -105,6 +105,9 @@ PG_RESET_TEMPLATE(batteryConfig_t, batteryConfig,
     .batteryCapacity = 0,
     .currentMeterSource = DEFAULT_CURRENT_METER_SOURCE,
 
+    // cells
+    .forceBatteryCellCount = 0, //0 will be ignored
+
     // warnings / alerts
     .useVBatAlerts = true,
     .useConsumptionAlerts = false,
@@ -180,14 +183,19 @@ void batteryUpdatePresence(void)
         /* battery has just been connected - calculate cells, warning voltages and reset state */
 
 
-        unsigned cells = (voltageMeter.filtered / batteryConfig()->vbatmaxcellvoltage) + 1;
-        if (cells > 8) {
-            // something is wrong, we expect 8 cells maximum (and autodetection will be problematic at 6+ cells)
-            cells = 8;
-        }
+
 
         consumptionState = voltageState = BATTERY_OK;
-        batteryCellCount = cells;
+        if (batteryConfig()->forceBatteryCellCount != 0) {
+            batteryCellCount = batteryConfig()->forceBatteryCellCount;
+        } else {
+            unsigned cells = (voltageMeter.filtered / batteryConfig()->vbatmaxcellvoltage) + 1;
+            if (cells > 8) {
+                // something is wrong, we expect 8 cells maximum (and autodetection will be problematic at 6+ cells)
+                cells = 8;
+            }
+            batteryCellCount = cells;
+        }
         batteryWarningVoltage = batteryCellCount * batteryConfig()->vbatwarningcellvoltage;
         batteryCriticalVoltage = batteryCellCount * batteryConfig()->vbatmincellvoltage;
         lowVoltageCutoff.percentage = 100;

--- a/src/main/sensors/battery.h
+++ b/src/main/sensors/battery.h
@@ -48,6 +48,7 @@ typedef struct batteryConfig_s {
 
     uint8_t vbatfullcellvoltage;            // Cell voltage at which the battery is deemed to be "full" 0.1V units, default is 41 (4.1V)
 
+    uint8_t forceBatteryCellCount;          // number of cells in battery, used for overwriting auto-detected cell count if someone has issues with it.
 } batteryConfig_t;
 
 typedef struct lowVoltageCutoff_s {


### PR DESCRIPTION
This add merged commit https://github.com/betaflight/betaflight/pull/6648 from betaflight to cleanflight.

On higher cells voltages overlap, which is why this command is necessary and also in demand.