### PR TITLE
CLOCK SOURCE MODIFIED FOR I2C1

### DIFF
--- a/src/main/startup/system_stm32f7xx.c
+++ b/src/main/startup/system_stm32f7xx.c
@@ -225,7 +225,7 @@
 
       // I2C clock sources: Note that peripheral clock determination in bus_i2c_hal_init.c must be modified when the sources are modified.
 
-      PeriphClkInitStruct.I2c1ClockSelection = RCC_I2C1CLKSOURCE_PCLK1;
+      PeriphClkInitStruct.I2c1ClockSelection = RCC_I2C1CLKSOURCE_SYSCLK;
       PeriphClkInitStruct.I2c2ClockSelection = RCC_I2C2CLKSOURCE_PCLK1;
       PeriphClkInitStruct.I2c3ClockSelection = RCC_I2C3CLKSOURCE_PCLK1;
       PeriphClkInitStruct.I2c4ClockSelection = RCC_I2C4CLKSOURCE_PCLK1;


### PR DESCRIPTION
Hello so i was learning the code for cleanflight and i have improvement for the i2c. I have NUCLEO-F7 and mpu6050 and hmc5883l. i was having 88us avg in gyro reading. which is fine. by seeing the code in here https://github.com/cleanflight/cleanflight/blob/master/src/main/startup/system_stm32f7xx.c#L228
 the clock for i2c is set from pclk1.

and i have attached the screen shot here i am having cpu time almost 50% and gyro avg is at 88us. THIS IS DEFAULT CLEANFLIGHT FIRMWARE
![before](https://user-images.githubusercontent.com/13694097/90015754-a9492580-dcc6-11ea-8587-3c75822b45ff.png)

Now I Changed that line ofcourse i2c source clock to sysclock since the board has 216Mhz and pclk1 is at 54mhz so i think it is a good to take advantage of that. and changed lines to this

![code](https://user-images.githubusercontent.com/13694097/90015808-bbc35f00-dcc6-11ea-894f-c408d40d664d.png)

and then the results are signficance change in cpu time its dropped to 2% I exactly do not know how did it happened but i think i2c clock source is having bad time with cpu usage. Please confirm if any other stm32f7 board has same thing happening Since i do not have any other stm32f7 board other than nucleo-f7. THIS IS MODIFIED CLEANFLIGHT FIRMWARE FOR I2C CLOCK

![after](https://user-images.githubusercontent.com/13694097/90015838-c54cc700-dcc6-11ea-802e-09503aa330a5.png)
Sensor readings of acc, gyro and mags are perfect board is giving perfect orientation
@hydra 
