### PR TITLE
Provide a way for users to easily create custom target headers.

### DIFF
--- a/make/targets.mk
+++ b/make/targets.mk
@@ -9,6 +9,12 @@ BASE_TARGET   := $(call get_base_target,$(TARGET))
 # silently ignore if the file is not present. Allows for target specific.
 -include $(ROOT)/src/main/target/$(BASE_TARGET)/$(TARGET).mk
 
+ifneq ("$(wildcard $(ROOT)/src/main/target/$(BASE_TARGET)/$(TARGET).h)","")
+    TARGET_INCLUDE := \"$(TARGET).h\" 
+else
+    TARGET_INCLUDE := \"target.h\"
+endif
+
 ifeq ($(filter $(TARGET),$(OPBL_TARGETS)), $(TARGET))
 OPBL            = yes
 endif
@@ -54,4 +60,4 @@ ifneq ($(BASE_TARGET), $(TARGET))
 TARGET_FLAGS  	:= $(TARGET_FLAGS) -D$(BASE_TARGET)
 endif
 
-TARGET_FLAGS  	:= $(TARGET_FLAGS) -D$(TARGET_MCU)
+TARGET_FLAGS  	:= $(TARGET_FLAGS) -D$(TARGET_MCU) -DTARGET_INCLUDE=$(TARGET_INCLUDE)

--- a/src/main/platform.h
+++ b/src/main/platform.h
@@ -124,7 +124,11 @@
 #endif
 
 #include "target/common_pre.h"
+#ifdef TARGET_INCLUDE
+#include TARGET_INCLUDE
+#else
 #include "target.h"
+#endif
 #include "target/common_deprecated_post.h"
 #include "target/common_post.h"
 #include "target/common_defaults_post.h"


### PR DESCRIPTION
To build a custom target:

* create YOUR_TARGET.mk file, empty.
* create YOUR_TARGET.h file, empty.
* in YOUR_TARGET.h file, add '#include "target.h"` as required.
* in YOUR_TARGET.h file, `#undef`/`#define` whatever you like.
* Compile with `make TARGET=YOUR_TARGET`.
* Flash the generated `obj\cleanflight_x.x.x_YOUR_TARGET.hex`
e.g.

```
SPRACINGF3NEO_CUSTOM1.h
SPRACINGF3NEO_CUSTOM1.mk
make TARGET=SPRACINGF3NEO_CUSTOM1
```

For a more complete example, see this commit:

https://github.com/hydra/cleanflight/commit/9b16fc0be9152a996fbbd6aa5600173b57f4c6e2

* Handy when the code compiles, but no longer fits in flash due to all the
different hardware support compiled in by default.
* Useful when you need custom binaries, but don't want your changes interfering with the base target files.
